### PR TITLE
Eliminated notifier, writer and RealmReference to avoid memory leak

### DIFF
--- a/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
@@ -48,17 +48,23 @@ public abstract class BaseRealm internal constructor(
      * updated to point to a new frozen version after writes or notification, so care should be
      * taken not to spread operations over different references.
      */
-    internal open var realmReference: RealmReference = RealmReference(this, dbPointer)
-        set(_) {
-            throw UnsupportedOperationException("BaseRealm reference should never be updated")
-        }
+    // FIXME Representing the underlying refetrence with a RealmReference seems to cause the
+    //  GC to not collect both the owner and reference on Native, so seems like the cycle is not
+    //  detected. 
+    internal open var dbPoiner: NativePointer = dbPointer
+//    internal open var realmReference: RealmReference = RealmReference(this, dbPointer)
+//        set(_) {
+//            throw UnsupportedOperationException("BaseRealm reference should never be updated")
+//        }
 
     /**
      * The current data version of this Realm and data fetched from it.
      */
     // TODO Could be abstracted into base implementation of RealmLifeCycle!?
     public var version: VersionId = VersionId(0)
-        get() { return realmReference.version() }
+        get() {
+            TODO() // return RealmInterop.version() }
+        }
 
     internal val log: RealmLog = RealmLog(configuration = configuration.log)
 
@@ -67,15 +73,16 @@ public abstract class BaseRealm internal constructor(
     }
 
     fun <T : RealmObject> objects(clazz: KClass<T>): RealmResults<T> {
+        TODO()
         // Use same reference through out all operations to avoid locking
-        val realmReference = this.realmReference
-        realmReference.checkClosed()
-        return RealmResults.fromQuery(
-            realmReference,
-            RealmInterop.realm_query_parse(realmReference.dbPointer, clazz.simpleName!!, "TRUEPREDICATE"),
-            clazz,
-            configuration.mediator
-        )
+//        val realmReference = this.realmReference
+//        realmReference.checkClosed()
+//        return RealmResults.fromQuery(
+//            realmReference,
+//            RealmInterop.realm_query_parse(realmReference.dbPointer, clazz.simpleName!!, "TRUEPREDICATE"),
+//            clazz,
+//            configuration.mediator
+//        )
     }
     // Convenience inline method for the above to skip KClass argument
     inline fun <reified T : RealmObject> objects(): RealmResults<T> { return objects(T::class) }
@@ -119,9 +126,10 @@ public abstract class BaseRealm internal constructor(
      * @see [RealmConfiguration.Builder.maxNumberOfActiveVersions]
      */
     public fun getNumberOfActiveVersions(): Long {
-        val reference = realmReference
-        reference.checkClosed()
-        return RealmInterop.realm_get_num_versions(reference.dbPointer)
+        TODO()
+//        val reference = realmReference
+//        reference.checkClosed()
+//        return RealmInterop.realm_get_num_versions(reference.dbPointer)
     }
 
     /**
@@ -131,14 +139,16 @@ public abstract class BaseRealm internal constructor(
      * @return `true` if the Realm has been closed. `false` if not.
      */
     public fun isClosed(): Boolean {
-        return realmReference.isClosed()
+        TODO()
+//        return realmReference.isClosed()
     }
 
     // Not all sub classes of `BaseRealm` can be closed by users.
     internal open fun close() {
-        val reference = realmReference
-        reference.checkClosed()
-        RealmInterop.realm_close(reference.dbPointer)
-        log.info("Realm closed: ${configuration.path}")
+        TODO()
+//        val reference = realmReference
+//        reference.checkClosed()
+//        RealmInterop.realm_close(reference.dbPointer)
+//        log.info("Realm closed: ${configuration.path}")
     }
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -59,15 +59,16 @@ class MutableRealm : BaseRealm {
         super(configuration, RealmInterop.realm_open(configuration.nativeConfig, dispatcher))
 
     internal fun beginTransaction() {
-        RealmInterop.realm_begin_write(realmReference.dbPointer)
+//        RealmInterop.realm_begin_write(realmReference.dbPointer)
     }
 
     internal fun commitTransaction() {
-        RealmInterop.realm_commit(realmReference.dbPointer)
+//        RealmInterop.realm_commit(realmReference.dbPointer)
     }
 
     internal fun isInTransaction(): Boolean {
-        return RealmInterop.realm_is_in_transaction(realmReference.dbPointer)
+        TODO()
+//        return RealmInterop.realm_is_in_transaction(realmReference.dbPointer)
     }
 
     /**
@@ -86,34 +87,36 @@ class MutableRealm : BaseRealm {
      * @throws IllegalArgumentException if called on an unmanaged object.
      */
     public fun <T : RealmObject> findLatest(obj: T?): T? {
-        return if (obj == null || !obj.isValid()) {
-            null
-        } else if (!obj.isManaged()) {
-            throw IllegalArgumentException(
-                "Unmanaged objects must be part of the Realm, before " +
-                    "they can be queried this way. Use `MutableRealm.copyToRealm()` to turn it into " +
-                    "a managed object."
-            )
-        } else if (!obj.isFrozen()) {
-            // If already valid, managed and not frozen, it must be live, and thus already
-            // up to date, just return input
-            obj
-        } else {
-            val liveRealm = realmReference.owner
-            (obj as RealmObjectInternal).thaw(liveRealm)
-        }
+//        return if (obj == null || !obj.isValid()) {
+//            null
+//        } else if (!obj.isManaged()) {
+//            throw IllegalArgumentException(
+//                "Unmanaged objects must be part of the Realm, before " +
+//                    "they can be queried this way. Use `MutableRealm.copyToRealm()` to turn it into " +
+//                    "a managed object."
+//            )
+//        } else if (!obj.isFrozen()) {
+//            // If already valid, managed and not frozen, it must be live, and thus already
+//            // up to date, just return input
+//            obj
+//        } else {
+//            val liveRealm = realmReference.owner
+//            (obj as RealmObjectInternal).thaw(liveRealm)
+//        }
+        TODO()
     }
 
     /**
      * Cancel the write. Any changes will not be persisted to disk.
      */
     public fun cancelWrite() {
-        RealmInterop.realm_rollback(realmReference.dbPointer)
+//        RealmInterop.realm_rollback(realmReference.dbPointer)
     }
 
     @Deprecated("Use MutableRealm.copyToRealm() instead", ReplaceWith("io.realm.MutableRealm.copyToRealm(obj)"))
     fun <T : RealmObject> create(type: KClass<T>): T {
-        return io.realm.internal.create(configuration.mediator, realmReference, type)
+        TODO()
+//        return io.realm.internal.create(configuration.mediator, realmReference, type)
     }
     // Convenience inline method for the above to skip KClass argument
     @Deprecated("Use MutableRealm.copyToRealm() instead", ReplaceWith("io.realm.MutableRealm.copyToRealm(obj)"))
@@ -121,7 +124,8 @@ class MutableRealm : BaseRealm {
 
     @Deprecated("Use MutableRealm.copyToRealm() instead", ReplaceWith("io.realm.MutableRealm.copyToRealm(obj)"))
     fun <T : RealmObject> create(type: KClass<T>, primaryKey: Any?): T {
-        return io.realm.internal.create(configuration.mediator, realmReference, type, primaryKey)
+        TODO()
+//        return io.realm.internal.create(configuration.mediator, realmReference, type, primaryKey)
     }
 
     /**
@@ -135,7 +139,8 @@ class MutableRealm : BaseRealm {
      * @return The managed version of the `instance`.
      */
     fun <T : RealmObject> copyToRealm(instance: T): T {
-        return io.realm.internal.copyToRealm(configuration.mediator, realmReference, instance)
+        TODO()
+//        return io.realm.internal.copyToRealm(configuration.mediator, realmReference, instance)
     }
     /**
      * Deletes the object from the underlying Realm.

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -88,25 +88,26 @@ internal fun <T : RealmObject> RealmObjectInternal.thaw(liveRealm: BaseRealm): T
     @Suppress("UNCHECKED_CAST")
     val type: KClass<T> = this::class as KClass<T>
     val managedModel = (`$realm$Mediator` as Mediator).createInstanceOf(type)
-    val dbPointer = liveRealm.realmReference.dbPointer
-    @Suppress("TooGenericExceptionCaught")
-    try {
-        return RealmInterop.realm_object_thaw(`$realm$ObjectPointer`!!, dbPointer)!!.let { thawedObject ->
-            managedModel.manage(
-                liveRealm.realmReference,
-                `$realm$Mediator` as Mediator,
-                type,
-                thawedObject
-            )
-        }
-    } catch (e: Exception) {
-        // FIXME C-API is currently throwing an error if the object has been deleted, so currently just
-        //  catching that and returning null. Only treat unknown null pointers as non-existing objects
-        //  to avoid handling unintended situations here.
-        if (e.message?.startsWith("[2]: null") ?: false) {
-            return null
-        } else {
-            throw e
-        }
-    }
+        TODO()
+//    val dbPointer = liveRealm.realmReference.dbPointer
+//    @Suppress("TooGenericExceptionCaught")
+//    try {
+//        return RealmInterop.realm_object_thaw(`$realm$ObjectPointer`!!, dbPointer)!!.let { thawedObject ->
+//            managedModel.manage(
+//                liveRealm.realmReference,
+//                `$realm$Mediator` as Mediator,
+//                type,
+//                thawedObject
+//            )
+//        }
+//    } catch (e: Exception) {
+//        // FIXME C-API is currently throwing an error if the object has been deleted, so currently just
+//        //  catching that and returning null. Only treat unknown null pointers as non-existing objects
+//        //  to avoid handling unintended situations here.
+//        if (e.message?.startsWith("[2]: null") ?: false) {
+//            return null
+//        } else {
+//            throw e
+//        }
+//    }
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -179,27 +179,28 @@ internal class SuspendableNotifier(private val owner: Realm, private val dispatc
      * FIXME Callers of this method must make sure it is called on the correct [SuspendableNotifier.dispatcher].
      */
     internal fun <T : RealmObject> registerResultsChangedListener(results: RealmResults<T>, callback: Callback<RealmResults<T>>): Cancellable {
-        val liveResults = results.thaw(realm.realmReference)
-        val token = RealmInterop.realm_results_add_notification_callback(
-            liveResults.result,
-            object : io.realm.interop.Callback {
-                override fun onChange(collectionChanges: NativePointer) {
-                    // FIXME How to make sure the Realm isn't closed when handling this?
-
-                    // FIXME The Realm should have been frozen in `realmChanged`, but this isn't supported yet.
-                    //  Instead we create the frozen version ourselves (which is correct, but pretty inefficient)
-                    //  We also send it to the owner Realm, so it can keep track of its lifecycle
-                    val frozenRealm = RealmReference(owner, RealmInterop.realm_freeze(realm.realmReference.dbPointer))
-                    notifyRealmChanged(frozenRealm)
-
-                    // Notifications need to be delivered with the version they where created on, otherwise
-                    // the fine-grained notification data might be out of sync.
-                    val frozenResults = liveResults.freeze(frozenRealm)
-                    callback.onChange(frozenResults)
-                }
-            }.freeze() // Freeze to allow cleaning up on another thread
-        )
-        return NotificationToken(callback, token)
+        TODO()
+//        val liveResults = results.thaw(realm.realmReference)
+//        val token = RealmInterop.realm_results_add_notification_callback(
+//            liveResults.result,
+//            object : io.realm.interop.Callback {
+//                override fun onChange(collectionChanges: NativePointer) {
+//                    // FIXME How to make sure the Realm isn't closed when handling this?
+//
+//                    // FIXME The Realm should have been frozen in `realmChanged`, but this isn't supported yet.
+//                    //  Instead we create the frozen version ourselves (which is correct, but pretty inefficient)
+//                    //  We also send it to the owner Realm, so it can keep track of its lifecycle
+//                    val frozenRealm = RealmReference(owner, RealmInterop.realm_freeze(realm.realmReference.dbPointer))
+//                    notifyRealmChanged(frozenRealm)
+//
+//                    // Notifications need to be delivered with the version they where created on, otherwise
+//                    // the fine-grained notification data might be out of sync.
+//                    val frozenResults = liveResults.freeze(frozenRealm)
+//                    callback.onChange(frozenResults)
+//                }
+//            }.freeze() // Freeze to allow cleaning up on another thread
+//        )
+//        return NotificationToken(callback, token)
     }
 
     /**
@@ -221,30 +222,31 @@ internal class SuspendableNotifier(private val owner: Realm, private val dispatc
      * FIXME Callers of this method must make sure it is called on the correct [SuspendableNotifier.dispatcher].
      */
     internal fun <T : RealmObject> registerObjectChangedListener(obj: T, callback: Callback<T?>): Cancellable {
-        val liveObject: RealmObjectInternal? = (obj as RealmObjectInternal).thaw(realm.realmReference.owner) as RealmObjectInternal?
-        if (liveObject == null || !liveObject.isValid()) {
-            return NO_OP_NOTIFICATION_TOKEN
-        }
-        val token = RealmInterop.realm_object_add_notification_callback(
-            liveObject.`$realm$ObjectPointer`!!,
-            object : io.realm.interop.Callback {
-                override fun onChange(objectChanges: NativePointer) {
-                    // FIXME How to make sure the Realm isn't closed when handling this?
-
-                    // FIXME The Realm should have been frozen in `realmChanged`, but this isn't supported yet.
-                    //  Instead we create the frozen version ourselves (which is correct, but pretty inefficient)
-                    val frozenRealm = RealmReference(owner, RealmInterop.realm_freeze(realm.realmReference.dbPointer))
-                    notifyRealmChanged(frozenRealm)
-
-                    if (!liveObject.isValid()) {
-                        callback.onChange(null)
-                    } else {
-                        callback.onChange(liveObject.freeze(frozenRealm))
-                    }
-                }
-            }.freeze() // Freeze to allow cleaning up on another thread
-        )
-        return NotificationToken(callback, token)
+        TODO()
+//        val liveObject: RealmObjectInternal? = (obj as RealmObjectInternal).thaw(realm.realmReference.owner) as RealmObjectInternal?
+//        if (liveObject == null || !liveObject.isValid()) {
+//            return NO_OP_NOTIFICATION_TOKEN
+//        }
+//        val token = RealmInterop.realm_object_add_notification_callback(
+//            liveObject.`$realm$ObjectPointer`!!,
+//            object : io.realm.interop.Callback {
+//                override fun onChange(objectChanges: NativePointer) {
+//                    // FIXME How to make sure the Realm isn't closed when handling this?
+//
+//                    // FIXME The Realm should have been frozen in `realmChanged`, but this isn't supported yet.
+//                    //  Instead we create the frozen version ourselves (which is correct, but pretty inefficient)
+//                    val frozenRealm = RealmReference(owner, RealmInterop.realm_freeze(realm.realmReference.dbPointer))
+//                    notifyRealmChanged(frozenRealm)
+//
+//                    if (!liveObject.isValid()) {
+//                        callback.onChange(null)
+//                    } else {
+//                        callback.onChange(liveObject.freeze(frozenRealm))
+//                    }
+//                }
+//            }.freeze() // Freeze to allow cleaning up on another thread
+//        )
+//        return NotificationToken(callback, token)
     }
 
     internal fun close() {

--- a/test/src/androidTest/kotlin/io/realm/shared/RealmTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/RealmTests.kt
@@ -400,18 +400,18 @@ class RealmTests {
     @Test
     @Suppress("invisible_member")
     fun closingIntermediateVersionsWhenNoLongerReferenced() {
-        assertEquals(0, realm.intermediateReferences.value.size)
-        var parent: Parent? = realm.writeBlocking { copyToRealm(Parent()) }
-        assertEquals(1, realm.intermediateReferences.value.size)
-        realm.writeBlocking { }
-        assertEquals(2, realm.intermediateReferences.value.size)
-
-        // Clear reference
-        parent = null
-        // Trigger GC
-        triggerGC()
-        // Close of intermediate version is currently only done when updating the realm after a write
-        realm.writeBlocking { }
-        assertEquals(1, realm.intermediateReferences.value.size)
+//        assertEquals(0, realm.intermediateReferences.value.size)
+//        var parent: Parent? = realm.writeBlocking { copyToRealm(Parent()) }
+//        assertEquals(1, realm.intermediateReferences.value.size)
+//        realm.writeBlocking { }
+//        assertEquals(2, realm.intermediateReferences.value.size)
+//
+//        // Clear reference
+//        parent = null
+//        // Trigger GC
+//        triggerGC()
+//        // Close of intermediate version is currently only done when updating the realm after a write
+//        realm.writeBlocking { }
+//        assertEquals(1, realm.intermediateReferences.value.size)
     }
 }

--- a/test/src/macosTest/kotlin/io/realm/MemoryTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/MemoryTests.kt
@@ -17,6 +17,7 @@
 
 package io.realm
 
+import io.realm.log.LogLevel
 import io.realm.util.PlatformUtils.createTempDir
 import io.realm.util.PlatformUtils.deleteTempDir
 import io.realm.util.PlatformUtils.triggerGC
@@ -31,7 +32,6 @@ import platform.posix.popen
 import test.Sample
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -51,7 +51,7 @@ class MemoryTests {
 
     // TODO Only run on macOS, filter using https://developer.apple.com/documentation/foundation/nsprocessinfo/3608556-iosapponmac when upgrading to XCode 12
     @Test
-    @Ignore // We currently do not clean up intermediate versions if the realm itself is garbage collected
+//    @Ignore // We currently do not clean up intermediate versions if the realm itself is garbage collected
     fun garbageCollectorShouldFreeNativeResources() {
         val referenceHolder = mutableListOf<Sample>()
         val amountOfMemoryMappedInProcessCMD =
@@ -59,34 +59,34 @@ class MemoryTests {
         {
             val realm = openRealmFromTmpDir()
             // TODO use Realm.delete once this is implemented
-            realm.writeBlocking {
-                objects(Sample::class).delete()
-            }
+//            realm.writeBlocking {
+//                objects(Sample::class).delete()
+//            }
 
             // allocating a 1 MB string
-            val oneMBstring = StringBuilder("").apply {
-                for (i in 1..4096) {
-                    // 128 length (256 bytes)
-                    append("v7TPOZtm50q8kMBoKiKRaD2JhXgjM6OUNzHojXuFXvxdtwtN9fCVIW4njdwVdZ9aChvXCtW4nzUYeYWbI6wuSspbyjvACtMtjQTtOoe12ZEPZPII6PAFTfbrQQxc3ymJ")
-                }
-            }.toString()
+//            val oneMBstring = StringBuilder("").apply {
+//                for (i in 1..4096) {
+//                    // 128 length (256 bytes)
+//                    append("v7TPOZtm50q8kMBoKiKRaD2JhXgjM6OUNzHojXuFXvxdtwtN9fCVIW4njdwVdZ9aChvXCtW4nzUYeYWbI6wuSspbyjvACtMtjQTtOoe12ZEPZPII6PAFTfbrQQxc3ymJ")
+//                }
+//            }.toString()
 
             // inserting ~ 100MB of data
-            val elements: List<Sample> =
-                realm.writeBlocking {
-                    IntRange(1, 100).map {
-                        copyToRealm(Sample()).apply {
-                            stringField = oneMBstring
-                        }
-                    }
-                }
-            referenceHolder.addAll(elements)
+//            val elements: List<Sample> =
+//                realm.writeBlocking {
+//                    IntRange(1, 100).map {
+//                        copyToRealm(Sample()).apply {
+//                            stringField = oneMBstring
+//                        }
+//                    }
+//                }
+//            referenceHolder.addAll(elements)
         }()
-        assertEquals(
-            "99.0M",
-            runSystemCommand(amountOfMemoryMappedInProcessCMD),
-            "We should have at least 99 MB allocated as mmap"
-        )
+//        assertEquals(
+//            "99.0M",
+//            runSystemCommand(amountOfMemoryMappedInProcessCMD),
+//            "We should have at least 99 MB allocated as mmap"
+//        )
         // After releasing all the 'realm_object_create' reference the Realm should be closed and the
         // no memory mapped file is allocated in the process
         referenceHolder.clear()
@@ -140,7 +140,10 @@ class MemoryTests {
     }
 
     private fun openRealmFromTmpDir(): Realm {
-        val configuration = RealmConfiguration(path = "$tmpDir/default.realm", schema = setOf(Sample::class))
+        val configuration = RealmConfiguration.Builder(
+            path = "$tmpDir/default.realm",
+            schema = setOf(Sample::class)
+        ).log(LogLevel.DEBUG).build()
         return Realm.open(configuration)
     }
 


### PR DESCRIPTION
`RealmReference` introduced a cycle in the references, which seems to cause GC to fail deallocation the Realm and the RealmReference on native. 

This draft PR is just my experiments of stripping the notifier and writer from `Realm` and then finally eliminating the `realmReference` in favor of a pure `NativePointer` in the `BaseRealm`. Just to show that this is in fact the triggering factor. 