### PR TITLE
Fix README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository holds the source code for the Kotlin SDK for Realm, which runs o
 
 https://github.com/realm/realm-kotlin-samples
 
-# Quick Startup
+# Quick Start
 
 ## Prerequisite
 
@@ -26,8 +26,7 @@ Start a new [KMM](https://kotlinlang.org/docs/mobile/create-first-app.html) proj
 ```Gradle
 buildscript {
     repositories {
-        // other repo
-        maven(url = "https://oss.jfrog.org/artifactory/oss-snapshot-local")
+        mavenCentral()
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20")// minimum 1.4.20
@@ -38,8 +37,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // other repo 
-        maven(url = "https://oss.jfrog.org/artifactory/oss-snapshot-local")
+        mavenCentral()
     }
 }
 ```
@@ -104,17 +102,9 @@ val person = Person().apply {
 }
 
 // persist it in a transaction
-realm.beginTransaction()
-val managedPerson = realm.copyToRealm(person)
-realm.commitTransaction()
-
-// alternatively we can use
-realm.beginTransaction()
-realm.create<Person>().apply {
-            name = "Bar"
-            dog = Dog().apply { name = "Filo"; age = 11 }
-        }
-realm.commitTransaction()
+realm.writeBlocking {
+    val managedPerson = this.copyToRealm(person)
+}
 ```
 
 ## Query
@@ -140,9 +130,9 @@ realm.objects<Person>().query("dog == NULL LIMIT(1)")
     .firstOrNull()
     ?.also { personWithoutDog ->
         // Add a dog in a transaction
-        realm.beginTransaction()
-        personWithoutDog.dog = Dog().apply { name = "Laika";  age = 3 }
-        realm.commitTransaction()
+        realm.writeBlocking {
+            personWithoutDog.dog = Dog().apply { name = "Laika"; age = 3 }
+        }
     }
 ```
 
@@ -151,11 +141,10 @@ realm.objects<Person>().query("dog == NULL LIMIT(1)")
 Use the result of a query to delete from the database
 ```Kotlin
 // delete all Dogs
-realm.beginTransaction()
-realm.objects<Dog>().delete()
-realm.commitTransaction()
+realm.writeBlocking {
+    realm.objects<Dog>().delete()
+}
 ```
-
 
 Next: head to the full KMM [example](./examples/kmm-sample).  
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Start a new [KMM](https://kotlinlang.org/docs/mobile/create-first-app.html) proj
 
 ## Setup
 
+*See [Config.kt](buildSrc/src/main/kotlin/Config.kt#L2txt) or the [realm-kotlin releases](https://github.com/realm/realm-kotlin/releases) for the latest version number.*
+
 - Add the following Gradle configuration in the root project (make sure you're using Kotlin `1.4.20` or recent)
 `<root project>/build.gradle.kts`
 ```Gradle
@@ -30,7 +32,7 @@ buildscript {
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20")// minimum 1.4.20
         classpath("com.android.tools.build:gradle:4.0.1")
-        classpath("io.realm.kotlin:gradle-plugin:0.0.1-SNAPSHOT")
+        classpath("io.realm.kotlin:gradle-plugin:<VERSION>")
     }
 }
 
@@ -41,29 +43,25 @@ allprojects {
     }
 }
 ```
-![Gradle Configuration](./images/RootGradle.png)
 
-- Apply the `realm-kotlin` plugin and specify the dependency in the common source set.
-
-*See [Config.kt](buildSrc/src/main/kotlin/Config.kt#L2txt) for the latest version number.*
+- Apply the `io.realm.kotlin` plugin and specify the dependency in the common source set.
 
 ```Gradle
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
-    id("realm-kotlin")
+    id("io.realm.kotlin")
 }
 
 kotlin {
   sourceSets {
       val commonMain by getting {
           dependencies {
-              implementation("io.realm.kotlin:library:0.0.1-SNAPSHOT")
+              implementation("io.realm.kotlin:library:<VERSION>")
           }
       }
 }
 ```
-![Gradle Configuration](./images/SharedGradle.png)
 
 ## Define model
 


### PR DESCRIPTION
- update "realm-kotlin" plugin name to "io.realm.kotlin"
- remove redundant screenshots
- remove explicit version references, replace with `<VERSION>` placeholder
- point users to config/github releases section for potential version values
- updated all transaction usages to the `write`/`writeBlocking` syntax from the now-removed `beginTransaction`/`commitTransaction` pattern
- removed usages of the `realm.create` method, which has been deprecated
- updated `maven(url = "https://oss.jfrog.org/artifactory/oss-snapshot-local")` dependency references to `mavenCentral()`, since that's a default KMM template setting that most users will understand that they don't need to change.