### PR TITLE
Publish to OJO using maven publish plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,7 @@ def runPublishToOjo() {
                 // artifactoryPublish directly.
                 sh """
                 cd packages
-                ./gradlew --no-daemon -DbintrayUser=${env.BINTRAY_USER} -DbintrayKey=${env.BINTRAY_KEY} artifactoryPublish
+                ./gradlew --no-daemon -DbintrayUser=${env.BINTRAY_USER} -DbintrayKey=${env.BINTRAY_KEY} publishAllPublicationsToOjoRepository
                 """
             }
         }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -45,7 +45,6 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
-        classpath("org.jfrog.buildinfo:build-info-extractor-gradle:${Versions.artifactoryPlugin}")
     }
 }
 
@@ -53,7 +52,6 @@ buildscript {
 // These seem to propagate to all projects including the buildSrc/ directory, which also means
 // they are not allowed to set the version. It can only be set from here.
 dependencies {
-    implementation("org.jfrog.buildinfo:build-info-extractor-gradle:${Versions.artifactoryPlugin}")
     implementation("org.jlleitschuh.gradle:ktlint-gradle:${Versions.ktlintPlugin}")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.detektPlugin}")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -16,7 +16,7 @@
  */
 
 object Realm {
-    const val version = "0.0.1-SNAPSHOT"
+    const val version = "0.0.2-SNAPSHOT"
     const val group = "io.realm.kotlin"
     const val projectUrl = "http://realm.io"
     const val plugin = "realm-kotlin"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -55,7 +55,6 @@ object Versions {
     }
     const val androidxJunit = "1.1.2" // https://maven.google.com/web/index.html#androidx.test.ext:junit
     const val androidxTest = "1.3.0" // https://maven.google.com/web/index.html#androidx.test:rules
-    const val artifactoryPlugin = "4.18.2" // https://plugins.gradle.org/plugin/com.jfrog.artifactory
     const val autoService = "1.0-rc6"
     const val detektPlugin = "1.14.1"
     const val junit = "4.12"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -16,7 +16,7 @@
  */
 
 object Realm {
-    const val version = "0.0.2-SNAPSHOT"
+    const val version = "0.0.1-SNAPSHOT"
     const val group = "io.realm.kotlin"
     const val projectUrl = "http://realm.io"
     const val plugin = "realm-kotlin"

--- a/buildSrc/src/main/kotlin/io/realm/RealmPublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/realm/RealmPublishPlugin.kt
@@ -31,6 +31,7 @@ import org.gradle.kotlin.dsl.getPluginByName
 import org.gradle.kotlin.dsl.withType
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
+import java.net.URL
 
 // Custom options for POM configurations that might differ between Realm modules
 open class PomOptions {
@@ -114,24 +115,15 @@ class RealmPublishPlugin : Plugin<Project> {
     }
 
     private fun configureArtifactory(project: Project, options: ArtifactoryOptions) {
-        project.convention.getPluginByName<ArtifactoryPluginConvention>("artifactory").apply {
-            setContextUrl("https://oss.jfrog.org/artifactory")
-            publish(
-                    delegateClosureOf<org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig> {
-                        repository(
-                                delegateClosureOf<groovy.lang.GroovyObject> {
-                                    setProperty("repoKey", "oss-snapshot-local")
-                                    setProperty("username", if (System.getProperties().containsKey("bintrayUser")) System.getProperty("bintrayUser") else "noUser")
-                                    setProperty("password", if (System.getProperties().containsKey("bintrayKey")) System.getProperty("bintrayKey") else "noKey")
-                                }
-                        )
-                        defaults(
-                                delegateClosureOf<groovy.lang.GroovyObject> {
-                                    invokeMethod("publications", options.publications)
-                                }
-                        )
-                    }
-            )
+        project.extensions.getByType<PublishingExtension>().apply {
+            repositories.maven {
+                name = "ojo"
+                url = URL("https://oss.jfrog.org/artifactory/oss-snapshot-local").toURI()
+                credentials {
+                    username = if (System.getProperties().containsKey("bintrayUser")) System.getProperty("bintrayUser") else "noUser"
+                    password = if (System.getProperties().containsKey("bintrayKey")) System.getProperty("bintrayKey") else "noKey"
+                }
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/realm/RealmPublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/realm/RealmPublishPlugin.kt
@@ -17,6 +17,7 @@
 
 package io.realm
 
+import Realm
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -24,13 +25,9 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.delegateClosureOf
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.getPluginByName
 import org.gradle.kotlin.dsl.withType
-import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
-import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import java.net.URL
 
 // Custom options for POM configurations that might differ between Realm modules
@@ -43,7 +40,6 @@ open class PomOptions {
 // Custom options for Artifactory configurations that might differ between Realm modules
 open class ArtifactoryOptions {
     open var isEnabled: Boolean = true
-    open var publications: Array<String> = arrayOf()
 }
 
 // Configure how the Realm module is published
@@ -65,7 +61,6 @@ open class RealmPublishExtensions {
 class RealmPublishPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         plugins.apply(MavenPublishPlugin::class.java)
-        plugins.apply(ArtifactoryPlugin::class.java)
         extensions.create<RealmPublishExtensions>("realmPublish")
         afterEvaluate {
             project.extensions.findByType<RealmPublishExtensions>()?.run {

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -312,7 +312,5 @@ realmPublish {
             "supposed to be consumed directly, but through " +
             "'io.realm.kotlin:gradle-plugin:${Realm.version}' instead."
     }
-    ojo {
-        publications = arrayOf("androidDebug", "androidRelease", "ios", "macos", "jvm", "kotlinMultiplatform", "metadata")
-    }
+    ojo { }
 }

--- a/packages/gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/build.gradle.kts
@@ -48,9 +48,7 @@ realmPublish {
         name = "Gradle Plugin"
         description = "Gradle plugin for Realm Kotlin. Realm is a mobile database: Build better apps faster."
     }
-    ojo {
-        publications = arrayOf(mavenPublicationName)
-    }
+    ojo { }
 }
 
 publishing {

--- a/packages/gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/build.gradle.kts
@@ -34,6 +34,12 @@ gradlePlugin {
             displayName = "Realm compiler plugin"
             implementationClass = "io.realm.gradle.RealmPlugin"
         }
+        // FIXME Disable publishing of marker artifact as it is currently causing authentication
+        //  issues when uploading to http://oss.jfrog.org/oss-snapshot-local.
+        //  NOTE This also disables publication of the marker artifact when publishing to local
+        //  maven repository
+        //  https://github.com/realm/realm-kotlin/issues/100
+        isAutomatedPublishing = false
     }
 }
 

--- a/packages/jni-swig-stub/build.gradle.kts
+++ b/packages/jni-swig-stub/build.gradle.kts
@@ -56,9 +56,7 @@ realmPublish {
             "supposed to be consumed directly, but through " +
             "'io.realm.kotlin:gradle-plugin:${Realm.version}' instead."
     }
-    ojo {
-        publications = arrayOf(mavenPublicationName)
-    }
+    ojo { }
 }
 
 publishing {

--- a/packages/library/build.gradle.kts
+++ b/packages/library/build.gradle.kts
@@ -187,9 +187,5 @@ realmPublish {
             "supposed to be consumed directly, but through " +
             "'io.realm.kotlin:gradle-plugin:${Realm.version}' instead."
     }
-    ojo {
-        // List fetched from https://medium.com/vmware-end-user-computing/publishing-kotlin-multiplatform-artifacts-to-artifactory-maven-a283ae5912d6
-        // TODO MPP-BUILD Unclear if we should name "iosArm64" and "macosX64" as well?
-        publications = arrayOf("androidDebug", "androidRelease", "ios", "macos", "jvm", "kotlinMultiplatform", "metadata")
-    }
+    ojo { }
 }

--- a/packages/plugin-compiler-shaded/build.gradle.kts
+++ b/packages/plugin-compiler-shaded/build.gradle.kts
@@ -56,9 +56,7 @@ realmPublish {
             "supposed to be consumed directly, but through " +
             "'io.realm.kotlin:gradle-plugin:${Realm.version}' instead."
     }
-    ojo {
-        publications = arrayOf(mavenPublicationName)
-    }
+    ojo { }
 }
 
 publishing {

--- a/packages/plugin-compiler/build.gradle.kts
+++ b/packages/plugin-compiler/build.gradle.kts
@@ -53,9 +53,7 @@ realmPublish {
             "supposed to be consumed directly, but through " +
             "'io.realm.kotlin:gradle-plugin:${Realm.version}' instead."
     }
-    ojo {
-        publications = arrayOf(mavenPublicationName)
-    }
+    ojo { }
 }
 
 publishing {

--- a/packages/runtime-api/build.gradle.kts
+++ b/packages/runtime-api/build.gradle.kts
@@ -135,9 +135,5 @@ realmPublish {
             "artifact is not supposed to be consumed directly, but through " +
             "'io.realm.kotlin:gradle-plugin:${Realm.version}' instead."
     }
-    ojo {
-        // List fetched from https://medium.com/vmware-end-user-computing/publishing-kotlin-multiplatform-artifacts-to-artifactory-maven-a283ae5912d6
-        // TODO MPP-BUILD Unclear if we should name "iosArm64" and "macosX64" as well?
-        publications = arrayOf("androidDebug", "androidRelease", "ios", "macos", "jvm", "kotlinMultiplatform", "metadata")
-    }
+    ojo { }
 }


### PR DESCRIPTION
Using https://www.jfrog.com/confluence/display/JFROG/Gradle+Artifactory+Plugin somehow renders stale files or metadata for `cinterop-...-cinterop-realm_wrapper.klib` and `cinterop-...-sources.jar` files. The files are correct on first release, but on subsequent SNAPSHOT releases the files will not be uploaded or they are uploaded in place of the previous release's files. 

Using plain `maven-plugin` repository fixes the issue. 