### PR TITLE
Add step to run monkey on sample app

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         }
         stage('Tests Android Sample App') {
             steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     runMonkey()
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -236,14 +236,15 @@ def test(task) {
 }
 
 def runMonkey() {
-    node(osx_kotlin) {
+    try {
         withEnv(['PATH+USER_BIN=/usr/local/bin']) {
             sh """
-                cd examples/kmm-sample
-                ./gradlew uninstallAll installDebug --info --stacktrace --no-daemon
                 $ANDROID_SDK_ROOT/platform-tools/adb shell monkey -p  io.realm.example.kmmsample.androidApp -v 500 --kill-process-after-error
             """
         }
+    } catch (err) {
+        currentBuild.result = 'FAILURE'
+        currentBuild.stageResult = 'FAILURE'
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,11 @@ pipeline {
                 test("connectedAndroidTest")
             }
         }
+        stage('Tests Android Sample App') {
+            steps {
+                runMonkey()
+            }
+        }
         stage('Publish to OJO') {
             when { expression { shouldReleaseSnapshot(version) } }
             steps {
@@ -226,7 +231,18 @@ def test(task) {
             step([$class: 'JUnitResultArchiver', allowEmptyResults: true, testResults: "test/build/**/TEST-*.xml"])
         }
     }
+}
 
+def runMonkey() {
+    node(osx_kotlin) {
+        withEnv(['PATH+USER_BIN=/usr/local/bin']) {
+            sh """
+                cd examples/kmm-sample
+                ./gradlew uninstallAll installDebug --info --stacktrace --no-daemon
+                ./gradlew monkey --info --stacktrace --no-daemon
+            """
+        }
+    }
 }
 
 def getArchive() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,9 @@ pipeline {
         }
         stage('Tests Android Sample App') {
             steps {
-                runMonkey()
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    runMonkey()
+                }
             }
         }
         stage('Publish to OJO') {
@@ -239,7 +241,7 @@ def runMonkey() {
             sh """
                 cd examples/kmm-sample
                 ./gradlew uninstallAll installDebug --info --stacktrace --no-daemon
-                ./gradlew monkey --info --stacktrace --no-daemon
+                $ANDROID_SDK_ROOT/platform-tools/adb shell monkey -p  io.realm.example.kmmsample.androidApp -v 500 --kill-process-after-error
             """
         }
     }

--- a/examples/kmm-sample/androidApp/build.gradle.kts
+++ b/examples/kmm-sample/androidApp/build.gradle.kts
@@ -76,6 +76,6 @@ android {
 }
 
 tasks.register("monkey", type = Exec::class) {
-    val clearDataCommand = listOf("adb", "shell", "monkey", "-p", "io.realm.example.kmmsample.androidApp", "-v", "500", "--kill-process-after-error")
-    commandLine(clearDataCommand)
+    val runMonkey = listOf("adb", "shell", "monkey", "-p", "io.realm.example.kmmsample.androidApp", "-v", "500", "--kill-process-after-error")
+    commandLine(runMonkey)
 }

--- a/examples/kmm-sample/androidApp/build.gradle.kts
+++ b/examples/kmm-sample/androidApp/build.gradle.kts
@@ -74,8 +74,3 @@ android {
         }
     }
 }
-
-tasks.register("monkey", type = Exec::class) {
-    val runMonkey = listOf("adb", "shell", "monkey", "-p", "io.realm.example.kmmsample.androidApp", "-v", "500", "--kill-process-after-error")
-    commandLine(runMonkey)
-}

--- a/examples/kmm-sample/androidApp/build.gradle.kts
+++ b/examples/kmm-sample/androidApp/build.gradle.kts
@@ -74,3 +74,8 @@ android {
         }
     }
 }
+
+tasks.register("monkey", type = Exec::class) {
+    val clearDataCommand = listOf("adb", "shell", "monkey", "-p", "io.realm.example.kmmsample.androidApp", "-v", "500", "--kill-process-after-error")
+    commandLine(clearDataCommand)
+}


### PR DESCRIPTION
Fixes #139 

now CI could fail with the following error after running monkey
```
47 actionable tasks: 47 executed

+ /Users/realm/Library/Android/sdk//platform-tools/adb shell monkey -p io.realm.example.kmmsample.androidApp -v 500 --kill-process-after-error

  bash arg: -p

  bash arg: io.realm.example.kmmsample.androidApp

  bash arg: -v

  bash arg: 500

  bash arg: --kill-process-after-error

args: [-p, io.realm.example.kmmsample.androidApp, -v, 500, --kill-process-after-error]

 arg: "-p"

 arg: "io.realm.example.kmmsample.androidApp"

 arg: "-v"

 arg: "500"

 arg: "--kill-process-after-error"

data="io.realm.example.kmmsample.androidApp"

:Monkey: seed=1615604288075 count=500

:AllowPackage: io.realm.example.kmmsample.androidApp

:IncludeCategory: android.intent.category.LAUNCHER

:IncludeCategory: android.intent.category.MONKEY

// Event percentages:

//   0: 15.0%

//   1: 10.0%

//   2: 2.0%

//   3: 15.0%

//   4: -0.0%

//   5: -0.0%

//   6: 25.0%

//   7: 15.0%

//   8: 2.0%

//   9: 2.0%

//   10: 1.0%

//   11: 13.0%

:Switch: #Intent;action=android.intent.action.MAIN;category=android.intent.category.LAUNCHER;launchFlags=0x10200000;component=io.realm.example.kmmsample.androidApp/.MainActivity;end

    // Allowing start of Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] cmp=io.realm.example.kmmsample.androidApp/.MainActivity } in package io.realm.example.kmmsample.androidApp

:Sending Touch (ACTION_DOWN): 0:(717.0,975.0)

:Sending Touch (ACTION_UP): 0:(714.475,976.16656)

:Sending Trackball (ACTION_MOVE): 0:(2.0,3.0)

:Sending Trackball (ACTION_MOVE): 0:(-4.0,-1.0)

:Sending Touch (ACTION_DOWN): 0:(103.0,277.0)

:Sending Touch (ACTION_UP): 0:(119.64768,297.7765)

:Sending Touch (ACTION_DOWN): 0:(272.0,865.0)

:Sending Touch (ACTION_UP): 0:(272.36356,869.6924)

:Sending Touch (ACTION_DOWN): 0:(178.0,91.0)

:Sending Touch (ACTION_UP): 0:(186.71057,169.58615)

:Sending Touch (ACTION_DOWN): 0:(741.0,1198.0)

:Sending Touch (ACTION_UP): 0:(749.10846,1190.497)

:Sending Trackball (ACTION_MOVE): 0:(1.0,-4.0)

:Sending Touch (ACTION_DOWN): 0:(484.0,1731.0)

:Sending Touch (ACTION_UP): 0:(415.5544,1794.0)

:Sending Touch (ACTION_DOWN): 0:(919.0,1302.0)

:Sending Touch (ACTION_UP): 0:(914.72327,1302.23)

:Sending Trackball (ACTION_MOVE): 0:(-2.0,-2.0)

    //[calendar_time:2021-03-10 12:24:58.782  system_uptime:110381899]

    // Sending event #100

    //[calendar_time:2021-03-10 12:24:58.792  system_uptime:110381899]

    // Sending event #100

:Sending Trackball (ACTION_MOVE): 0:(-5.0,3.0)

:Sending Trackball (ACTION_MOVE): 0:(4.0,0.0)

// CRASH: io.realm.example.kmmsample.androidApp (pid 18680)

// Short Msg: Native crash

// Long Msg: Native crash: Segmentation fault

// Build Label: google/sdk_gphone_x86_64/generic_x86_64_arm64:11/RSR1.201013.001/6903271:user/release-keys

// Build Changelist: 6903271

// Build Time: 1602627948000

// *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***

// Build fingerprint: 'google/sdk_gphone_x86_64/generic_x86_64_arm64:11/RSR1.201013.001/6903271:user/release-keys'

// Revision: '0'

// ABI: 'x86_64'

// Timestamp: 2021-03-10 12:24:58-0500

// pid: 18680, tid: 18734, name: RealmFinalizing  >>> io.realm.example.kmmsample.androidApp <<<

// uid: 10162

// signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x8

// Cause: null pointer dereference

//     rax 00007ffd115157d0  rbx 000075b414c35b90  rcx 0000000000000000  rdx f81705ece73d42f5

//     r8  0000000000000000  r9  0000000000000000  r10 000075b29c809c65  r11 00000000ebad6a89

//     r12 000075b414c35c48  r13 0000000000000000  r14 000075b24c22d020  r15 000075b2903f25f0

//     rdi 00007ffd115157d0  rsi 000075b24c22ca04

//     rbp 000075b24c22c9e0  rsp 000075b24c22c9a0  rip 000075b24b722dbe

// 

// backtrace:

//       #00 pc 00000000003d9dbe  /data/app/~~65U5v64KrU8kwC_IYWDreg==/io.realm.example.kmmsample.androidApp-FhHtrK0-zwDPwx_vJpMEtw==/lib/x86_64/librealmc.so (realm_release+62) (BuildId: ff3f80622fe094fe9adb50c99392972e639a0ab3)

//       #01 pc 0000000000377dec  /data/app/~~65U5v64KrU8kwC_IYWDreg==/io.realm.example.kmmsample.androidApp-FhHtrK0-zwDPwx_vJpMEtw==/lib/x86_64/librealmc.so (Java_io_realm_interop_realmcJNI_realm_1release+44) (BuildId: ff3f80622fe094fe9adb50c99392972e639a0ab3)

//       #02 pc 0000000000183ec7  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+215) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #03 pc 0000000000178e16  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+806) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #04 pc 000000000020b8a1  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+257) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #05 pc 00000000003a78d5  /apex/com.android.art/lib64/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+357) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #06 pc 000000000039c214  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+1252) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #07 pc 000000000078c6c2  /apex/com.android.art/lib64/libart.so (MterpInvokeStatic+674) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #08 pc 0000000000162f19  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_static+25) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #09 pc 00000000000072d0  [anon:dalvik-classes6.dex extracted in memory from /data/app/~~65U5v64KrU8kwC_IYWDreg==/io.realm.example.kmmsample.androidApp-FhHtrK0-zwDPwx_vJpMEtw==/base.apk!classes6.dex] (io.realm.interop.realmc.realm_release)

//       #10 pc 000000000078caa4  /apex/com.android.art/lib64/libart.so (MterpInvokeStatic+1668) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #11 pc 0000000000162f19  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_static+25) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #12 pc 0000000000005334  [anon:dalvik-classes5.dex extracted in memory from /data/app/~~65U5v64KrU8kwC_IYWDreg==/io.realm.example.kmmsample.androidApp-FhHtrK0-zwDPwx_vJpMEtw==/base.apk!classes5.dex] (io.realm.interop.gc.NativeObjectReference.cleanup+12)

//       #13 pc 000000000039297f  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.llvm.7156190274679362403)+335) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #14 pc 000000000039b6c8  /apex/com.android.art/lib64/libart.so (art::interpreter::ArtInterpreterToInterpreterBridge(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*, art::JValue*)+200) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #15 pc 000000000039c1f9  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+1225) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #16 pc 0000000000788e62  /apex/com.android.art/lib64/libart.so (MterpInvokeVirtual+1026) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #17 pc 0000000000162d99  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_virtual+25) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #18 pc 0000000000004ff4  [anon:dalvik-classes5.dex extracted in memory from /data/app/~~65U5v64KrU8kwC_IYWDreg==/io.realm.example.kmmsample.androidApp-FhHtrK0-zwDPwx_vJpMEtw==/base.apk!classes5.dex] (io.realm.interop.gc.FinalizerRunnable.run+28)

//       #19 pc 000000000039297f  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.llvm.7156190274679362403)+335) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #20 pc 000000000039b6c8  /apex/com.android.art/lib64/libart.so (art::interpreter::ArtInterpreterToInterpreterBridge(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*, art::JValue*)+200) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #21 pc 000000000039c1f9  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+1225) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #22 pc 000000000078acb3  /apex/com.android.art/lib64/libart.so (MterpInvokeInterface+1251) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #23 pc 0000000000162f99  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_interface+25) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #24 pc 00000000000eb7d0  /apex/com.android.art/javalib/core-oj.jar (java.lang.Thread.run+8)

//       #25 pc 000000000039297f  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.llvm.7156190274679362403)+335) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #26 pc 0000000000774b8f  /apex/com.android.art/lib64/libart.so (artQuickToInterpreterBridge+1103) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #27 pc 000000000018404c  /apex/com.android.art/lib64/libart.so (art_quick_to_interpreter_bridge+140) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #28 pc 0000000000178ab4  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+756) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #29 pc 000000000020b892  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+242) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #30 pc 000000000062879e  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithJValues<art::ArtMethod*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, art::ArtMethod*, jvalue const*)+478) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #31 pc 000000000068be23  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallback(void*)+1411) (BuildId: 9d8a2c952a23b0c0ac813df0bda9bbf9)

//       #32 pc 00000000000c7d2a  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+58) (BuildId: 3707c39fc397eeaa328142d90b50a973)

//       #33 pc 000000000005f0c7  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+55) (BuildId: 3707c39fc397eeaa328142d90b50a973)

// 

** Monkey aborted due to error.

Events injected: 137
```