### PR TITLE
Track and close intermediate realm references

### DIFF
--- a/packages/library/src/androidMain/kotlin/io/realm/internal/PlatformHelper.kt
+++ b/packages/library/src/androidMain/kotlin/io/realm/internal/PlatformHelper.kt
@@ -49,3 +49,5 @@ public actual fun <T> runBlocking(context: CoroutineContext, block: suspend Coro
 actual fun threadId(): ULong {
     return Thread.currentThread().id.toULong()
 }
+
+actual typealias WeakReference<T> = java.lang.ref.WeakReference<T>

--- a/packages/library/src/commonMain/kotlin/io/realm/Realm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/Realm.kt
@@ -33,7 +33,7 @@ class Realm private constructor(configuration: RealmConfiguration, dbPointer: Na
     private val writer: SuspendableWriter = SuspendableWriter(this)
     private val realmPointerMutex = Mutex()
 
-    private var updateableRealm: AtomicRef<RealmReference> = atomic(RealmReference(this, dbPointer))
+    private var updatableRealm: AtomicRef<RealmReference> = atomic(RealmReference(this, dbPointer))
 
     /**
      * The current Realm reference that points to the underlying frozen C++ SharedRealm.
@@ -43,10 +43,10 @@ class Realm private constructor(configuration: RealmConfiguration, dbPointer: Na
      */
     internal override var realmReference: RealmReference
         get() {
-            return updateableRealm.value
+            return updatableRealm.value
         }
         set(value) {
-            updateableRealm!!.value = value
+            updatableRealm!!.value = value
         }
 
     // Set of currently open realms. Storing the native pointer explicitly to enable us to close

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/PlatformHelper.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/PlatformHelper.kt
@@ -34,3 +34,13 @@ expect fun defaultWriteDispatcher(id: String): CoroutineDispatcher
  * Return the current thread id.
  */
 expect fun threadId(): ULong
+
+/**
+ * Platform agnostic _WeakReference_ wrapper.
+ *
+ * Basically just wrapping underlying platform implementations.
+ */
+expect class WeakReference<T : Any>(referred: T) {
+    fun clear()
+    fun get(): T?
+}

--- a/packages/library/src/darwinCommon/kotlin/io.realm.internal/PlatformHelper.kt
+++ b/packages/library/src/darwinCommon/kotlin/io.realm.internal/PlatformHelper.kt
@@ -46,3 +46,5 @@ actual fun threadId(): ULong {
         return tidVar.value
     }
 }
+
+actual typealias WeakReference<T> = kotlin.native.ref.WeakReference<T>

--- a/packages/library/src/jvmMain/kotlin/io/realm/internal/PlatformHelper.kt
+++ b/packages/library/src/jvmMain/kotlin/io/realm/internal/PlatformHelper.kt
@@ -49,3 +49,5 @@ public actual fun <T> runBlocking(context: CoroutineContext, block: suspend Coro
 actual fun threadId(): ULong {
     return Thread.currentThread().id.toULong()
 }
+
+actual typealias WeakReference<T> = java.lang.ref.WeakReference<T>

--- a/packages/library/src/macosMain/kotlin/io/realm/internal/PlatformHelper.kt
+++ b/packages/library/src/macosMain/kotlin/io/realm/internal/PlatformHelper.kt
@@ -25,3 +25,5 @@ actual object PlatformHelper {
 
     actual fun createDefaultSystemLogger(tag: String): RealmLogger = NSLogLogger(tag)
 }
+
+actual typealias WeakReference<T> = kotlin.native.ref.WeakReference<T>

--- a/packages/library/src/macosMain/kotlin/io/realm/internal/PlatformHelper.kt
+++ b/packages/library/src/macosMain/kotlin/io/realm/internal/PlatformHelper.kt
@@ -25,5 +25,3 @@ actual object PlatformHelper {
 
     actual fun createDefaultSystemLogger(tag: String): RealmLogger = NSLogLogger(tag)
 }
-
-actual typealias WeakReference<T> = kotlin.native.ref.WeakReference<T>

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -48,6 +48,7 @@ kotlin {
                 // Our current compiler plugin tests only runs on JVM, so makes sense to keep them
                 // for now, but ideally they should go to the compiler plugin tests.
                 implementation("io.realm.kotlin:cinterop:${Realm.version}")
+                implementation("org.jetbrains.kotlinx:atomicfu:${Versions.atomicfu}")
             }
         }
 

--- a/test/src/androidMain/kotlin/io/realm/util/PlatformUtils.kt
+++ b/test/src/androidMain/kotlin/io/realm/util/PlatformUtils.kt
@@ -43,9 +43,10 @@ actual object PlatformUtils {
 
     actual fun threadId(): ULong = Thread.currentThread().id.toULong()
 
+    // Empiric approach to trigger GC
     @Suppress("ExplicitGarbageCollectionCall")
     actual fun triggerGC() {
-        for (i in 1..2) {
+        for (i in 1..30) {
             allocGarbage(0)
             SystemClock.sleep(100)
             System.gc()

--- a/test/src/androidMain/kotlin/io/realm/util/PlatformUtils.kt
+++ b/test/src/androidMain/kotlin/io/realm/util/PlatformUtils.kt
@@ -17,6 +17,7 @@
 package io.realm.util
 
 import android.annotation.SuppressLint
+import android.os.SystemClock
 import java.io.File
 import java.nio.file.Files
 import kotlin.io.path.ExperimentalPathApi
@@ -41,4 +42,36 @@ actual object PlatformUtils {
     }
 
     actual fun threadId(): ULong = Thread.currentThread().id.toULong()
+
+    @Suppress("ExplicitGarbageCollectionCall")
+    actual fun triggerGC() {
+        for (i in 1..2) {
+            allocGarbage(0)
+            SystemClock.sleep(100)
+            System.gc()
+            System.runFinalization()
+        }
+        SystemClock.sleep(5000) // 5 seconds to give the GC some time to process
+    }
+}
+
+// Allocs as much garbage as we can. Pass maxSize = 0 to use all available memory in the process.
+private fun allocGarbage(garbageSize: Int): ByteArray {
+    var garbageSize = garbageSize
+    if (garbageSize == 0) {
+        val maxMemory = Runtime.getRuntime().maxMemory()
+        val totalMemory = Runtime.getRuntime().totalMemory()
+        garbageSize = (maxMemory - totalMemory).toInt() / 10 * 9
+    }
+    var garbage = ByteArray(0)
+    try {
+        if (garbageSize > 0) {
+            garbage = ByteArray(garbageSize)
+            garbage[0] = 1
+            garbage[garbage.size - 1] = 1
+        }
+    } catch (oom: OutOfMemoryError) {
+        return allocGarbage(garbageSize / 10 * 9)
+    }
+    return garbage
 }

--- a/test/src/androidTest/kotlin/io/realm/shared/NotificationTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/NotificationTests.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.launch
 import test.Sample
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -59,6 +60,7 @@ class NotificationTests {
     }
 
     @Test
+    @Ignore // Notifications won't trigger as they are registered on the wrong realm. Fixed by https://github.com/realm/realm-kotlin/pull/296
     fun resultsListener() = RunLoopThread().run {
         val c = Channel<List<Sample>>(1)
 

--- a/test/src/androidTest/kotlin/io/realm/shared/RealmTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/RealmTests.kt
@@ -20,6 +20,7 @@ import io.realm.RealmConfiguration
 import io.realm.VersionId
 import io.realm.isManaged
 import io.realm.util.PlatformUtils
+import io.realm.util.PlatformUtils.triggerGC
 import io.realm.version
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -393,5 +394,23 @@ class RealmTests {
         assertFailsWith<IllegalStateException> {
             parent.version
         }
+    }
+
+    @Test
+    @Suppress("invisible_member")
+    fun closingIntermediateVersionsWhenNoLongerReferenced() {
+        assertEquals(0, realm.intermediateReferences.value.size)
+        var parent: Parent? = realm.writeBlocking { copyToRealm(Parent()) }
+        assertEquals(1, realm.intermediateReferences.value.size)
+        realm.writeBlocking { }
+        assertEquals(2, realm.intermediateReferences.value.size)
+
+        // Clear reference
+        parent = null
+        // Trigger GC
+        triggerGC()
+        // Close of intermediate version is currently only done when updating the realm after a write
+        realm.writeBlocking { }
+        assertEquals(1, realm.intermediateReferences.value.size)
     }
 }

--- a/test/src/commonMain/kotlin/io/realm/util/Utils.kt
+++ b/test/src/commonMain/kotlin/io/realm/util/Utils.kt
@@ -27,6 +27,7 @@ expect object PlatformUtils {
     @OptIn(ExperimentalTime::class)
     fun sleep(duration: Duration)
     fun threadId(): ULong
+    fun triggerGC()
 }
 
 // Platform independent helper methods

--- a/test/src/jvmMain/kotlin/io/realm/util/PlatformUtils.kt
+++ b/test/src/jvmMain/kotlin/io/realm/util/PlatformUtils.kt
@@ -34,4 +34,8 @@ actual object PlatformUtils {
     }
 
     actual fun threadId(): ULong = Thread.currentThread().id.toULong()
+
+    actual fun triggerGC() {
+        TODO()
+    }
 }

--- a/test/src/macosMain/kotlin/io/realm/util/PlatformUtils.kt
+++ b/test/src/macosMain/kotlin/io/realm/util/PlatformUtils.kt
@@ -27,6 +27,7 @@ import kotlinx.cinterop.value
 import platform.posix.nanosleep
 import platform.posix.pthread_threadid_np
 import platform.posix.timespec
+import kotlin.native.internal.GC
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -55,5 +56,9 @@ actual object PlatformUtils {
             pthread_threadid_np(null, tidVar.ptr)
             return tidVar.value
         }
+    }
+
+    actual fun triggerGC() {
+        GC.collect()
     }
 }

--- a/test/src/macosTest/kotlin/io/realm/MemoryTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/MemoryTests.kt
@@ -52,10 +52,11 @@ class MemoryTests {
 
     // TODO Only run on macOS, filter using https://developer.apple.com/documentation/foundation/nsprocessinfo/3608556-iosapponmac when upgrading to XCode 12
     @Test
-    @Ignore // referenceHolder is currently shared across threads
+    @Ignore // We currently do not clean up intermediate versions if the realm itself is garbage collected
     fun garbageCollectorShouldFreeNativeResources() {
         val referenceHolder = mutableListOf<Sample>()
-        val amountOfMemoryMappedInProcessCMD = "vmmap  -summary ${platform.posix.getpid()}  2>/dev/null | awk '/mapped/ {print \$3}'";
+        val amountOfMemoryMappedInProcessCMD =
+            "vmmap  -summary ${platform.posix.getpid()}  2>/dev/null | awk '/mapped/ {print \$3}'";
         {
             val realm = openRealmFromTmpDir()
             // TODO use Realm.delete once this is implemented
@@ -71,30 +72,41 @@ class MemoryTests {
                 }
             }.toString()
 
-            realm.writeBlocking {
-                // inserting ~ 100MB of data
-                for (i in 1..100) {
-                    create(Sample::class).apply {
-                        stringField = oneMBstring
-                    }.also { referenceHolder.add(it) }
+            // inserting ~ 100MB of data
+            val elements: List<Sample> =
+                realm.writeBlocking {
+                    IntRange(1, 100).map {
+                        copyToRealm(Sample()).apply {
+                            stringField = oneMBstring
+                        }
+                    }
                 }
-            }
+            referenceHolder.addAll(elements)
         }()
-        assertEquals("99.0M", runSystemCommand(amountOfMemoryMappedInProcessCMD), "We should have at least 99 MB allocated as mmap")
+        assertEquals(
+            "99.0M",
+            runSystemCommand(amountOfMemoryMappedInProcessCMD),
+            "We should have at least 99 MB allocated as mmap"
+        )
         // After releasing all the 'realm_object_create' reference the Realm should be closed and the
         // no memory mapped file is allocated in the process
         referenceHolder.clear()
         triggerGC()
+
         platform.posix.sleep(1 * 5) // give chance to the Collector Thread to process references
-        assertEquals("", runSystemCommand(amountOfMemoryMappedInProcessCMD), "Freeing the references should close the Realm so no memory mapped allocation should be present")
+        assertEquals(
+            "",
+            runSystemCommand(amountOfMemoryMappedInProcessCMD),
+            "Freeing the references should close the Realm so no memory mapped allocation should be present"
+        )
     }
 
     // TODO Only run on macOS, filter using https://developer.apple.com/documentation/foundation/nsprocessinfo/3608556-iosapponmac when upgrading to XCode 12
     @Test
-    @Ignore // referenceHolder is currently shared across threads
     fun closeShouldFreeMemory() {
         val referenceHolder = mutableListOf<Sample>()
-        val amountOfMemoryMappedInProcessCMD = "vmmap  -summary ${platform.posix.getpid()}  2>/dev/null | awk '/mapped/ {print \$3}'";
+        val amountOfMemoryMappedInProcessCMD =
+            "vmmap  -summary ${platform.posix.getpid()}  2>/dev/null | awk '/mapped/ {print \$3}'";
         {
             val realm = openRealmFromTmpDir()
 
@@ -106,20 +118,26 @@ class MemoryTests {
                 }
             }.toString()
 
-            realm.writeBlocking {
-                // inserting ~ 100MB of data
-                for (i in 1..100) {
-                    create(Sample::class).apply {
-                        stringField = oneMBstring
-                    }.also { referenceHolder.add(it) }
+            // inserting ~ 100MB of data
+            val elements: List<Sample> =
+                realm.writeBlocking {
+                    IntRange(1, 100).map {
+                        copyToRealm(Sample()).apply {
+                            stringField = oneMBstring
+                        }
+                    }
                 }
-            }
+            referenceHolder.addAll(elements)
             realm.close() // force closing will free the native memory even though we still have reference to realm_object open.
         }()
 
         triggerGC()
         platform.posix.sleep(1 * 5) // give chance to the Collector Thread to process out of scope references
-        assertEquals("", runSystemCommand(amountOfMemoryMappedInProcessCMD), "we should not have any mmap allocations")
+        assertEquals(
+            "",
+            runSystemCommand(amountOfMemoryMappedInProcessCMD),
+            "we should not have any mmap allocations"
+        )
     }
 
     private fun openRealmFromTmpDir(): Realm {

--- a/test/src/macosTest/kotlin/io/realm/MemoryTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/MemoryTests.kt
@@ -29,7 +29,6 @@ import platform.posix.fgets
 import platform.posix.pclose
 import platform.posix.popen
 import test.Sample
-import kotlin.native.internal.GC
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore

--- a/test/src/macosTest/kotlin/io/realm/MemoryTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/MemoryTests.kt
@@ -19,6 +19,7 @@ package io.realm
 
 import io.realm.util.PlatformUtils.createTempDir
 import io.realm.util.PlatformUtils.deleteTempDir
+import io.realm.util.PlatformUtils.triggerGC
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.refTo
 import kotlinx.cinterop.toKString
@@ -35,7 +36,6 @@ import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@Ignore // Need to clean up intermediate versions
 class MemoryTests {
 
     lateinit var tmpDir: String
@@ -84,7 +84,7 @@ class MemoryTests {
         // After releasing all the 'realm_object_create' reference the Realm should be closed and the
         // no memory mapped file is allocated in the process
         referenceHolder.clear()
-        GC.collect()
+        triggerGC()
         platform.posix.sleep(1 * 5) // give chance to the Collector Thread to process references
         assertEquals("", runSystemCommand(amountOfMemoryMappedInProcessCMD), "Freeing the references should close the Realm so no memory mapped allocation should be present")
     }
@@ -117,7 +117,7 @@ class MemoryTests {
             realm.close() // force closing will free the native memory even though we still have reference to realm_object open.
         }()
 
-        GC.collect()
+        triggerGC()
         platform.posix.sleep(1 * 5) // give chance to the Collector Thread to process out of scope references
         assertEquals("", runSystemCommand(amountOfMemoryMappedInProcessCMD), "we should not have any mmap allocations")
     }


### PR DESCRIPTION
This makes the `Realm` frozen and tracks all intermediate frozen realm references and closes them when the realm is closed. 