### PR TITLE
Fix kmm-sample to use version 0.1.0

### DIFF
--- a/examples/kmm-sample/androidApp/build.gradle.kts
+++ b/examples/kmm-sample/androidApp/build.gradle.kts
@@ -22,13 +22,13 @@ plugins {
     id("kotlin-android-extensions")
     // Apply Realm Kotlin plugin even though we technically do not need it, to ensure that we have
     // the right kotlinOptions
-    id("io.realm.kotlin") version Realm.version
+    id("io.realm.kotlin") version "0.1.0"
     // Apply Realm specific linting plugin to get common Realm linting tasks
     id("realm-lint")
 }
 
 group = "io.realm.example"
-version = Realm.version
+version = "0.1.0"
 
 dependencies {
     implementation(project(":shared"))
@@ -36,7 +36,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")
     // TODO AUTO-SETUP
-    compileOnly("io.realm.kotlin:library:${Realm.version}")
+    compileOnly("io.realm.kotlin:library:${version}")
 }
 
 android {
@@ -47,7 +47,7 @@ android {
         minSdkVersion(21)
         targetSdkVersion(Versions.Android.targetSdk)
         versionCode = 1
-        versionName = Realm.version
+        versionName = "$version"
     }
     buildTypes {
         getByName("release") {

--- a/examples/kmm-sample/build.gradle.kts
+++ b/examples/kmm-sample/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     }
 }
 group = "io.realm.example"
-version = Realm.version
+version = "0.1.0"
 
 allprojects {
     repositories {

--- a/examples/kmm-sample/shared/build.gradle.kts
+++ b/examples/kmm-sample/shared/build.gradle.kts
@@ -23,13 +23,13 @@ plugins {
     id("com.android.library")
     id("kotlin-android-extensions")
     // Apply Realm Kotlin plugin
-    id("io.realm.kotlin") version Realm.version
+    id("io.realm.kotlin") version "0.1.0"
     // Apply Realm specific linting plugin to get common Realm linting tasks
     id("realm-lint")
 }
 
 group = "io.realm.example"
-version = Realm.version
+version = "0.1.0"
 
 kotlin {
     android()
@@ -46,7 +46,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 // TODO AUTO-SETUP
-                implementation("io.realm.kotlin:library:${Realm.version}")
+                implementation("io.realm.kotlin:library:${version}")
             }
         }
         val commonTest by getting {
@@ -77,7 +77,7 @@ android {
         minSdkVersion(Versions.Android.minSdk)
         targetSdkVersion(Versions.Android.targetSdk)
         versionCode = 1
-        versionName = Realm.version
+        versionName = "$version"
     }
     buildTypes {
         getByName("release") {


### PR DESCRIPTION
The sample project cannot even initialize in the IDE when trying to resolve the snapshot version defined in `Config.kt`. Hardcode the sample to use the latest released version until settling on the correct setup. 