### PR TITLE
KLIB release build type as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0 (YYYY-MM-DD)
+## 0.3.0 (2021-06-30)
 
 ### Breaking Changes
 * None.

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -16,7 +16,7 @@
  */
 
 object Realm {
-    const val version = "0.3.0-SNAPSHOT"
+    const val version = "0.3.0"
     const val group = "io.realm.kotlin"
     const val projectUrl = "https://realm.io"
     const val pluginPortalId = "io.realm.kotlin"

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -43,7 +43,8 @@ val idea: Boolean = System.getProperty("idea.active") == "true"
 //               realm-kotlin/packages> CONFIGURATION=Release ./gradlew capiIosArm64
 //               * to force build a debug (default BTW) use
 //               realm-kotlin/packages> CONFIGURATION=Debug ./gradlew capiIosArm64
-val isReleaseBuild: Boolean = (System.getenv("CONFIGURATION") ?: "DEBUG").equals("Release", ignoreCase = true)
+//               default is 'Release'
+val isReleaseBuild: Boolean = (System.getenv("CONFIGURATION") ?: "RELEASE").equals("Release", ignoreCase = true)
 
 val corePath = "external/core"
 val absoluteCorePath = "$rootDir/$corePath"


### PR DESCRIPTION
When releasing darwing artifacts the default build type was set to `debug` 
<img width="1443" alt="Screenshot 2021-06-30 at 16 25 11" src="https://user-images.githubusercontent.com/1793238/123997680-8d2aa180-d9c8-11eb-9cb6-151b5c744010.png">

Setting the default to `Release` will allow uploading the stripped KLIB instead