### PR TITLE
Move external sources to packages folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external/core"]
-	path = external/core
+	path = packages/external/core
 	url = https://github.com/realm/realm-core.git
 	branch = su/c-api

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -38,7 +38,9 @@ repositories {
 //  Currently just adding the common darwin parts to macos-target.
 val idea = System.getProperty("idea.active") == "true"
 
-val corePath = "../external/core"
+val corePath = "external/core"
+val relativeCorePath = "../$corePath"
+val cinteropCorePath = "$rootDir/$corePath"
 
 android {
     compileSdkVersion(Versions.Android.compileSdkVersion)
@@ -87,23 +89,23 @@ android {
 }
 
 val nativeLibraryIncludesMacosUniversal = listOf(
-    "-include-binary", "$rootDir/external/core/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static-dbg.a",
-    "-include-binary", "$rootDir/external/core/capi_macos_universal/src/realm/librealm-dbg.a",
-    "-include-binary", "$rootDir/external/core/capi_macos_universal/src/realm/parser/librealm-parser-dbg.a",
-    "-include-binary", "$rootDir/external/core/capi_macos_universal/src/realm/object-store/librealm-object-store-dbg.a"
+    "-include-binary", "$cinteropCorePath/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static-dbg.a",
+    "-include-binary", "$cinteropCorePath/capi_macos_universal/src/realm/librealm-dbg.a",
+    "-include-binary", "$cinteropCorePath/capi_macos_universal/src/realm/parser/librealm-parser-dbg.a",
+    "-include-binary", "$cinteropCorePath/capi_macos_universal/src/realm/object-store/librealm-object-store-dbg.a"
 )
 // TODO remove the debug suffix (-dbg) when switching to use release
 val nativeLibraryIncludesIosArm64 = listOf(
-    "-include-binary", "$rootDir/external/core/build-capi_ios_Arm64/lib/librealm-ffi-static-dbg.a",
-    "-include-binary", "$rootDir/external/core/build-capi_ios_Arm64/lib/librealm-dbg.a",
-    "-include-binary", "$rootDir/external/core/build-capi_ios_Arm64/lib/librealm-parser-dbg.a",
-    "-include-binary", "$rootDir/external/core/build-capi_ios_Arm64/lib/librealm-object-store-dbg.a"
+    "-include-binary", "$cinteropCorePath/build-capi_ios_Arm64/lib/librealm-ffi-static-dbg.a",
+    "-include-binary", "$cinteropCorePath/build-capi_ios_Arm64/lib/librealm-dbg.a",
+    "-include-binary", "$cinteropCorePath/build-capi_ios_Arm64/lib/librealm-parser-dbg.a",
+    "-include-binary", "$cinteropCorePath/build-capi_ios_Arm64/lib/librealm-object-store-dbg.a"
 )
 val nativeLibraryIncludesIosSimulatorUniversal = listOf(
-    "-include-binary", "$rootDir/external/core/build-simulator_universal/lib/librealm-ffi-static-dbg.a",
-    "-include-binary", "$rootDir/external/core/build-simulator_universal/lib/librealm-dbg.a",
-    "-include-binary", "$rootDir/external/core/build-simulator_universal/lib/librealm-parser-dbg.a",
-    "-include-binary", "$rootDir/external/core/build-simulator_universal/lib/librealm-object-store-dbg.a"
+    "-include-binary", "$cinteropCorePath/build-simulator_universal/lib/librealm-ffi-static-dbg.a",
+    "-include-binary", "$cinteropCorePath/build-simulator_universal/lib/librealm-dbg.a",
+    "-include-binary", "$cinteropCorePath/build-simulator_universal/lib/librealm-parser-dbg.a",
+    "-include-binary", "$cinteropCorePath/build-simulator_universal/lib/librealm-object-store-dbg.a"
 )
 
 kotlin {
@@ -129,7 +131,7 @@ kotlin {
             cinterops.create("realm_wrapper") {
                 defFile = project.file("src/nativeCommon/realm.def")
                 packageName = "realm_wrapper"
-                includeDirs(project.file("$corePath/src/"))
+                includeDirs(project.file("$relativeCorePath/src/"))
             }
             // Relative paths in def file depends are resolved differently dependent on execution
             // location
@@ -147,7 +149,7 @@ kotlin {
             cinterops.create("realm_wrapper") {
                 defFile = project.file("src/nativeCommon/realm.def")
                 packageName = "realm_wrapper"
-                includeDirs(project.file("$corePath/src/"))
+                includeDirs(project.file("$relativeCorePath/src/"))
             }
             // Relative paths in def file depends are resolved differently dependent on execution
             // location
@@ -294,14 +296,14 @@ fun Task.build_C_API_Android(releaseBuild: Boolean = false) {
     doLast {
         // x86_64
         exec {
-            workingDir(project.file("$corePath"))
+            workingDir(project.file("$relativeCorePath"))
             commandLine("tools/cross_compile.sh", "-t", buildType, "-a", "x86_64", "-o", "android", "-f", "-DREALM_ENABLE_SYNC=0 -DREALM_NO_TESTS=ON")
             environment(mapOf("ANDROID_NDK" to android.ndkDirectory))
         }
 
         // arm64-v8a
         exec {
-            workingDir(project.file("$corePath"))
+            workingDir(project.file("$relativeCorePath"))
             commandLine("tools/cross_compile.sh", "-t", buildType, "-a", "arm64-v8a", "-o", "android", "-f", "-DREALM_ENABLE_SYNC=0 -DREALM_NO_TESTS=ON")
             environment(mapOf("ANDROID_NDK" to android.ndkDirectory))
         }
@@ -315,22 +317,22 @@ fun Task.build_C_API_Macos_Universal(releaseBuild: Boolean = false) {
 
     doLast {
         exec {
-            workingDir(project.file("$corePath"))
+            workingDir(project.file("$relativeCorePath"))
             commandLine("mkdir", "-p", "capi_macos_universal")
         }
         exec {
             commandLine("cmake", "-DCMAKE_TOOLCHAIN_FILE=../tools/cmake/macosx.toolchain.cmake", "-DCMAKE_BUILD_TYPE=$buildType", "-DREALM_ENABLE_SYNC=0", "-DREALM_NO_TESTS=1", "-DOSX_ARM64=1", "..")
-            workingDir(project.file("$corePath/capi_macos_universal"))
+            workingDir(project.file("$relativeCorePath/capi_macos_universal"))
         }
         exec {
-            workingDir(project.file("$corePath/capi_macos_universal"))
+            workingDir(project.file("$relativeCorePath/capi_macos_universal"))
             commandLine("cmake", "--build", ".", "-j8")
         }
     }
-    outputs.file(project.file("$corePath/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/capi_macos_universal/src/realm/librealm$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/capi_macos_universal/src/realm/object-store/librealm-object-store$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/capi_macos_universal/src/realm/librealm$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/capi_macos_universal/src/realm/object-store/librealm-object-store$buildTypeSuffix.a"))
 }
 
 fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
@@ -339,11 +341,11 @@ fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
 
     doLast {
         exec {
-            workingDir(project.file("$corePath"))
+            workingDir(project.file("$relativeCorePath"))
             commandLine("mkdir", "-p", "build-simulator_universal")
         }
         exec {
-            workingDir(project.file("$corePath/build-simulator_universal"))
+            workingDir(project.file("$relativeCorePath/build-simulator_universal"))
             commandLine(
                 "cmake", "-DCMAKE_TOOLCHAIN_FILE=../tools/cmake/ios.toolchain.cmake",
                 "-DCMAKE_INSTALL_PREFIX=.",
@@ -357,7 +359,7 @@ fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
             )
         }
         exec {
-            workingDir(project.file("$corePath/build-simulator_universal"))
+            workingDir(project.file("$relativeCorePath/build-simulator_universal"))
             commandLine(
                 "xcodebuild",
                 "-sdk",
@@ -370,10 +372,10 @@ fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
             )
         }
     }
-    outputs.file(project.file("$corePath/build-simulator_universal/lib/librealm-ffi-static$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/build-simulator_universal/lib/librealm$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/build-simulator_universal/lib/librealm-parser$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/build-simulator_universal/lib/librealm-object-store$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/build-simulator_universal/lib/librealm-ffi-static$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/build-simulator_universal/lib/librealm$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/build-simulator_universal/lib/librealm-parser$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/build-simulator_universal/lib/librealm-object-store$buildTypeSuffix.a"))
 }
 
 fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
@@ -382,11 +384,11 @@ fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
 
     doLast {
         exec {
-            workingDir(project.file("$corePath"))
+            workingDir(project.file("$relativeCorePath"))
             commandLine("mkdir", "-p", "build-capi_ios_Arm64")
         }
         exec {
-            workingDir(project.file("$corePath/build-capi_ios_Arm64"))
+            workingDir(project.file("$relativeCorePath/build-capi_ios_Arm64"))
             commandLine(
                 "cmake", "-DCMAKE_TOOLCHAIN_FILE=../tools/cmake/ios.toolchain.cmake",
                 "-DCMAKE_INSTALL_PREFIX=.",
@@ -400,7 +402,7 @@ fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
             )
         }
         exec {
-            workingDir(project.file("$corePath/build-capi_ios_Arm64"))
+            workingDir(project.file("$relativeCorePath/build-capi_ios_Arm64"))
             commandLine(
                 "xcodebuild",
                 "-sdk",
@@ -416,10 +418,10 @@ fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
             )
         }
     }
-    outputs.file(project.file("$corePath/build-capi_ios_Arm64/lib/librealm-ffi-static$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/build-capi_ios_Arm64/lib/librealm$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/build-capi_ios_Arm64/lib/librealm-parser$buildTypeSuffix.a"))
-    outputs.file(project.file("$corePath/build-capi_ios_Arm64/lib/librealm-object-store$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/build-capi_ios_Arm64/lib/librealm-ffi-static$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/build-capi_ios_Arm64/lib/librealm$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/build-capi_ios_Arm64/lib/librealm-parser$buildTypeSuffix.a"))
+    outputs.file(project.file("$relativeCorePath/build-capi_ios_Arm64/lib/librealm-object-store$buildTypeSuffix.a"))
 }
 
 afterEvaluate {

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -38,6 +38,8 @@ repositories {
 //  Currently just adding the common darwin parts to macos-target.
 val idea = System.getProperty("idea.active") == "true"
 
+val corePath = "../external/core"
+
 android {
     compileSdkVersion(Versions.Android.compileSdkVersion)
     buildToolsVersion = Versions.Android.buildToolsVersion
@@ -85,23 +87,23 @@ android {
 }
 
 val nativeLibraryIncludesMacosUniversal = listOf(
-    "-include-binary", "$rootDir/../external/core/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static-dbg.a",
-    "-include-binary", "$rootDir/../external/core/capi_macos_universal/src/realm/librealm-dbg.a",
-    "-include-binary", "$rootDir/../external/core/capi_macos_universal/src/realm/parser/librealm-parser-dbg.a",
-    "-include-binary", "$rootDir/../external/core/capi_macos_universal/src/realm/object-store/librealm-object-store-dbg.a"
+    "-include-binary", "$rootDir/external/core/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static-dbg.a",
+    "-include-binary", "$rootDir/external/core/capi_macos_universal/src/realm/librealm-dbg.a",
+    "-include-binary", "$rootDir/external/core/capi_macos_universal/src/realm/parser/librealm-parser-dbg.a",
+    "-include-binary", "$rootDir/external/core/capi_macos_universal/src/realm/object-store/librealm-object-store-dbg.a"
 )
 // TODO remove the debug suffix (-dbg) when switching to use release
 val nativeLibraryIncludesIosArm64 = listOf(
-    "-include-binary", "$rootDir/../external/core/build-capi_ios_Arm64/lib/librealm-ffi-static-dbg.a",
-    "-include-binary", "$rootDir/../external/core/build-capi_ios_Arm64/lib/librealm-dbg.a",
-    "-include-binary", "$rootDir/../external/core/build-capi_ios_Arm64/lib/librealm-parser-dbg.a",
-    "-include-binary", "$rootDir/../external/core/build-capi_ios_Arm64/lib/librealm-object-store-dbg.a"
+    "-include-binary", "$rootDir/external/core/build-capi_ios_Arm64/lib/librealm-ffi-static-dbg.a",
+    "-include-binary", "$rootDir/external/core/build-capi_ios_Arm64/lib/librealm-dbg.a",
+    "-include-binary", "$rootDir/external/core/build-capi_ios_Arm64/lib/librealm-parser-dbg.a",
+    "-include-binary", "$rootDir/external/core/build-capi_ios_Arm64/lib/librealm-object-store-dbg.a"
 )
 val nativeLibraryIncludesIosSimulatorUniversal = listOf(
-    "-include-binary", "$rootDir/../external/core/build-simulator_universal/lib/librealm-ffi-static-dbg.a",
-    "-include-binary", "$rootDir/../external/core/build-simulator_universal/lib/librealm-dbg.a",
-    "-include-binary", "$rootDir/../external/core/build-simulator_universal/lib/librealm-parser-dbg.a",
-    "-include-binary", "$rootDir/../external/core/build-simulator_universal/lib/librealm-object-store-dbg.a"
+    "-include-binary", "$rootDir/external/core/build-simulator_universal/lib/librealm-ffi-static-dbg.a",
+    "-include-binary", "$rootDir/external/core/build-simulator_universal/lib/librealm-dbg.a",
+    "-include-binary", "$rootDir/external/core/build-simulator_universal/lib/librealm-parser-dbg.a",
+    "-include-binary", "$rootDir/external/core/build-simulator_universal/lib/librealm-object-store-dbg.a"
 )
 
 kotlin {
@@ -127,7 +129,7 @@ kotlin {
             cinterops.create("realm_wrapper") {
                 defFile = project.file("src/nativeCommon/realm.def")
                 packageName = "realm_wrapper"
-                includeDirs(project.file("../../external/core/src/"))
+                includeDirs(project.file("$corePath/src/"))
             }
             // Relative paths in def file depends are resolved differently dependent on execution
             // location
@@ -145,7 +147,7 @@ kotlin {
             cinterops.create("realm_wrapper") {
                 defFile = project.file("src/nativeCommon/realm.def")
                 packageName = "realm_wrapper"
-                includeDirs(project.file("../../external/core/src/"))
+                includeDirs(project.file("$corePath/src/"))
             }
             // Relative paths in def file depends are resolved differently dependent on execution
             // location
@@ -292,14 +294,14 @@ fun Task.build_C_API_Android(releaseBuild: Boolean = false) {
     doLast {
         // x86_64
         exec {
-            workingDir(project.file("../../external/core"))
+            workingDir(project.file("$corePath"))
             commandLine("tools/cross_compile.sh", "-t", buildType, "-a", "x86_64", "-o", "android", "-f", "-DREALM_ENABLE_SYNC=0 -DREALM_NO_TESTS=ON")
             environment(mapOf("ANDROID_NDK" to android.ndkDirectory))
         }
 
         // arm64-v8a
         exec {
-            workingDir(project.file("../../external/core"))
+            workingDir(project.file("$corePath"))
             commandLine("tools/cross_compile.sh", "-t", buildType, "-a", "arm64-v8a", "-o", "android", "-f", "-DREALM_ENABLE_SYNC=0 -DREALM_NO_TESTS=ON")
             environment(mapOf("ANDROID_NDK" to android.ndkDirectory))
         }
@@ -313,22 +315,22 @@ fun Task.build_C_API_Macos_Universal(releaseBuild: Boolean = false) {
 
     doLast {
         exec {
-            workingDir(project.file("../../external/core"))
+            workingDir(project.file("$corePath"))
             commandLine("mkdir", "-p", "capi_macos_universal")
         }
         exec {
-            workingDir(project.file("../../external/core/capi_macos_universal"))
             commandLine("cmake", "-DCMAKE_TOOLCHAIN_FILE=../tools/cmake/macosx.toolchain.cmake", "-DCMAKE_BUILD_TYPE=$buildType", "-DREALM_ENABLE_SYNC=0", "-DREALM_NO_TESTS=1", "-DOSX_ARM64=1", "..")
+            workingDir(project.file("$corePath/capi_macos_universal"))
         }
         exec {
-            workingDir(project.file("../../external/core/capi_macos_universal"))
+            workingDir(project.file("$corePath/capi_macos_universal"))
             commandLine("cmake", "--build", ".", "-j8")
         }
     }
-    outputs.file(project.file("../../external/core/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/capi_macos_universal/src/realm/librealm$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/capi_macos_universal/src/realm/object-store/librealm-object-store$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/capi_macos_universal/src/realm/librealm$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/capi_macos_universal/src/realm/object-store/c_api/librealm-ffi-static$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/capi_macos_universal/src/realm/object-store/librealm-object-store$buildTypeSuffix.a"))
 }
 
 fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
@@ -337,11 +339,11 @@ fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
 
     doLast {
         exec {
-            workingDir(project.file("../../external/core"))
+            workingDir(project.file("$corePath"))
             commandLine("mkdir", "-p", "build-simulator_universal")
         }
         exec {
-            workingDir(project.file("../../external/core/build-simulator_universal"))
+            workingDir(project.file("$corePath/build-simulator_universal"))
             commandLine(
                 "cmake", "-DCMAKE_TOOLCHAIN_FILE=../tools/cmake/ios.toolchain.cmake",
                 "-DCMAKE_INSTALL_PREFIX=.",
@@ -355,7 +357,7 @@ fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
             )
         }
         exec {
-            workingDir(project.file("../../external/core/build-simulator_universal"))
+            workingDir(project.file("$corePath/build-simulator_universal"))
             commandLine(
                 "xcodebuild",
                 "-sdk",
@@ -368,10 +370,10 @@ fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
             )
         }
     }
-    outputs.file(project.file("../../external/core/build-simulator_universal/lib/librealm-ffi-static$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/build-simulator_universal/lib/librealm$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/build-simulator_universal/lib/librealm-parser$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/build-simulator_universal/lib/librealm-object-store$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/build-simulator_universal/lib/librealm-ffi-static$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/build-simulator_universal/lib/librealm$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/build-simulator_universal/lib/librealm-parser$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/build-simulator_universal/lib/librealm-object-store$buildTypeSuffix.a"))
 }
 
 fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
@@ -380,11 +382,11 @@ fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
 
     doLast {
         exec {
-            workingDir(project.file("../../external/core"))
+            workingDir(project.file("$corePath"))
             commandLine("mkdir", "-p", "build-capi_ios_Arm64")
         }
         exec {
-            workingDir(project.file("../../external/core/build-capi_ios_Arm64"))
+            workingDir(project.file("$corePath/build-capi_ios_Arm64"))
             commandLine(
                 "cmake", "-DCMAKE_TOOLCHAIN_FILE=../tools/cmake/ios.toolchain.cmake",
                 "-DCMAKE_INSTALL_PREFIX=.",
@@ -398,7 +400,7 @@ fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
             )
         }
         exec {
-            workingDir(project.file("../../external/core/build-capi_ios_Arm64"))
+            workingDir(project.file("$corePath/build-capi_ios_Arm64"))
             commandLine(
                 "xcodebuild",
                 "-sdk",
@@ -414,10 +416,10 @@ fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
             )
         }
     }
-    outputs.file(project.file("../../external/core/build-capi_ios_Arm64/lib/librealm-ffi-static$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/build-capi_ios_Arm64/lib/librealm$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/build-capi_ios_Arm64/lib/librealm-parser$buildTypeSuffix.a"))
-    outputs.file(project.file("../../external/core/build-capi_ios_Arm64/lib/librealm-object-store$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/build-capi_ios_Arm64/lib/librealm-ffi-static$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/build-capi_ios_Arm64/lib/librealm$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/build-capi_ios_Arm64/lib/librealm-parser$buildTypeSuffix.a"))
+    outputs.file(project.file("$corePath/build-capi_ios_Arm64/lib/librealm-object-store$buildTypeSuffix.a"))
 }
 
 afterEvaluate {

--- a/packages/cinterop/src/jvmCommon/CMakeLists.txt
+++ b/packages/cinterop/src/jvmCommon/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
-set(CAPI "${CMAKE_SOURCE_DIR}/../../../../external/core/")
+set(CAPI "${CMAKE_SOURCE_DIR}/../../../external/core/")
 set(CAPI_BUILD "${CAPI}/build-android-${ANDROID_ABI}-${CMAKE_BUILD_TYPE}")
 set(SWIG_JNI "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 

--- a/packages/jni-swig-stub/build.gradle.kts
+++ b/packages/jni-swig-stub/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.create("realmWrapperJvm") {
     doLast {
         exec {
             workingDir(".")
-            commandLine("swig", "-java", "-c++", "-package", "io.realm.interop", "-I$projectDir/../../external/core/src", "-o", "$projectDir/src/main/jni/realmc.cpp", "-outdir", "$projectDir/src/main/java/io/realm/interop", "realm.i")
+            commandLine("swig", "-java", "-c++", "-package", "io.realm.interop", "-I$projectDir/../external/core/src", "-o", "$projectDir/src/main/jni/realmc.cpp", "-outdir", "$projectDir/src/main/java/io/realm/interop", "realm.i")
         }
     }
     inputs.file("realm.i")


### PR DESCRIPTION
This moves the `external` folder to `packages` as it is really annoying to navigate to the sources outside of the actual project