### PR TITLE
Remove minifying from the library

### DIFF
--- a/packages/library/build.gradle.kts
+++ b/packages/library/build.gradle.kts
@@ -93,7 +93,6 @@ android {
 
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = true
             consumerProguardFiles("proguard-rules-consumer-common.pro")
         }
     }


### PR DESCRIPTION
Setting `isMinified = true` for a library project https://github.com/realm/realm-kotlin/blob/master/packages/library/build.gradle.kts#L96  doesn't make sense (since it will remove all entries for release when producing the AAR). 

With this fix the `Release` variant for Android is working again.

<img width="922" alt="Screenshot 2021-07-02 at 10 19 30" src="https://user-images.githubusercontent.com/1793238/124257529-5b2e5200-db24-11eb-862f-ea016ad6832d.png">
