### PR TITLE
Add findLatest to resolve latest version of frozen object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements
 * Add support for suspending writes executed on the Realm Write Dispatcher with `suspend fun <R> write(block: MutableRealm.() -> R): R`
+* Add support for retrieving the latest version of an object inside a write transaction with `<T : RealmObject> MutableRealm.findLatests(obj: T?): T?`
 
 ### Fixed
 * None.

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/interop/RealmInterop.kt
@@ -82,7 +82,7 @@ expect object RealmInterop {
     fun realm_object_create_with_primary_key(realm: NativePointer, key: Long, primaryKey: Any?): NativePointer
     fun realm_object_is_valid(obj: NativePointer): Boolean
     fun realm_object_freeze(liveObject: NativePointer, frozenRealm: NativePointer): NativePointer
-    fun realm_object_thaw(frozenObject: NativePointer, liveRealm: NativePointer): NativePointer
+    fun realm_object_thaw(frozenObject: NativePointer, liveRealm: NativePointer): NativePointer?
 
     fun realm_object_as_link(obj: NativePointer): Link
 

--- a/packages/cinterop/src/darwinCommon/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwinCommon/kotlin/io/realm/interop/RealmInterop.kt
@@ -400,7 +400,7 @@ actual object RealmInterop {
         return CPointerWrapper(realm_wrapper.realm_object_freeze(liveObject.cptr(), frozenRealm.cptr()))
     }
 
-    actual fun realm_object_thaw(frozenObject: NativePointer, liveRealm: NativePointer): NativePointer {
+    actual fun realm_object_thaw(frozenObject: NativePointer, liveRealm: NativePointer): NativePointer? {
         return CPointerWrapper(realm_wrapper.realm_object_thaw(frozenObject.cptr(), liveRealm.cptr()))
     }
 

--- a/packages/cinterop/src/darwinCommon/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwinCommon/kotlin/io/realm/interop/RealmInterop.kt
@@ -74,7 +74,7 @@ private fun throwOnError() {
     memScoped {
         val error = alloc<realm_error_t>()
         if (realm_get_last_error(error.ptr)) {
-            val runtimeException = RuntimeException(error.message?.toKString())
+            val runtimeException = RuntimeException("[${error.error}]: ${error.message?.toKString()}")
             realm_clear_last_error()
             // FIXME Extract all error information and throw exceptions based on type
             //  https://github.com/realm/realm-kotlin/issues/70

--- a/packages/cinterop/src/jvmCommon/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvmCommon/kotlin/io/realm/interop/RealmInterop.kt
@@ -203,7 +203,7 @@ actual object RealmInterop {
         return LongPointerWrapper(realmc.realm_object_freeze(liveObject.cptr(), frozenRealm.cptr()))
     }
 
-    actual fun realm_object_thaw(frozenObject: NativePointer, liveRealm: NativePointer): NativePointer {
+    actual fun realm_object_thaw(frozenObject: NativePointer, liveRealm: NativePointer): NativePointer? {
         return LongPointerWrapper(realmc.realm_object_thaw(frozenObject.cptr(), liveRealm.cptr()))
     }
 

--- a/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -90,6 +90,8 @@ class MutableRealm : BaseRealm {
      *
      * @param obj Realm object to look up. Its latest state will be returned. If the object
      * has been deleted, `null` will be returned.
+     *
+     * @throws IllegalArgumentException if called on an unmanaged object.
      */
     public fun <T : RealmObject> findLatest(obj: T?): T? {
         return if (obj == null || !obj.isValid()) {

--- a/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -40,7 +40,7 @@ class MutableRealm : BaseRealm {
 
         private fun checkObjectValid(obj: RealmObjectInternal) {
             if (!obj.isValid()) {
-                throw IllegalArgumentException("Cannot perform operation on an invalid/deleted object")
+                throw IllegalArgumentException("Cannot perform this operation on an invalid/deleted object")
             }
         }
     }
@@ -105,8 +105,7 @@ class MutableRealm : BaseRealm {
             // up to date, just return input
             obj
         } else {
-            val realmReference1 = this.realmReference
-            val liveRealm = realmReference1.owner
+            val liveRealm = realmReference.owner
             (obj as RealmObjectInternal).thaw(liveRealm)
         }
     }

--- a/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -79,6 +79,8 @@ class MutableRealm : BaseRealm {
     }
 
     /**
+     * Get latest version of an object.
+     *
      * Realm write transactions always operate on the latest version of data. This method
      * makes it possible to easily find the latest version of any frozen Realm Object and
      * return a copy of it that can be modified while inside the write block.

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -19,7 +19,6 @@ package io.realm.internal
 import io.realm.RealmObject
 import io.realm.interop.Link
 import io.realm.interop.RealmInterop
-import io.realm.isValid
 
 object RealmObjectHelper {
     // Issues (not yet fully uncovered/filed) met when calling these or similar methods from

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -19,6 +19,7 @@ package io.realm.internal
 import io.realm.RealmObject
 import io.realm.interop.Link
 import io.realm.interop.RealmInterop
+import io.realm.isValid
 
 object RealmObjectHelper {
     // Issues (not yet fully uncovered/filed) met when calling these or similar methods from
@@ -32,6 +33,7 @@ object RealmObjectHelper {
     // Consider inlining
     @Suppress("unused") // Called from generated code
     fun <R> getValue(obj: RealmObjectInternal, col: String): Any? {
+        obj.checkValid()
         val realm = obj.`$realm$Owner` as RealmReference? ?: throw IllegalStateException("Invalid/deleted object")
         val o = obj.`$realm$ObjectPointer` ?: throw IllegalStateException("Invalid/deleted object")
         val key = RealmInterop.realm_get_col_key(realm.dbPointer, obj.`$realm$TableName`!!, col)
@@ -44,6 +46,7 @@ object RealmObjectHelper {
         obj: RealmObjectInternal,
         col: String,
     ): Any? {
+        obj.checkValid()
         val realm = obj.`$realm$Owner` as RealmReference? ?: throw IllegalStateException("Invalid/deleted object")
         val o = obj.`$realm$ObjectPointer` ?: throw IllegalStateException("Invalid/deleted object")
         val key = RealmInterop.realm_get_col_key(realm.dbPointer, obj.`$realm$TableName`!!, col)
@@ -64,6 +67,7 @@ object RealmObjectHelper {
     // Consider inlining
     @Suppress("unused") // Called from generated code
     fun <R> setValue(obj: RealmObjectInternal, col: String, value: R) {
+        obj.checkValid()
         val realm = obj.`$realm$Owner` as RealmReference? ?: throw IllegalStateException("Invalid/deleted object")
         val o = obj.`$realm$ObjectPointer` ?: throw IllegalStateException("Invalid/deleted object")
         val key = RealmInterop.realm_get_col_key(realm.dbPointer, obj.`$realm$TableName`!!, col)
@@ -81,6 +85,7 @@ object RealmObjectHelper {
         col: String,
         value: R?
     ) {
+        obj.checkValid()
         val newValue = if (value?.`$realm$IsManaged` == false) {
             copyToRealm(obj.`$realm$Mediator` as Mediator, obj.`$realm$Owner` as RealmReference, value)
         } else value

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -30,6 +30,6 @@ interface RealmObjectInternal : RealmObject, io.realm.interop.RealmObjectInterop
 
 fun RealmObjectInternal.checkValid() {
     if (!this.isValid()) {
-        throw IllegalStateException("Cannot perform operation on an invalid/deleted object")
+        throw IllegalStateException("Cannot perform this operation on an invalid/deleted object")
     }
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -25,7 +25,12 @@ import kotlin.reflect.KClass
 
 // TODO API-INTERNAL
 // We could inline this
-fun <T : RealmObject> RealmObjectInternal.manage(realm: RealmReference, mediator: Mediator, type: KClass<T>, objectPointer: NativePointer): T {
+fun <T : RealmObject> RealmObjectInternal.manage(
+    realm: RealmReference,
+    mediator: Mediator,
+    type: KClass<T>,
+    objectPointer: NativePointer
+): T {
     this.`$realm$IsManaged` = true
     this.`$realm$Owner` = realm
     this.`$realm$TableName` = type.simpleName
@@ -38,7 +43,12 @@ fun <T : RealmObject> RealmObjectInternal.manage(realm: RealmReference, mediator
 }
 
 // TODO API-INTERNAL
-fun <T : RealmObject> RealmObjectInternal.link(realm: RealmReference, mediator: Mediator, type: KClass<T>, link: Link): T {
+fun <T : RealmObject> RealmObjectInternal.link(
+    realm: RealmReference,
+    mediator: Mediator,
+    type: KClass<T>,
+    link: Link
+): T {
     this.`$realm$IsManaged` = true
     this.`$realm$Owner` = realm
     this.`$realm$TableName` = type.simpleName
@@ -84,15 +94,24 @@ fun <T : RealmObject> RealmObjectInternal.freeze(frozenRealm: RealmReference): T
  *
  * @param liveRealm Reference to the Live Realm that should own the thawed object.
  */
-internal fun <T : RealmObject> RealmObjectInternal.thaw(liveRealm: BaseRealm): T {
+internal fun <T : RealmObject> RealmObjectInternal.thaw(liveRealm: BaseRealm): T? {
     @Suppress("UNCHECKED_CAST")
     val type: KClass<T> = this::class as KClass<T>
     val managedModel = (`$realm$Mediator` as Mediator).createInstanceOf(type)
     val dbPointer = liveRealm.realmReference.dbPointer
-    return managedModel.manage(
-        liveRealm.realmReference,
-        `$realm$Mediator` as Mediator,
-        type,
-        RealmInterop.realm_object_thaw(`$realm$ObjectPointer`!!, dbPointer)
-    )
+    // FIXME C-API is currently throwing an error if the object has been deleted, so currently just
+    //  catching that and returning null
+    @Suppress("TooGenericExceptionCaught")
+    try {
+        return RealmInterop.realm_object_thaw(`$realm$ObjectPointer`!!, dbPointer)!!.let { thawedObject ->
+            managedModel.manage(
+                liveRealm.realmReference,
+                `$realm$Mediator` as Mediator,
+                type,
+                thawedObject
+            )
+        }
+    } catch (e: Exception) {
+        return null
+    }
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -59,16 +59,6 @@ fun <T : RealmObject> RealmObjectInternal.link(
     return this as T
 }
 
-fun RealmObjectInternal.unmanage() {
-    // FIXME API-LIFECYCLE For now update the object to an inconsistent state that triggers Realm setters and
-    //  getters to raise an IllegalStateException by keeping the `$realm$IsManaged` property set to
-    //  true (triggers delegation to Realm-backed getter/setter) while clearing the native
-    //  pointers (triggers the native getter/setter to throw the IllegalStateException).
-    this.`$realm$IsManaged` = true
-    this.`$realm$ObjectPointer` = null
-    this.`$realm$Owner` = null
-}
-
 /**
  * Creates a frozen copy of this object.
  *

--- a/test/src/androidTest/kotlin/io/realm/shared/MutableRealmTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/MutableRealmTests.kt
@@ -19,7 +19,6 @@ import io.realm.util.PlatformUtils
 import test.StringPropertyWithPrimaryKey
 import test.link.Child
 import test.link.Parent
-import java.lang.IllegalArgumentException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/test/src/androidTest/kotlin/io/realm/shared/MutableRealmTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/MutableRealmTests.kt
@@ -16,13 +16,17 @@
 package io.realm
 
 import io.realm.util.PlatformUtils
+import test.StringPropertyWithPrimaryKey
 import test.link.Child
 import test.link.Parent
+import java.lang.IllegalArgumentException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class MutableRealmTests {
 
@@ -35,7 +39,7 @@ class MutableRealmTests {
         tmpDir = PlatformUtils.createTempDir()
         configuration = RealmConfiguration(
             path = "$tmpDir/default.realm",
-            schema = setOf(Parent::class, Child::class)
+            schema = setOf(Parent::class, Child::class, StringPropertyWithPrimaryKey::class)
         )
         realm = Realm.open(configuration)
     }
@@ -65,6 +69,71 @@ class MutableRealmTests {
             // FIXME Should be IllegalStateException
             assertFailsWith<RuntimeException> {
                 cancelWrite()
+            }
+        }
+    }
+
+    @Test
+    fun findLatest_basic() {
+        val instance = realm.writeBlocking { copyToRealm(StringPropertyWithPrimaryKey()) }
+
+        realm.writeBlocking {
+            val latest = findLatest(instance)
+            assertNotNull(latest)
+            assertEquals(instance.id, latest.id)
+        }
+    }
+
+    @Test
+    fun findLatest_updated() {
+        val updatedValue = "UPDATED"
+        val instance = realm.writeBlocking { copyToRealm(StringPropertyWithPrimaryKey()) }
+        assertNull(instance.value)
+
+        realm.writeBlocking {
+            val latest = findLatest(instance)
+            assertNotNull(latest)
+            assertEquals(instance.id, latest.id)
+            latest.value = updatedValue
+        }
+        assertNull(instance.value)
+
+        realm.writeBlocking {
+            val latest = findLatest(instance)
+            assertNotNull(latest)
+            assertEquals(instance.id, latest.id)
+            assertEquals(updatedValue, latest.value)
+        }
+    }
+
+    @Test
+    fun findLatest_deleted() {
+        val instance = realm.writeBlocking { copyToRealm(StringPropertyWithPrimaryKey()) }
+
+        realm.writeBlocking {
+            findLatest(instance)?.let {
+                delete(it)
+            }
+        }
+        realm.writeBlocking {
+            assertNull(findLatest(instance))
+        }
+    }
+
+    @Test
+    fun findLatest_identityForLiveObject() {
+        realm.writeBlocking {
+            val instance = copyToRealm(StringPropertyWithPrimaryKey())
+            val latest = findLatest(instance)
+            assert(instance === latest)
+        }
+    }
+
+    @Test
+    fun findLatest_unmanagedThrows() {
+        realm.writeBlocking {
+            assertFailsWith<IllegalArgumentException> {
+                val latest = findLatest(StringPropertyWithPrimaryKey())
             }
         }
     }

--- a/test/src/commonMain/kotlin/test/StringPropertyWithPrimaryKey.kt
+++ b/test/src/commonMain/kotlin/test/StringPropertyWithPrimaryKey.kt
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-package io.realm.internal
+package test
 
+import io.realm.PrimaryKey
 import io.realm.RealmObject
-import io.realm.isValid
+import kotlin.random.Random
+import kotlin.random.nextULong
 
-/**
- * Internal interface for Realm objects.
- *
- * The interface is added by the compiler plugin to all [RealmObject] classes to have an interface
- * exposing our internal API and compiler plugin additions without leaking it to the public
- * [RealmObject].
- */
-interface RealmObjectInternal : RealmObject, io.realm.interop.RealmObjectInterop
-
-fun RealmObjectInternal.checkValid() {
-    if (!this.isValid()) {
-        throw IllegalStateException("Cannot perform operation on an invalid/deleted object")
-    }
+class StringPropertyWithPrimaryKey : RealmObject {
+    @PrimaryKey
+    var id: String = Random.nextULong().toString()
+    var value: String? = null
 }


### PR DESCRIPTION
Add method to retrieve latest version of a frozen inside a write transaction. 

```
class MutableRealm : BaseRealm {
    /**
     * Get latest version of an object.
     *
     * Realm write transactions always operate on the latest version of data. This method
     * makes it possible to easily find the latest version of any frozen Realm Object and
     * return a copy of it that can be modified while inside the write block.
     *
     * *Note:* This object is not readable outside the write block unless it has been explicitly
     * returned from the write.
     *
     * @param obj Realm object to look up. Its latest state will be returned. If the object
     * has been deleted, `null` will be returned.
     */
    public fun <T : RealmObject> findLatest(obj: T?): T?
}
```

FIXMEs:
- [ ] The C-API is currently throwing an error when thawing a deleted object. Current implementation catches this and returns null, but should instead be fixed in https://github.com/realm/realm-core/pull/4658