### PR TITLE
Consume public artifacts in sample projects

### DIFF
--- a/examples/kmm-sample/androidApp/build.gradle.kts
+++ b/examples/kmm-sample/androidApp/build.gradle.kts
@@ -20,12 +20,26 @@ plugins {
     id("com.android.application")
     kotlin("android")
     id("kotlin-android-extensions")
+    // TODO Publish marker artifact to OJO to allow applying plugin by id
+    //  https://github.com/realm/realm-kotlin/issues/100
     // Apply Realm Kotlin plugin even though we technically do not need it, to ensure that we have
     // the right kotlinOptions
-    id("realm-kotlin") version Realm.version
+    // id("realm-kotlin") version Realm.version
     // Apply Realm specific linting plugin to get common Realm linting tasks
     id("realm-lint")
 }
+// TODO Publish marker artifact to OJO to allow applying plugin by id instead of this
+//  https://github.com/realm/realm-kotlin/issues/100
+buildscript {
+    repositories {
+        maven(url = "http://oss.jfrog.org/artifactory/oss-snapshot-local")
+    }
+    dependencies {
+        classpath("io.realm.kotlin:gradle-plugin:${Realm.version}")
+    }
+}
+apply(plugin="realm-kotlin")
+
 group = "io.realm.example"
 version = Realm.version
 
@@ -34,13 +48,14 @@ repositories {
     google()
     jcenter()
     mavenCentral()
+    maven(url = "http://oss.jfrog.org/artifactory/oss-snapshot-local")
 }
 dependencies {
     implementation(project(":shared"))
     implementation("com.google.android.material:material:1.2.0")
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")
-    // FIXME TODO-SETUP
+    // TODO AUTO-SETUP
     compileOnly("io.realm.kotlin:library:${Realm.version}")
 }
 android {

--- a/examples/kmm-sample/androidApp/build.gradle.kts
+++ b/examples/kmm-sample/androidApp/build.gradle.kts
@@ -38,7 +38,7 @@ buildscript {
         classpath("io.realm.kotlin:gradle-plugin:${Realm.version}")
     }
 }
-apply(plugin="realm-kotlin")
+apply(plugin = "realm-kotlin")
 
 group = "io.realm.example"
 version = Realm.version

--- a/examples/kmm-sample/androidApp/src/main/res/layout/activity_main.xml
+++ b/examples/kmm-sample/androidApp/src/main/res/layout/activity_main.xml
@@ -36,7 +36,7 @@
 
     <TextView
         android:id="@+id/textView"
-        android:layout_width="12"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Hello World!"
         android:textAlignment="center" />

--- a/examples/kmm-sample/build.gradle.kts
+++ b/examples/kmm-sample/build.gradle.kts
@@ -13,11 +13,20 @@ buildscript {
 group = "io.realm.example"
 version = Realm.version
 
-subprojects {
-    repositories {
-        mavenLocal()
-    }
-}
+// Applying this here causes Gradle to hang, so applying in individual modules
+// subprojects {
+//    buildscript {
+//        repositories {
+//            maven(url = "http://oss.jfrog.org/artifactory/oss-snapshot-local")
+//        }
+//        dependencies {
+//            classpath("io.realm.kotlin:gradle-plugin:${Realm.version}")
+//        }
+//    }
+//    repositories {
+//        maven(url = "http://oss.jfrog.org/artifactory/oss-snapshot-local")
+//    }
+// }
 repositories {
     mavenCentral()
 }

--- a/examples/kmm-sample/settings.gradle.kts
+++ b/examples/kmm-sample/settings.gradle.kts
@@ -13,9 +13,9 @@ pluginManagement {
         google()
         jcenter()
         mavenCentral()
-        // FIXME Update sample projects to use public releases/snapshot OJO
-        //  https://github.com/realm/realm-kotlin/issues/74
-        mavenLocal()
+        // TODO Publish marker artifact to OJO to allow applying plugin by id
+        //  https://github.com/realm/realm-kotlin/issues/100
+        // maven(url = "http://oss.jfrog.org/artifactory/oss-snapshot-local")
     }
     resolutionStrategy {
         eachPlugin {

--- a/examples/kmm-sample/shared/build.gradle.kts
+++ b/examples/kmm-sample/shared/build.gradle.kts
@@ -39,7 +39,7 @@ buildscript {
         classpath("io.realm.kotlin:gradle-plugin:${Realm.version}")
     }
 }
-apply(plugin="realm-kotlin")
+apply(plugin = "realm-kotlin")
 
 group = "io.realm.example"
 version = Realm.version

--- a/examples/kmm-sample/shared/build.gradle.kts
+++ b/examples/kmm-sample/shared/build.gradle.kts
@@ -22,11 +22,25 @@ plugins {
     kotlin("multiplatform")
     id("com.android.library")
     id("kotlin-android-extensions")
+    // TODO Publish marker artifact to OJO to allow applying plugin by id
+    //  https://github.com/realm/realm-kotlin/issues/100
     // Apply Realm Kotlin plugin
-    id("realm-kotlin") version Realm.version
+    // id("realm-kotlin") version Realm.version
     // Apply Realm specific linting plugin to get common Realm linting tasks
     id("realm-lint")
 }
+// TODO Publish marker artifact to OJO to allow applying plugin by id instead of this
+//  https://github.com/realm/realm-kotlin/issues/100
+buildscript {
+    repositories {
+        maven(url = "http://oss.jfrog.org/artifactory/oss-snapshot-local")
+    }
+    dependencies {
+        classpath("io.realm.kotlin:gradle-plugin:${Realm.version}")
+    }
+}
+apply(plugin="realm-kotlin")
+
 group = "io.realm.example"
 version = Realm.version
 
@@ -35,6 +49,7 @@ repositories {
     google()
     jcenter()
     mavenCentral()
+    maven(url = "http://oss.jfrog.org/artifactory/oss-snapshot-local")
 }
 kotlin {
     android()


### PR DESCRIPTION
This updates the sample project to use our snapshots from OJO. Due to the marker artifacts not being published (#100) we have to apply our plugin the old way. 

Closes #74 