### PR TITLE
Remove version from path of API reference links

### DIFF
--- a/packages/library/build.gradle.kts
+++ b/packages/library/build.gradle.kts
@@ -244,7 +244,7 @@ tasks.register("uploadDokka") {
                     "--acl-public",
                     "--access_key=$awsAccessKey",
                     "--secret_key=$awsSecretKey",
-                    "${dokkaDir.absolutePath}/-realm -kotlin -s-d-k-$version/", // Add / to only upload content of the folder, not the folder itself.
+                    "${dokkaDir.absolutePath}/", // Add / to only upload content of the folder, not the folder itself.
                     "s3://realm-sdks/realm-sdks/kotlin/$version/"
                 )
             }

--- a/packages/library/build.gradle.kts
+++ b/packages/library/build.gradle.kts
@@ -200,7 +200,7 @@ realmPublish {
 }
 
 tasks.dokkaHtml.configure {
-    moduleName.set("Realm Kotlin SDK ${Realm.version}")
+    moduleName.set("Realm Kotlin Multiplatform SDK")
     dokkaSourceSets {
         configureEach {
             moduleVersion.set(Realm.version)

--- a/packages/library/build.gradle.kts
+++ b/packages/library/build.gradle.kts
@@ -244,7 +244,7 @@ tasks.register("uploadDokka") {
                     "--acl-public",
                     "--access_key=$awsAccessKey",
                     "--secret_key=$awsSecretKey",
-                    "${dokkaDir.absolutePath}/", // Add / to only upload content of the folder, not the folder itself.
+                    "${dokkaDir.absolutePath}/-realm -kotlin -s-d-k-$version/", // Add / to only upload content of the folder, not the folder itself.
                     "s3://realm-sdks/realm-sdks/kotlin/$version/"
                 )
             }


### PR DESCRIPTION
(so we can direct link to classes across SDK releases -- versions are already handled in the base path)