### PR TITLE
Add timeout to CI jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,7 @@ pipeline {
     // build.
     options {
         lock resource: 'kotlin_build_lock'
+        timeout(time: 2, activity: true, unit: 'HOURS') 
     }
     environment {
           ANDROID_SDK_ROOT='/Users/realm/Library/Android/sdk/'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
     // build.
     options {
         lock resource: 'kotlin_build_lock'
-        timeout(time: 2, activity: true, unit: 'HOURS') 
+        timeout(time: 15, activity: true, unit: 'MINUTES') 
     }
     environment {
           ANDROID_SDK_ROOT='/Users/realm/Library/Android/sdk/'


### PR DESCRIPTION
This adds a 2-hour timeout to CI jobs. The activity flags mean the timeout is counted from the last activity in the logs instead of total duration. This seems to be match closer what we are after and we don't have any tests or otherwise that risk going into a loop and logging things at the same time.