### PR TITLE
Enable slack notifications for CI failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ import groovy.json.JsonOutput
 @Library('realm-ci') _
 
 // Branches that are "important", so if they do not compile they will generate a Slack notification
-slackNotificationBranches = [ 'master', 'releases', 'next-major', 'cm/slack-notifications' ]
+slackNotificationBranches = [ 'master', 'releases', 'next-major' ]
 currentBranch = env.CHANGE_BRANCH
 
 pipeline {


### PR DESCRIPTION
Enable automatic Slack notifications for changes we should be aware of for important branches.

TODO:
- [x] Check failure and recovery works