### PR TITLE
RealmList - copyToRealm with prepopulated lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.3.2 (2021-07-06)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* [Bug](https://github.com/realm/realm-kotlin/issues/334) in `copyToRealm` causing a `RealmList` not to be saved as part of the model.
+
+### Compatibility
+* This release is compatible with Kotlin 1.5.10 and Coroutines 1.5.0.
+
+### Internal
+* None.
+
+
 ## 0.3.1 (2021-07-02)
 
 ### Breaking Changes

--- a/test/src/androidTest/kotlin/io/realm/shared/RealmListTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/RealmListTests.kt
@@ -21,8 +21,12 @@ import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.RealmList
 import io.realm.RealmObject
+import io.realm.RealmResults
 import io.realm.util.PlatformUtils
 import io.realm.util.TypeDescriptor
+import test.list.Level1
+import test.list.Level2
+import test.list.Level3
 import test.list.RealmListContainer
 import kotlin.reflect.KClassifier
 import kotlin.reflect.KMutableProperty1
@@ -47,7 +51,7 @@ class RealmListTests {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration(
             path = "$tmpDir/default.realm",
-            schema = setOf(RealmListContainer::class)
+            schema = setOf(RealmListContainer::class, Level1::class, Level2::class, Level3::class)
         )
         realm = Realm.open(configuration)
     }
@@ -58,6 +62,83 @@ class RealmListTests {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)
+    }
+
+    @Test
+    fun nestedObjectTest() {
+        realm.writeBlocking {
+            val level1_1 = Level1().apply { name = "l1_1" }
+            val level1_2 = Level1().apply { name = "l1_2" }
+            val level2_1 = Level2().apply { name = "l2_1" }
+            val level2_2 = Level2().apply { name = "l2_2" }
+            val level3_1 = Level3().apply { name = "l3_1" }
+            val level3_2 = Level3().apply { name = "l3_2" }
+
+            level1_1.list.add(level2_1)
+            level1_2.list.addAll(listOf(level2_1, level2_2))
+
+            level2_1.list.add(level3_1)
+            level2_2.list.addAll(listOf(level3_1, level3_2))
+
+            level3_1.list.add(level1_1)
+            level3_2.list.addAll(listOf(level1_1, level1_2))
+
+            copyToRealm(level1_2) // this includes the graph of all 6 objects
+        }
+
+        val objectsL1: RealmResults<Level1> =
+            realm.objects<Level1>().query("name BEGINSWITH \"l\" SORT(name ASC)")
+        val objectsL2: RealmResults<Level2> =
+            realm.objects<Level2>().query("name BEGINSWITH \"l\" SORT(name ASC)")
+        val objectsL3: RealmResults<Level3> =
+            realm.objects<Level3>().query("name BEGINSWITH \"l\" SORT(name ASC)")
+
+        assertEquals(2, objectsL1.count())
+        assertEquals(2, objectsL2.count())
+        assertEquals(2, objectsL3.count())
+
+        // Checking insertion order is honoured
+        assertEquals("l1_1", objectsL1[0].name)
+        assertEquals(1, objectsL1[0].list.size)
+        assertEquals("l2_1", objectsL1[0].list[0].name)
+
+        assertEquals("l1_2", objectsL1[1].name)
+        assertEquals(2, objectsL1[1].list.size)
+        assertEquals("l2_1", objectsL1[1].list[0].name)
+        assertEquals("l2_2", objectsL1[1].list[1].name)
+
+        assertEquals("l2_1", objectsL2[0].name)
+        assertEquals(1, objectsL2[0].list.size)
+        assertEquals("l3_1", objectsL2[0].list[0].name)
+
+        assertEquals("l2_2", objectsL2[1].name)
+        assertEquals(2, objectsL2[1].list.size)
+        assertEquals("l3_1", objectsL2[1].list[0].name)
+        assertEquals("l3_2", objectsL2[1].list[1].name)
+
+        assertEquals("l3_1", objectsL3[0].name)
+        assertEquals(1, objectsL3[0].list.size)
+        assertEquals("l1_1", objectsL3[0].list[0].name)
+
+        assertEquals("l3_2", objectsL3[1].name)
+        assertEquals(2, objectsL3[1].list.size)
+        assertEquals("l1_1", objectsL3[1].list[0].name)
+        assertEquals("l1_2", objectsL3[1].list[1].name)
+
+        // Following circular links
+        assertEquals("l1_1", objectsL1[0].name)
+        assertEquals(1, objectsL1[0].list.size)
+        assertEquals("l2_1", objectsL1[0].list[0].name)
+        assertEquals(1, objectsL1[0].list[0].list.size)
+        assertEquals("l3_1", objectsL1[0].list[0].list[0].name)
+        assertEquals("l1_1", objectsL1[0].list[0].list[0].list[0].name)
+    }
+
+    @Test
+    fun copyToRealm() {
+        for (tester in managedTesters) {
+            tester.copyToRealm()
+        }
     }
 
     @Test
@@ -217,6 +298,7 @@ class RealmListTests {
 internal interface ListApiTester {
 
     override fun toString(): String
+    fun copyToRealm()
     fun get()
     fun getFailsIfClosed(realm: Realm)
     fun addWithIndex()
@@ -268,6 +350,11 @@ internal interface TypeSafetyManager<T> {
     override fun toString(): String // Default implementation not allowed as it comes from "Any"
     fun createContainerAndGetList(realm: MutableRealm? = null): RealmList<T>
     fun getInitialDataSet(): List<T>
+
+    fun createPrePopulatedContainer(dataSet: List<T>): RealmListContainer =
+        RealmListContainer().also {
+            property.get(it).apply { addAll(dataSet) }
+        }
 
     fun getList(container: RealmListContainer): RealmList<T> = property.get(container)
 }
@@ -383,6 +470,27 @@ internal abstract class ManagedListTester<T>(
 
     override fun toString(): String = "Managed-$typeSafetyManager"
 
+    override fun copyToRealm() {
+        val dataSet = typeSafetyManager.getInitialDataSet()
+
+        val assertions = { container: RealmListContainer ->
+            dataSet.forEachIndexed { index, t ->
+                assertElementsAreEqual(t, typeSafetyManager.getList(container)[index])
+            }
+        }
+
+        errorCatcher {
+            val container = typeSafetyManager.createPrePopulatedContainer(dataSet)
+
+            realm.writeBlocking {
+                val managedContainer = copyToRealm(container)
+                assertions(managedContainer)
+            }
+        }
+
+        assertContainerAndCleanup { container -> assertions(container) }
+    }
+
     override fun get() {
         val dataSet = typeSafetyManager.getInitialDataSet()
         val assertions = { list: RealmList<T> ->
@@ -409,7 +517,7 @@ internal abstract class ManagedListTester<T>(
             }
         }
 
-        assertAndCleanup { list -> assertions(list) }
+        assertListAndCleanup { list -> assertions(list) }
     }
 
     override fun getFailsIfClosed(realm: Realm) {
@@ -465,7 +573,7 @@ internal abstract class ManagedListTester<T>(
             }
         }
 
-        assertAndCleanup { list -> assertions(list) }
+        assertListAndCleanup { list -> assertions(list) }
     }
 
     override fun addWithIndexFailsIfClosed(realm: Realm) {
@@ -535,7 +643,7 @@ internal abstract class ManagedListTester<T>(
             }
         }
 
-        assertAndCleanup { list -> assertions(list) }
+        assertListAndCleanup { list -> assertions(list) }
     }
 
     override fun addAllWithIndexFailsIfClosed(realm: Realm) {
@@ -571,7 +679,7 @@ internal abstract class ManagedListTester<T>(
             }
         }
 
-        assertAndCleanup { list -> assertions(list) }
+        assertListAndCleanup { list -> assertions(list) }
     }
 
     override fun clearFailsIfClosed(realm: Realm) {
@@ -623,7 +731,7 @@ internal abstract class ManagedListTester<T>(
             }
         }
 
-        assertAndCleanup { list -> assertions(list) }
+        assertListAndCleanup { list -> assertions(list) }
     }
 
     override fun removeAtFailsIfClosed(realm: Realm) {
@@ -673,7 +781,7 @@ internal abstract class ManagedListTester<T>(
             }
         }
 
-        assertAndCleanup { list -> assertions(list) }
+        assertListAndCleanup { list -> assertions(list) }
     }
 
     override fun setFailsIfClosed(realm: Realm) {
@@ -693,13 +801,27 @@ internal abstract class ManagedListTester<T>(
     }
 
     // Retrieves the list again but this time from Realm to check the getter is called correctly
-    private fun assertAndCleanup(assertion: (RealmList<T>) -> Unit) {
+    private fun assertListAndCleanup(assertion: (RealmList<T>) -> Unit) {
         val container = realm.objects<RealmListContainer>().first()
         val list = typeSafetyManager.getList(container)
 
         // Assert
         errorCatcher {
             assertion(list)
+        }
+
+        // Clean up
+        realm.writeBlocking {
+            delete(container)
+        }
+    }
+
+    private fun assertContainerAndCleanup(assertion: (RealmListContainer) -> Unit) {
+        val container = realm.objects<RealmListContainer>().first()
+
+        // Assert
+        errorCatcher {
+            assertion(container)
         }
 
         // Clean up

--- a/test/src/commonMain/kotlin/test/list/RealmListContainer.kt
+++ b/test/src/commonMain/kotlin/test/list/RealmListContainer.kt
@@ -76,3 +76,19 @@ class RealmListContainer : RealmObject {
         ).toMap()
     }
 }
+
+// Circular dependencies with lists
+class Level1 : RealmObject {
+    var name: String = ""
+    var list: RealmList<Level2> = RealmList()
+}
+
+class Level2 : RealmObject {
+    var name: String = ""
+    var list: RealmList<Level3> = RealmList()
+}
+
+class Level3 : RealmObject {
+    var name: String = ""
+    var list: RealmList<Level1> = RealmList()
+}


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/334.

Fixed bug that prevented us from storing prepopulated lists (whether of primitive type or objects) using `copyToRealm`.