### PR TITLE
Update "How to build" instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You can also run tests from the commandline:
 
 ```
 cd test
+./gradlew connectedAndroidTest
 ./gradlew macosTest
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,17 @@ The public API of the SDK has not been finalized. Design discussions will happen
 
 ```
 git submodule update --init --recursive
-cd test
+cd packages
 ./gradlew assemble
 ```
 In Android Studio open the `test` project, which will open also the `realm-library` and the compiler projects
 
+You can also run tests from the commandline:
+
+```
+cd test
+./gradlew macosTest
+```
 
 # Using Snapshots
 


### PR DESCRIPTION
Calling `./gradlew assemble` from test results in 

```
> Task :compileKotlinJvm FAILED
e: java.lang.IllegalStateException: Cannot find io.realm.interop.RealmModelInternal on platform JVM (JVM_1_8).
```

Compiling `packages` and running the test targets like CI does works fine