### PR TITLE
Fixed IR generation assertion violation when using KLIB on macos target

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ stage('SCM') {
 
 stage('build') {
     parralelExecutors = [:]
-    parralelExecutors['compiler']  = jvm             { 
+    parralelExecutors['compiler']  = jvm             {
         sh """
             cd packages
             ./gradlew clean :plugin-compiler:test --info --stacktrace
@@ -37,7 +37,7 @@ stage('build') {
     }
     parralelExecutors['jvm']       = jvm             { test("jvmTest") }
     parralelExecutors['android']   = androidEmulator { test("connectedAndroidTest") }
-    // DISABLED until https://youtrack.jetbrains.com/issue/KT-42443 is fixed  parralelExecutors['macos']   = macos           { test("macosTest") }
+    parralelExecutors['macos']   = macos           { test("macosTest") }
     parallel parralelExecutors
 }
 

--- a/packages/library/src/commonMain/kotlin/io/realm/util/Module.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/util/Module.kt
@@ -1,24 +1,24 @@
-package io.realm.util
-
-import io.realm.runtimeapi.RealmCompanion
-import io.realm.runtimeapi.RealmModel
-import kotlin.reflect.KClass
-
-/**
- * Interim helper to place manual code written around schemas.
- */
-class Module(classes: List<KClass<out RealmModel>>) {
-    val classes: Collection<KClass<out RealmModel>> = HashSet(classes.toSet())
-
-    fun schema(): String {
-        return classes
-                .map { it.companion() }
-                .map { it.schema() }
-                .joinToString(prefix = "[", separator = ",", postfix = "]") { it }
-    }
-
-    private fun <T : Any> KClass<T>.companion(): RealmCompanion {
-        return this.nestedClasses.first { it.isCompanion }.objectInstance as RealmCompanion
-    }
-
-}
+//package io.realm.util
+//
+//import io.realm.runtimeapi.RealmCompanion
+//import io.realm.runtimeapi.RealmModel
+//import kotlin.reflect.KClass
+//
+///**
+// * Interim helper to place manual code written around schemas.
+// */
+//class Module(classes: List<KClass<out RealmModel>>) {
+//    val classes: Collection<KClass<out RealmModel>> = HashSet(classes.toSet())
+//
+//    fun schema(): String {
+//        return classes
+//                .map { it.companion() }
+//                .map { it.schema() }
+//                .joinToString(prefix = "[", separator = ",", postfix = "]") { it }
+//    }
+//
+//    private fun <T : Any> KClass<T>.companion(): RealmCompanion {
+//        return this.nestedClasses.first { it.isCompanion }.objectInstance as RealmCompanion
+//    }
+//
+//}

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/IrUtils.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/IrUtils.kt
@@ -4,7 +4,9 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
+import org.jetbrains.kotlin.ir.builders.declarations.IrFieldBuilder
 import org.jetbrains.kotlin.ir.builders.declarations.IrFunctionBuilder
+import org.jetbrains.kotlin.ir.builders.declarations.IrPropertyBuilder
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.declarations.IrFunction
@@ -66,6 +68,21 @@ fun IrFunction.isRealmBoolean(): Boolean {
     return isPropertyAccessor
             && isGetter
             && returnType.makeNotNull().isBoolean()
+}
+
+internal fun IrFunctionBuilder.at(startOffset: Int, endOffset: Int) = also {
+    this.startOffset = startOffset
+    this.endOffset = endOffset
+}
+
+internal fun IrFieldBuilder.at(startOffset: Int, endOffset: Int) = also {
+    this.startOffset = startOffset
+    this.endOffset = endOffset
+}
+
+internal fun IrPropertyBuilder.at(startOffset: Int, endOffset: Int) = also {
+    this.startOffset = startOffset
+    this.endOffset = endOffset
 }
 
 object SchemaCollector {

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -65,6 +65,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
     private fun IrClass.addNullableProperty(propertyName: Name, propertyType: IrType) {
         // PROPERTY name:realmPointer visibility:public modality:OPEN [var]
         val property = addProperty {
+            at(this@addNullableProperty.startOffset, this@addNullableProperty.endOffset)
             name = propertyName
             visibility = DescriptorVisibilities.PUBLIC
             modality = Modality.OPEN
@@ -72,6 +73,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         }
         // FIELD PROPERTY_BACKING_FIELD name:objectPointer type:kotlin.Long? visibility:private
         property.backingField = pluginContext.irFactory.buildField {
+            at(this@addNullableProperty.startOffset, this@addNullableProperty.endOffset)
             origin = IrDeclarationOrigin.PROPERTY_BACKING_FIELD
             name = property.name
             visibility = DescriptorVisibilities.PRIVATE
@@ -90,6 +92,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         // FUN DEFAULT _PROPERTY_ACCESSOR name:<get-objectPointer> visibility:public modality:OPEN <> ($this:dev.nhachicha.Foo.$RealmHandler) returnType:kotlin.Long?
         // correspondingProperty: PROPERTY name:objectPointer visibility:public modality:OPEN [var]
         val getter = property.addGetter {
+            at(this@addNullableProperty.startOffset, this@addNullableProperty.endOffset)
             visibility = DescriptorVisibilities.PUBLIC
             modality = Modality.OPEN
             returnType = propertyType
@@ -108,6 +111,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         // GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectPointer type:kotlin.Long? visibility:private' type=kotlin.Long? origin=null
         // receiver: GET_VAR '<this>: dev.nhachicha.Foo.$RealmHandler declared in dev.nhachicha.Foo.$RealmHandler.<get-objectPointer>' type=dev.nhachicha.Foo.$RealmHandler origin=null
         getter.body = pluginContext.blockBody(getter.symbol) {
+            at(startOffset, endOffset)
             +irReturn(
                     irGetField(irGet(getter.dispatchReceiverParameter!!), property.backingField!!)
             )
@@ -115,7 +119,8 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
 
         // FUN DEFAULT_PROPERTY_ACCESSOR name:<set-realmPointer> visibility:public modality:OPEN <> ($this:dev.nhachicha.Child, <set-?>:kotlin.Long?) returnType:kotlin.Unit
         //  correspondingProperty: PROPERTY name:realmPointer visibility:public modality:OPEN [var]
-        val setter = property.addSetter() {
+        val setter = property.addSetter {
+            at(this@addNullableProperty.startOffset, this@addNullableProperty.endOffset)
             visibility = DescriptorVisibilities.PUBLIC
             modality = Modality.OPEN
             returnType = pluginContext.irBuiltIns.unitType
@@ -141,6 +146,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
             this.type = propertyType
         }
         setter.body = DeclarationIrBuilder(pluginContext, setter.symbol).irBlockBody {
+            at(startOffset, endOffset)
             +irSetField(irGet(setter.dispatchReceiverParameter!!), property.backingField!!, irGet(valueParameter))
         }
     }

--- a/test/src/commonTest/kotlin/io/realm/ModuleTest.kt
+++ b/test/src/commonTest/kotlin/io/realm/ModuleTest.kt
@@ -1,18 +1,18 @@
-package io.realm
-
-import io.realm.util.Module
-import test.Sample
-import kotlin.test.Test
-import kotlin.test.assertEquals
-
-class ModuleTest {
-
-    @Test
-    fun schema() {
-        val moduleSchema = Module(listOf(Sample::class)).schema()
-        assertEquals(
-                listOf(Sample.schema()).joinToString(prefix = "[", separator = ",", postfix = "]") { it },
-                moduleSchema
-        )
-    }
-}
+//package io.realm
+//
+//import io.realm.util.Module
+//import test.Sample
+//import kotlin.test.Test
+//import kotlin.test.assertEquals
+//
+//class ModuleTest {
+//
+//    @Test
+//    fun schema() {
+//        val moduleSchema = Module(listOf(Sample::class)).schema()
+//        assertEquals(
+//                listOf(Sample.schema()).joinToString(prefix = "[", separator = ",", postfix = "]") { it },
+//                moduleSchema
+//        )
+//    }
+//}


### PR DESCRIPTION
- Fixes macos assertion error while linking the test project https://youtrack.jetbrains.com/issue/KT-42443

- Disabled the Module class and test since nestedClasses is only available for Kotlin JVM https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-class/nested-classes.html

- Re-enabled CI macos taget