### PR TITLE
Update type handling according to new C-API

### DIFF
--- a/packages/cinterop/src/androidTest/java/io/realm/interop/CinteropTest.kt
+++ b/packages/cinterop/src/androidTest/java/io/realm/interop/CinteropTest.kt
@@ -36,12 +36,15 @@ class CinteropTest {
         System.loadLibrary("realmc")
         println(realmc.realm_get_library_version())
 
+        val rlmInvalidPropertyKey = realmc.getRLM_INVALID_PROPERTY_KEY()
+        val rlmInvalidClassKey = realmc.getRLM_INVALID_CLASS_KEY()
+
         val class_1 = realm_class_info_t().apply {
             name = "foo"
             primary_key = ""
             num_properties = 3
             num_computed_properties = 0
-            key = realm_table_key_t()
+            key = rlmInvalidClassKey
             flags = realm_class_flags_e.RLM_CLASS_NORMAL
         }
 
@@ -52,7 +55,7 @@ class CinteropTest {
             collection_type = realm_collection_type_e.RLM_COLLECTION_TYPE_NONE
             link_target = ""
             link_origin_property_name = ""
-            key = realm_col_key_t()
+            key = rlmInvalidPropertyKey
             flags = realm_property_flags_e.RLM_PROPERTY_NORMAL
         }
         val prop_1_2 = realm_property_info_t().apply {
@@ -62,7 +65,7 @@ class CinteropTest {
             collection_type = realm_collection_type_e.RLM_COLLECTION_TYPE_NONE
             link_target = ""
             link_origin_property_name = ""
-            key = realm_col_key_t()
+            key = rlmInvalidPropertyKey
             flags = realm_property_flags_e.RLM_PROPERTY_NORMAL
         }
         val prop_1_3 = realm_property_info_t().apply {
@@ -72,7 +75,7 @@ class CinteropTest {
             collection_type = realm_collection_type_e.RLM_COLLECTION_TYPE_LIST
             link_target = "bar"
             link_origin_property_name = ""
-            key = realm_col_key_t()
+            key = rlmInvalidPropertyKey
             flags = realm_property_flags_e.RLM_PROPERTY_NORMAL
         }
 
@@ -81,7 +84,7 @@ class CinteropTest {
             primary_key = "int"
             num_properties = 2
             num_computed_properties = 0
-            key = realm_table_key_t()
+            key = rlmInvalidClassKey
             flags = realm_class_flags_e.RLM_CLASS_NORMAL
         }
 
@@ -107,7 +110,7 @@ class CinteropTest {
                     collection_type = realm_collection_type_e.RLM_COLLECTION_TYPE_NONE
                     link_target = ""
                     link_origin_property_name = ""
-                    key = realm_col_key_t()
+                    key = rlmInvalidPropertyKey
                     flags = realm_property_flags_e.RLM_PROPERTY_INDEXED or realm_property_flags_e.RLM_PROPERTY_PRIMARY_KEY
                 },
                 realm_property_info_t().apply {
@@ -117,7 +120,7 @@ class CinteropTest {
                     collection_type = realm_collection_type_e.RLM_COLLECTION_TYPE_LIST
                     link_target = ""
                     link_origin_property_name = ""
-                    key = realm_col_key_t()
+                    key = rlmInvalidPropertyKey
                     flags = realm_property_flags_e.RLM_PROPERTY_NORMAL or realm_property_flags_e.RLM_PROPERTY_NULLABLE
                 }
             ).forEachIndexed { i, prop ->
@@ -203,10 +206,10 @@ class CinteropTest {
         realmc.realm_query_find_first(query, findFirstValue, findFirstFound)
         assertTrue(findFirstFound[0])
         assertEquals(realm_value_type_e.RLM_TYPE_LINK, findFirstValue.type)
-        assertEquals(foo_info.key.table_key, findFirstValue.link.target_table.table_key)
+        assertEquals(foo_info.key, findFirstValue.link.target_table)
         val realmObjectGetKey = realmc.realm_object_get_key(foo1)
         // Will not be true unless executed on a fresh realm
-        assertEquals(realmObjectGetKey.obj_key, findFirstValue.link.target.obj_key)
+        assertEquals(realmObjectGetKey, findFirstValue.link.target)
 
         val results: Long = realmc.realm_query_find_all(query)
 

--- a/packages/cinterop/src/darwinCommon/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwinCommon/kotlin/io/realm/interop/RealmInterop.kt
@@ -34,7 +34,6 @@ import kotlinx.cinterop.getBytes
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.readBytes
-import kotlinx.cinterop.readValue
 import kotlinx.cinterop.set
 import kotlinx.cinterop.toKString
 import kotlinx.cinterop.value
@@ -44,11 +43,9 @@ import realm_wrapper.realm_config_t
 import realm_wrapper.realm_error_t
 import realm_wrapper.realm_find_property
 import realm_wrapper.realm_get_last_error
-import realm_wrapper.realm_obj_key
 import realm_wrapper.realm_property_info_t
 import realm_wrapper.realm_schema_mode
 import realm_wrapper.realm_string_t
-import realm_wrapper.realm_table_key_t
 import realm_wrapper.realm_value_t
 import realm_wrapper.realm_value_type
 
@@ -56,7 +53,7 @@ private fun throwOnError() {
     memScoped {
         val error = alloc<realm_error_t>()
         if (realm_get_last_error(error.ptr)) {
-            val runtimeException = RuntimeException(error.message.toKString())
+            val runtimeException = RuntimeException(error.message?.toKString())
             realm_clear_last_error()
             // FIXME Extract all error information and throw exceptions based on type
             //  https://github.com/realm/realm-kotlin/issues/70
@@ -151,8 +148,8 @@ actual object RealmInterop {
                 val properties = clazz.properties
                 // Class
                 cclasses[i].apply {
-                    name.set(memScope, clazz.name)
-                    primary_key.set(memScope, clazz.primaryKey)
+                    name = clazz.name.cstr.ptr
+                    primary_key = clazz.primaryKey.cstr.ptr
                     num_properties = properties.size.toULong()
                     num_computed_properties = 0U
                     flags =
@@ -162,7 +159,10 @@ actual object RealmInterop {
                     allocArray<realm_property_info_t>(properties.size).getPointer(memScope)
                 for ((j, property) in properties.withIndex()) {
                     cproperties[i]!![j].apply {
-                        name.set(memScope, property.name)
+                        name = property.name.cstr.ptr
+                        public_name = "".cstr.ptr
+                        link_target = "".cstr.ptr
+                        link_origin_property_name = "".cstr.ptr
                         type = property.type.nativeValue
                         collection_type = property.collectionType.nativeValue
                         flags =
@@ -185,14 +185,7 @@ actual object RealmInterop {
     }
 
     actual fun realm_config_set_path(config: NativePointer, path: String) {
-        memScoped {
-            throwOnError(
-                realm_wrapper.realm_config_set_path(
-                    config.cptr(),
-                    path.toRString(memScope)
-                )
-            )
-        }
+        throwOnError(realm_wrapper.realm_config_set_path(config.cptr(), path))
     }
 
     actual fun realm_config_set_schema_mode(config: NativePointer, mode: SchemaMode) {
@@ -256,7 +249,7 @@ actual object RealmInterop {
             throwOnError(
                 realm_wrapper.realm_find_class(
                     realm.cptr(),
-                    name.toRString(memScope),
+                    name,
                     found.ptr,
                     classInfo.ptr
                 )
@@ -264,13 +257,12 @@ actual object RealmInterop {
             if (!found.value) {
                 throw RuntimeException("Class \"$name\" not found")
             }
-            return classInfo.key.table_key.toLong()
+            return classInfo.key.toLong()
         }
     }
 
     actual fun realm_object_create(realm: NativePointer, key: Long): NativePointer {
-        val tableKey = cValue<realm_table_key_t> { table_key = key.toUInt() }
-        return CPointerWrapper(realm_wrapper.realm_object_create(realm.cptr(), tableKey))
+        return CPointerWrapper(realm_wrapper.realm_object_create(realm.cptr(), key.toUInt()))
     }
 
     // FIXME API-INTERNAL How should we support the various types. Through generic dispatching
@@ -316,7 +308,7 @@ actual object RealmInterop {
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
             val value = alloc<realm_value_t>()
-            realm_wrapper.realm_get_value(obj.cptr(), propertyInfo.key.readValue(), value.ptr)
+            realm_wrapper.realm_get_value(obj.cptr(), propertyInfo.key, value.ptr)
             when (value.type) {
                 realm_value_type.RLM_TYPE_STRING ->
                     return value.string.toKString()
@@ -345,7 +337,7 @@ actual object RealmInterop {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
             realm_wrapper.realm_set_value_string(
                 obj.cptr(),
-                propertyInfo.key.readValue(),
+                propertyInfo.key,
                 value.toRString(memScope),
                 false
             )
@@ -369,8 +361,8 @@ actual object RealmInterop {
             return CPointerWrapper(
                 realm_wrapper.realm_query_parse(
                     realm.cptr(),
-                    classInfo(realm, table).key.readValue(),
-                    query.toRString(memScope),
+                    classInfo(realm, table).key,
+                    query,
                     count.toULong(),
                     cArgs
                 )
@@ -389,7 +381,7 @@ actual object RealmInterop {
             if (value.type != realm_value_type.RLM_TYPE_LINK) {
                 error("Query did not return link but ${value.type}")
             }
-            return Link(value.link.target.obj_key, value.link.target_table.table_key.toLong())
+            return Link(value.link.target, value.link.target_table.toLong())
         }
     }
 
@@ -414,9 +406,7 @@ actual object RealmInterop {
     }
 
     actual fun realm_get_object(realm: NativePointer, link: Link): NativePointer {
-        val tableKey = cValue<realm_table_key_t> { table_key = link.tableKey.toUInt() }
-        val objKey = cValue<realm_obj_key> { obj_key = link.objKey }
-        val ptr = throwOnError(realm_wrapper.realm_get_object(realm.cptr(), tableKey, objKey))
+        val ptr = throwOnError(realm_wrapper.realm_get_object(realm.cptr(), link.tableKey.toUInt(), link.objKey))
         return CPointerWrapper(ptr)
     }
 
@@ -431,7 +421,7 @@ actual object RealmInterop {
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
             val value = alloc<realm_value_t>()
-            realm_wrapper.realm_get_value(o.cptr(), propertyInfo.key.readValue(), value.ptr)
+            realm_wrapper.realm_get_value(o.cptr(), propertyInfo.key, value.ptr)
             when (value.type) {
                 realm_value_type.RLM_TYPE_INT ->
                     return value.integer
@@ -450,7 +440,7 @@ actual object RealmInterop {
         }
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
-            realm_wrapper.realm_set_value_int64(o.cptr(), propertyInfo.key.readValue(), value, false)
+            realm_wrapper.realm_set_value_int64(o.cptr(), propertyInfo.key, value, false)
         }
     }
 
@@ -461,7 +451,7 @@ actual object RealmInterop {
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
             val value = alloc<realm_value_t>()
-            realm_wrapper.realm_get_value(o.cptr(), propertyInfo.key.readValue(), value.ptr)
+            realm_wrapper.realm_get_value(o.cptr(), propertyInfo.key, value.ptr)
             when (value.type) {
                 realm_value_type.RLM_TYPE_BOOL ->
                     return value.boolean
@@ -480,7 +470,7 @@ actual object RealmInterop {
         }
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
-            realm_wrapper.realm_set_value_boolean(o.cptr(), propertyInfo.key.readValue(), value, false)
+            realm_wrapper.realm_set_value_boolean(o.cptr(), propertyInfo.key, value, false)
         }
     }
 
@@ -491,7 +481,7 @@ actual object RealmInterop {
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
             val value = alloc<realm_value_t>()
-            realm_wrapper.realm_get_value(o.cptr(), propertyInfo.key.readValue(), value.ptr)
+            realm_wrapper.realm_get_value(o.cptr(), propertyInfo.key, value.ptr)
             when (value.type) {
                 realm_value_type.RLM_TYPE_FLOAT ->
                     return value.fnum
@@ -510,7 +500,7 @@ actual object RealmInterop {
         }
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
-            realm_wrapper.realm_set_value_float(o.cptr(), propertyInfo.key.readValue(), value, false)
+            realm_wrapper.realm_set_value_float(o.cptr(), propertyInfo.key, value, false)
         }
     }
 
@@ -521,7 +511,7 @@ actual object RealmInterop {
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
             val value = alloc<realm_value_t>()
-            realm_wrapper.realm_get_value(o.cptr(), propertyInfo.key.readValue(), value.ptr)
+            realm_wrapper.realm_get_value(o.cptr(), propertyInfo.key, value.ptr)
             when (value.type) {
                 realm_value_type.RLM_TYPE_DOUBLE ->
                     return value.dnum
@@ -540,7 +530,7 @@ actual object RealmInterop {
         }
         memScoped {
             val propertyInfo = propertyInfo(realm, classInfo(realm, table), col)
-            realm_wrapper.realm_set_value_double(o.cptr(), propertyInfo.key.readValue(), value, false)
+            realm_wrapper.realm_set_value_double(o.cptr(), propertyInfo.key, value, false)
         }
     }
 
@@ -554,7 +544,7 @@ actual object RealmInterop {
         throwOnError(
             realm_wrapper.realm_find_class(
                 realm.cptr(),
-                table.toRString(memScope),
+                table,
                 found.ptr,
                 classInfo.ptr
             )
@@ -572,8 +562,8 @@ actual object RealmInterop {
         throwOnError(
             realm_find_property(
                 realm.cptr(),
-                classInfo.key.readValue(),
-                col.toRString(memScope),
+                classInfo.key,
+                col,
                 found.ptr,
                 propertyInfo.ptr
             )
@@ -585,6 +575,6 @@ actual object RealmInterop {
         if (this.type != realm_value_type.RLM_TYPE_LINK) {
             error("Value is not of type link: $this.type")
         }
-        return Link(this.link.target.obj_key, this.link.target_table.table_key.toLong())
+        return Link(this.link.target, this.link.target_table.toLong())
     }
 }

--- a/packages/cinterop/src/jvmCommon/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvmCommon/kotlin/io/realm/interop/RealmInterop.kt
@@ -21,7 +21,11 @@ package io.realm.interop
 import io.realm.runtimeapi.Link
 import io.realm.runtimeapi.NativePointer
 
+private val INVALID_CLASS_KEY: Long by lazy { realmc.getRLM_INVALID_CLASS_KEY() }
+private val INVALID_PROPERTY_KEY: Long by lazy { realmc.getRLM_INVALID_PROPERTY_KEY() }
+
 actual object RealmInterop {
+
     // TODO API-CLEANUP Maybe pull library loading into separate method
     //  https://github.com/realm/realm-kotlin/issues/56
     init {
@@ -45,7 +49,7 @@ actual object RealmInterop {
                 primary_key = clazz.primaryKey
                 num_properties = properties.size.toLong()
                 num_computed_properties = 0
-                key = -1 // Use constant directly to avoid JNI round trip to realmc.getRLM_INVALID_CLASS_KEY()
+                key = INVALID_CLASS_KEY
                 flags = clazz.flags.fold(0) { flags, element -> flags or element.nativeValue }
             }
             // Properties
@@ -58,7 +62,7 @@ actual object RealmInterop {
                     collection_type = property.collectionType.nativeValue
                     link_target = property.linkTarget
                     link_origin_property_name = property.linkOriginPropertyName
-                    key = -1 // Use constant directly to avoid JNI round trip to realmc.getRLM_INVALID_PROPERTY_KEY()
+                    key = INVALID_PROPERTY_KEY
                     flags = property.flags.fold(0) { flags, element -> flags or element.nativeValue }
                 }
                 realmc.propertyArray_setitem(classProperties, j, cproperty)

--- a/packages/cinterop/src/jvmCommon/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvmCommon/kotlin/io/realm/interop/RealmInterop.kt
@@ -323,7 +323,7 @@ actual object RealmInterop {
             }
             is Char -> {
                 value.type = realm_value_type_e.RLM_TYPE_INT
-                value.integer = o as Long
+                value.integer = o.toLong()
             }
             is Float -> {
                 value.type = realm_value_type_e.RLM_TYPE_FLOAT

--- a/packages/cinterop/src/nativeCommon/realm.def
+++ b/packages/cinterop/src/nativeCommon/realm.def
@@ -28,35 +28,35 @@ struct dirent * readdir$INODE64( DIR * dir )
 // These functions are a work around to avoid anonymous union not being supported in Kotlin/Native https://youtrack.jetbrains.com/issue/KT-43833
 // which will call to `realm_wrapper.realm_set_value` using a `cValue<realm_value>` throw a
 // type kotlinx.cinterop.CValue<realm_wrapper.realm_value{ realm_wrapper.realm_value_t }>  is not supported here: not a structure or too complex
-static bool realm_set_value_string(realm_object_t* object, realm_col_key_t col, realm_string_t new_value, bool is_default) {
+static bool realm_set_value_string(realm_object_t* object, realm_property_key_t col, realm_string_t new_value, bool is_default) {
     realm_value_t value;
     value.type = RLM_TYPE_STRING;
     value.string = new_value;
     return realm_set_value(object, col, value, is_default);
 }
 
-static bool realm_set_value_int64(realm_object_t* object, realm_col_key_t col, int64_t new_value, bool is_default) {
+static bool realm_set_value_int64(realm_object_t* object, realm_property_key_t col, int64_t new_value, bool is_default) {
     realm_value_t value;
     value.type = RLM_TYPE_INT;
     value.integer = new_value;
     return realm_set_value(object, col, value, is_default);
 }
 
-static bool realm_set_value_boolean(realm_object_t* object, realm_col_key_t col, bool new_value, bool is_default) {
+static bool realm_set_value_boolean(realm_object_t* object, realm_property_key_t col, bool new_value, bool is_default) {
     realm_value_t value;
     value.type = RLM_TYPE_BOOL;
     value.integer = new_value;
     return realm_set_value(object, col, value, is_default);
 }
 
-static bool realm_set_value_float(realm_object_t* object, realm_col_key_t col, float new_value, bool is_default) {
+static bool realm_set_value_float(realm_object_t* object, realm_property_key_t col, float new_value, bool is_default) {
     realm_value_t value;
     value.type = RLM_TYPE_FLOAT;
     value.fnum = new_value;
     return realm_set_value(object, col, value, is_default);
 }
 
-static bool realm_set_value_double(realm_object_t* object, realm_col_key_t col, double new_value, bool is_default) {
+static bool realm_set_value_double(realm_object_t* object, realm_property_key_t col, double new_value, bool is_default) {
     realm_value_t value;
     value.type = RLM_TYPE_DOUBLE;
     value.dnum = new_value;

--- a/packages/jni-swig-stub/build.gradle.kts
+++ b/packages/jni-swig-stub/build.gradle.kts
@@ -37,7 +37,7 @@ tasks.create("realmWrapperJvm") {
     doLast {
         exec {
             workingDir(".")
-            commandLine("swig", "-java", "-c++", "-package", "io.realm.interop", "-I$projectDir/../../external/core/src/realm", "-o", "$projectDir/src/main/jni/realmc.cpp", "-outdir", "$projectDir/src/main/java/io/realm/interop", "realm.i")
+            commandLine("swig", "-java", "-c++", "-package", "io.realm.interop", "-I$projectDir/../../external/core/src", "-o", "$projectDir/src/main/jni/realmc.cpp", "-outdir", "$projectDir/src/main/java/io/realm/interop", "realm.i")
         }
     }
     inputs.file("realm.i")

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -1,6 +1,6 @@
 %module realmc
 %{
-#include "realm/realm.h"
+#include "realm.h"
 #include <cstring>
 #include <string>
 %}
@@ -62,7 +62,7 @@ bool realm_object_is_valid(const realm_object_t*);
     if (!result) {
         realm_error_t error;
         if (realm_get_last_error(&error)) {
-            std::string message("[" + std::to_string(error.error) + "]: " + error.message.data);
+            std::string message("[" + std::to_string(error.error) + "]: " + error.message);
             realm_clear_last_error();
             // TODO API-SCHEMA Cache class lookup
             // FIXME Extract all error information and throw exceptions based on type
@@ -77,7 +77,7 @@ bool realm_object_is_valid(const realm_object_t*);
     if (!result) {
         realm_error_t error;
         if (realm_get_last_error(&error)) {
-            std::string message("[" + std::to_string(error.error) + "]: " + error.message.data);
+            std::string message("[" + std::to_string(error.error) + "]: " + error.message);
             realm_clear_last_error();
             // TODO API-SCHEMA Cache class lookup
             // FIXME Extract all error information and throw exceptions based on type

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -125,8 +125,9 @@ struct realm_size_t {
 %typemap(javaclassmodifiers) SWIGTYPE "class";
 %typemap(javaclassmodifiers) enum SWIGTYPE "final class";
 
-// Ignored due to incorrect type cast in Swig-generated wrapper for "const realm_property_key_t*"
-// which is not cast correctly to the underlying C-API method.
+// FIXME OPTIMIZE Support getting/setting multiple attributes. Ignored for now due to incorrect
+//  type cast in Swig-generated wrapper for "const realm_property_key_t*" which is not cast
+//  correctly to the underlying C-API method.
 %ignore "realm_get_values";
 %ignore "realm_set_values";
 // Not yet available in library

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -103,10 +103,7 @@ bool realm_object_is_valid(const realm_object_t*);
 %array_functions(realm_value_t, valueArray);
 
 // size_t output parameter
-struct realm_size_t {
-    size_t value;
-};
-%{
+%inline %{
 struct realm_size_t {
     size_t value;
 };
@@ -128,6 +125,10 @@ struct realm_size_t {
 %typemap(javaclassmodifiers) SWIGTYPE "class";
 %typemap(javaclassmodifiers) enum SWIGTYPE "final class";
 
+// Ignored due to incorrect type cast in Swig-generated wrapper for "const realm_property_key_t*"
+// which is not cast correctly to the underlying C-API method.
+%ignore "realm_get_values";
+%ignore "realm_set_values";
 // Not yet available in library
 %ignore "realm_get_async_error";
 %ignore "realm_get_last_error_as_async_error";

--- a/packages/runtime-api/src/commonMain/kotlin/io/realm/runtimeapi/Link.kt
+++ b/packages/runtime-api/src/commonMain/kotlin/io/realm/runtimeapi/Link.kt
@@ -4,5 +4,7 @@ package io.realm.runtimeapi
 // FIXME Do we need a type variable here?
 class Link(
     var objKey: Long,
+    // Could potentially be narrowed to Int, but Swig automatically returns long for the underlying
+    // uint32_t, while cinterop uses UInt!?
     var tableKey: Long,
 )


### PR DESCRIPTION
This updates to the latest C-API with update API (`realm_string_t`->`const char*` and plain typedefs for key types).