### PR TITLE
Dokka cleanups

### DIFF
--- a/packages/library/build.gradle.kts
+++ b/packages/library/build.gradle.kts
@@ -217,7 +217,8 @@ realmPublish {
 }
 
 tasks.dokkaHtml.configure {
-    moduleName.set("realm-kotlin")
+    moduleName.set("Realm Kotlin Multiplatform SDK")
+    moduleVersion.set(Realm.version)
     dokkaSourceSets {
         configureEach {
             moduleVersion.set(Realm.version)

--- a/packages/library/build.gradle.kts
+++ b/packages/library/build.gradle.kts
@@ -217,7 +217,7 @@ realmPublish {
 }
 
 tasks.dokkaHtml.configure {
-    moduleName.set("Realm Kotlin Multiplatform SDK")
+    moduleName.set("realm-kotlin")
     dokkaSourceSets {
         configureEach {
             moduleVersion.set(Realm.version)
@@ -227,9 +227,14 @@ tasks.dokkaHtml.configure {
                 matchingRegex.set("io\\.realm\\.internal\\.*")
                 suppress.set(true)
             }
+            jdkVersion.set(8)
         }
         val commonMain by getting {
-            includes.from("overview.md", "io.realm.md")
+            includes.from(
+                "overview.md",
+                "src/commonMain/kotlin/io/realm/info.md",
+                "src/commonMain/kotlin/io/realm/log/info.md"
+            )
             sourceRoot("../runtime-api/src/commonMain/kotlin")
         }
     }

--- a/packages/library/io.realm.md
+++ b/packages/library/io.realm.md
@@ -1,5 +1,0 @@
-# Package io.realm
-
-Info for package realm
-
-// TODO Write meaningful docs when API settles a bit more

--- a/packages/library/overview.md
+++ b/packages/library/overview.md
@@ -1,7 +1,1 @@
-# Module Realm Kotlin SDK
-
-Realm Kotlin Multiplatform SDK
-
-// TODO Write meaningful docs when API settles a bit more
-
-
+# Module realm-kotlin

--- a/packages/library/overview.md
+++ b/packages/library/overview.md
@@ -1,1 +1,1 @@
-# Module realm-kotlin
+# Module Realm Kotlin Multiplatform SDK

--- a/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
@@ -69,7 +69,7 @@ public abstract class BaseRealm internal constructor(
     /**
      * Returns the results of querying for all objects of a specific type.
      *
-     * For a [Realm] instance this will reflect the state of the Realm at the invocation time, thus
+     * For a [Realm] instance this reflects the state of the realm at the invocation time, thus
      * the results will not change on updates to the Realm. For a [MutableRealm] the result is live
      * and will in fact reflect updates to the [MutableRealm].
      *

--- a/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
@@ -54,7 +54,7 @@ public abstract class BaseRealm internal constructor(
         }
 
     /**
-     * The current version of the data in this Realm.
+     * The current version of the data in this realm.
      */
     // TODO Could be abstracted into base implementation of RealmLifeCycle!?
     public var version: VersionId = VersionId(0)

--- a/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
@@ -35,7 +35,7 @@ public abstract class BaseRealm internal constructor(
 ) {
 
     companion object {
-        private const val observablesNotSupportMessage = "Observing changes are not supported by this Realm."
+        private const val observablesNotSupportedMessage = "Observing changes are not supported by this Realm."
     }
 
     /**
@@ -54,7 +54,7 @@ public abstract class BaseRealm internal constructor(
         }
 
     /**
-     * The current version of this Realm and data fetched from it.
+     * The current version of the data in this Realm.
      */
     // TODO Could be abstracted into base implementation of RealmLifeCycle!?
     public var version: VersionId = VersionId(0)
@@ -72,6 +72,9 @@ public abstract class BaseRealm internal constructor(
      * For a [Realm] instance this will reflect the state of the Realm at the invocation time, thus
      * the results will not change on updates to the Realm. For a [MutableRealm] the result is live
      * and will in fact reflect updates to the [MutableRealm].
+     *
+     * @param clazz The class of the objects to query for.
+     * @return The result of the query as of the time of invoking this method.
      */
     open fun <T : RealmObject> objects(clazz: KClass<T>): RealmResults<T> {
         // Use same reference through out all operations to avoid locking
@@ -88,39 +91,44 @@ public abstract class BaseRealm internal constructor(
      * Returns the results of querying for all objects of a specific type.
      *
      * Convenience inline method to catch the reified class type of single argument variant of [objects].
-    */
+     *
+     * @param T The type of the objects to query for.
+     * @return The result of the query. Dependent of the type of the Realm this will either reflect
+     * for [Realm]: the state at invocation or for [MutableRealm] the latest updated state of the
+     * mutable realm.
+     */
     inline fun <reified T : RealmObject> objects(): RealmResults<T> { return objects(T::class) }
 
     internal open fun <T : RealmObject> registerResultsChangeListener(
         results: RealmResults<T>,
         callback: Callback<RealmResults<T>>
     ): Cancellable {
-        throw NotImplementedError(observablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportedMessage)
     }
 
     internal open fun <T : RealmObject> registerListChangeListener(
         list: List<T>,
         callback: Callback<List<T>>
     ): Cancellable {
-        throw NotImplementedError(observablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportedMessage)
     }
 
     internal open fun <T : RealmObject> registerObjectChangeListener(
         obj: T,
         callback: Callback<T?>
     ): Cancellable {
-        throw NotImplementedError(observablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportedMessage)
     }
 
     internal open fun <T : RealmObject> registerResultsObserver(results: RealmResults<T>): Flow<RealmResults<T>> {
-        throw NotImplementedError(observablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportedMessage)
     }
     internal open fun <T : RealmObject> registerListObserver(list: List<T>): Flow<List<T>> {
-        throw NotImplementedError(observablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportedMessage)
     }
 
     internal open fun <T : RealmObject> registerObjectObserver(obj: T): Flow<T> {
-        throw NotImplementedError(observablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportedMessage)
     }
 
     /**

--- a/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
 /**
- * Base class for all Realm instances.
+ * Base class for all Realm instances ([Realm] and [MutableRealm]).
  */
 @Suppress("UnnecessaryAbstractClass")
 public abstract class BaseRealm internal constructor(
@@ -35,7 +35,7 @@ public abstract class BaseRealm internal constructor(
 ) {
 
     companion object {
-        const val observerablesNotSupportMessage = "Observing changes are not supported by this Realm."
+        private const val observablesNotSupportMessage = "Observing changes are not supported by this Realm."
     }
 
     /**
@@ -54,7 +54,7 @@ public abstract class BaseRealm internal constructor(
         }
 
     /**
-     * The current data version of this Realm and data fetched from it.
+     * The current version of this Realm and data fetched from it.
      */
     // TODO Could be abstracted into base implementation of RealmLifeCycle!?
     public var version: VersionId = VersionId(0)
@@ -66,7 +66,14 @@ public abstract class BaseRealm internal constructor(
         log.info("Realm opened: ${configuration.path}")
     }
 
-    fun <T : RealmObject> objects(clazz: KClass<T>): RealmResults<T> {
+    /**
+     * Returns the results of querying for all objects of a specific type.
+     *
+     * For a [Realm] instance this will reflect the state of the Realm at the invocation time, thus
+     * the results will not change on updates to the Realm. For a [MutableRealm] the result is live
+     * and will in fact reflect updates to the [MutableRealm].
+     */
+    open fun <T : RealmObject> objects(clazz: KClass<T>): RealmResults<T> {
         // Use same reference through out all operations to avoid locking
         val realmReference = this.realmReference
         realmReference.checkClosed()
@@ -77,39 +84,43 @@ public abstract class BaseRealm internal constructor(
             configuration.mediator
         )
     }
-    // Convenience inline method for the above to skip KClass argument
+    /**
+     * Returns the results of querying for all objects of a specific type.
+     *
+     * Convenience inline method to catch the reified class type of single argument variant of [objects].
+    */
     inline fun <reified T : RealmObject> objects(): RealmResults<T> { return objects(T::class) }
 
     internal open fun <T : RealmObject> registerResultsChangeListener(
         results: RealmResults<T>,
         callback: Callback<RealmResults<T>>
     ): Cancellable {
-        throw NotImplementedError(observerablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportMessage)
     }
 
     internal open fun <T : RealmObject> registerListChangeListener(
         list: List<T>,
         callback: Callback<List<T>>
     ): Cancellable {
-        throw NotImplementedError(observerablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportMessage)
     }
 
     internal open fun <T : RealmObject> registerObjectChangeListener(
         obj: T,
         callback: Callback<T?>
     ): Cancellable {
-        throw NotImplementedError(observerablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportMessage)
     }
 
     internal open fun <T : RealmObject> registerResultsObserver(results: RealmResults<T>): Flow<RealmResults<T>> {
-        throw NotImplementedError(observerablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportMessage)
     }
     internal open fun <T : RealmObject> registerListObserver(list: List<T>): Flow<List<T>> {
-        throw NotImplementedError(observerablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportMessage)
     }
 
     internal open fun <T : RealmObject> registerObjectObserver(obj: T): Flow<T> {
-        throw NotImplementedError(observerablesNotSupportMessage)
+        throw NotImplementedError(observablesNotSupportMessage)
     }
 
     /**

--- a/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
@@ -34,7 +34,7 @@ public abstract class BaseRealm internal constructor(
     dbPointer: NativePointer
 ) {
 
-    companion object {
+    private companion object {
         private const val observablesNotSupportedMessage = "Observing changes are not supported by this Realm."
     }
 

--- a/packages/library/src/commonMain/kotlin/io/realm/Callback.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/Callback.kt
@@ -16,7 +16,10 @@
 
 package io.realm
 
-fun interface Callback<T> {
+/**
+ * A `callback` interface to receive notifications about updates.
+ */
+internal fun interface Callback<T> {
     fun onChange(result: T)
     // FIXME API-NOTIFICATION Consider adding an onError(throwable: Throwable)
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/Cancellable.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/Cancellable.kt
@@ -16,6 +16,9 @@
 
 package io.realm
 
-interface Cancellable {
+/**
+ * A _cancellable_ representing ongoing tasks or subscription that can be cancelled.
+ */
+internal interface Cancellable {
     fun cancel()
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -32,7 +32,7 @@ import kotlin.reflect.KClass
  * All objects created and/or obtained from the _mutable realm_ in a write-transaction are bound to
  * the thread executing the transaction and all operations on the _mutable realm_ or on any of the
  * objects must be done on the thread executing the transaction. Only exception are objects returned
- * from [Realm.write] and [Realm.writeBlocking] which will be frozen and kept tied to resulting
+ * from [Realm.write] and [Realm.writeBlocking] which will be frozen and kept tied to the resulting
  * version of the write-transaction.
  */
 class MutableRealm : BaseRealm {

--- a/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -155,6 +155,9 @@ class MutableRealm : BaseRealm {
      * The result is live and are thus also reflecting any update to the MutableRealm.
      *
      * The result is only valid on the calling thread.
+     *
+     * @param clazz The class of the objects to query for.
+     * @return The result of the query, reflecting future updates to the mutable realm.
      */
     override fun <T : RealmObject> objects(clazz: KClass<T>): RealmResults<T> {
         return super.objects(clazz)

--- a/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -23,9 +23,17 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
 /**
- * This class represents the writeable state of a Realm file. The only way to modify data in a Realm is through
- * instances of this class. These are provided and managed automatically through either [Realm.write] or
+ * Represents the writeable state of a Realm file.
+ *
+ * The only way to modify data in a Realm is through instances of this class.
+ * These are provided and managed automatically through either [Realm.write] or
  * [Realm.writeBlocking].
+ *
+ * All objects created and/or obtained from the _mutable realm_ in a write-transaction are bound to
+ * the thread executing the transaction and all operations on the _mutable realm_ or on any of the
+ * objects must be done on the thread executing the transaction. Only exception are objects returned
+ * from [Realm.write] and [Realm.writeBlocking] which will be frozen and kept tied to resulting
+ * version of the write-transaction.
  */
 class MutableRealm : BaseRealm {
 
@@ -134,9 +142,24 @@ class MutableRealm : BaseRealm {
      * @param instance The object to create a copy from.
      * @return The managed version of the `instance`.
      */
+    // FIXME Due to lack of throwing C-API this will not throw on duplicate keys, so this
+    //  currently effectively mimics the copyOrUpdate API from realm-java.
+    //  https://github.com/realm/realm-kotlin/issues/192
     fun <T : RealmObject> copyToRealm(instance: T): T {
         return io.realm.internal.copyToRealm(configuration.mediator, realmReference, instance)
     }
+
+    /**
+     * Returns the results of querying for all objects of a specific type.
+     *
+     * The result is live and are thus also reflecting any update to the MutableRealm.
+     *
+     * The result is only valid on the calling thread.
+     */
+    override fun <T : RealmObject> objects(clazz: KClass<T>): RealmResults<T> {
+        return super.objects(clazz)
+    }
+
     /**
      * Deletes the object from the underlying Realm.
      *
@@ -153,30 +176,30 @@ class MutableRealm : BaseRealm {
     //  https://github.com/realm/realm-kotlin/issues/64
     // fun <T : RealmModel> delete(clazz: KClass<T>)
 
-    override fun <T : RealmObject> registerResultsObserver(results: RealmResults<T>): Flow<RealmResults<T>> {
+    internal override fun <T : RealmObject> registerResultsObserver(results: RealmResults<T>): Flow<RealmResults<T>> {
         throw IllegalStateException("Changes to RealmResults cannot be observed during a write.")
     }
 
-    override fun <T : RealmObject> registerListObserver(list: List<T>): Flow<List<T>> {
+    internal override fun <T : RealmObject> registerListObserver(list: List<T>): Flow<List<T>> {
         throw IllegalStateException("Changes to RealmList cannot be observed during a write.")
     }
 
-    override fun <T : RealmObject> registerObjectObserver(obj: T): Flow<T> {
+    internal override fun <T : RealmObject> registerObjectObserver(obj: T): Flow<T> {
         throw IllegalStateException("Changes to RealmObject cannot be observed during a write.")
     }
 
-    override fun <T : RealmObject> registerResultsChangeListener(
+    internal override fun <T : RealmObject> registerResultsChangeListener(
         results: RealmResults<T>,
         callback: Callback<RealmResults<T>>
     ): Cancellable {
         throw IllegalStateException("Changes to RealmResults cannot be observed during a write.")
     }
 
-    override fun <T : RealmObject> registerListChangeListener(list: List<T>, callback: Callback<List<T>>): Cancellable {
+    internal override fun <T : RealmObject> registerListChangeListener(list: List<T>, callback: Callback<List<T>>): Cancellable {
         throw IllegalStateException("Changes to RealmResults cannot be observed during a write.")
     }
 
-    override fun <T : RealmObject> registerObjectChangeListener(obj: T, callback: Callback<T?>): Cancellable {
+    internal override fun <T : RealmObject> registerObjectChangeListener(obj: T, callback: Callback<T?>): Cancellable {
         throw IllegalStateException("Changes to RealmResults cannot be observed during a write.")
     }
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/PrimaryKey.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/PrimaryKey.kt
@@ -26,6 +26,6 @@ package io.realm
  * identify the object.
  *
  * It is allowed to apply this annotation on the following primitive types: String, Byte, Char,
- * Short, Int, and Long and are permitted to have null as a primary key value.
+ * Short, Int, and Long, as well as their nullable variants.
  */
 annotation class PrimaryKey

--- a/packages/library/src/commonMain/kotlin/io/realm/PrimaryKey.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/PrimaryKey.kt
@@ -26,6 +26,6 @@ package io.realm
  * identify the object.
  *
  * It is allowed to apply this annotation on the following primitive types: String, Byte, Char,
- * Short, Int, and Long, as well as their nullable variants.
+ * Short, Int and Long, as well as their nullable variants.
  */
 annotation class PrimaryKey

--- a/packages/library/src/commonMain/kotlin/io/realm/PrimaryKey.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/PrimaryKey.kt
@@ -19,4 +19,13 @@ package io.realm
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.FIELD)
 @MustBeDocumented
+/**
+ * Annotation marking a field as a primary key inside Realm.
+ *
+ * Only one field in a RealmObject class can have this annotation, and the field should uniquely
+ * identify the object.
+ *
+ * It is allowed to apply this annotation on the following primitive types: String, Byte, Char,
+ * Short, Int, and Long and are permitted to have null as a primary key value.
+ */
 annotation class PrimaryKey

--- a/packages/library/src/commonMain/kotlin/io/realm/Queryable.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/Queryable.kt
@@ -24,8 +24,6 @@ package io.realm
 //  https://github.com/realm/realm-kotlin/issues/206
 /**
  * Interface holding common query methods.
- *
- * Will most likely change in the future.
  */
 interface Queryable<T : RealmObject> {
     fun query(query: String = "TRUEPREDICATE", vararg args: Any): RealmResults<T>

--- a/packages/library/src/commonMain/kotlin/io/realm/Queryable.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/Queryable.kt
@@ -21,7 +21,12 @@ package io.realm
 //    dependent on how the final API is going to look like.
 //  - Query could alternatively be separated into builder to await constructing new results until
 //    actually executing the query
-// FIXME Is this deprecated?
+//  https://github.com/realm/realm-kotlin/issues/206
+/**
+ * Interface holding common query methods.
+ *
+ * Will most likely change in the future.
+ */
 interface Queryable<T : RealmObject> {
     fun query(query: String = "TRUEPREDICATE", vararg args: Any): RealmResults<T>
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/Queryable.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/Queryable.kt
@@ -21,6 +21,7 @@ package io.realm
 //    dependent on how the final API is going to look like.
 //  - Query could alternatively be separated into builder to await constructing new results until
 //    actually executing the query
+// FIXME Is this deprecated?
 interface Queryable<T : RealmObject> {
     fun query(query: String = "TRUEPREDICATE", vararg args: Any): RealmResults<T>
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/Realm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/Realm.kt
@@ -34,7 +34,14 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.reflect.KClass
 
+/**
+ * Main entry point for interacting with the persisted Realm store.
+ *
+ * @see Realm.open
+ * @see RealmConfiguration
+ */
 // TODO API-PUBLIC Document platform specific internals (RealmInitializer, etc.)
 class Realm private constructor(configuration: RealmConfiguration, dbPointer: NativePointer) :
     BaseRealm(configuration, dbPointer) {
@@ -112,8 +119,20 @@ class Realm private constructor(configuration: RealmConfiguration, dbPointer: Na
      *  this constructor should be the primary way to open Realms (as you only need
      *  to do it once pr. app).
      */
+    // FIXME This is not updated to the frozen architecture. Which way to go? Towards Realm.open or
+    //  move logic from Realm.open to this constructor?
     public constructor(configuration: RealmConfiguration) :
         this(configuration, RealmInterop.realm_open(configuration.nativeConfig))
+
+    /**
+     * Returns the results of querying for all objects of a specific type.
+     *
+     * The result is reflecting the state of the Realm at the invocation time, thus the results
+     * will not change on updates to the Realm.
+     */
+    override fun <T : RealmObject> objects(clazz: KClass<T>): RealmResults<T> {
+        return super.objects(clazz)
+    }
 
     /**
      * Modify the underlying Realm file in a suspendable transaction on the default Realm Write

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -70,15 +70,55 @@ public class RealmConfiguration private constructor(
     deleteRealmIfMigrationNeeded: Boolean,
 ) {
     // Public properties making up the RealmConfiguration
-    // TODO Add KDoc for all of these
+    // TODO Add more elaborate KDoc for all of these
+    /**
+     * Path to the realm file.
+     */
     public val path: String
+
+    /**
+     * Filename of the realm file.
+     */
     public val name: String
+
+    /**
+     * The set of classes included in the schema for the realm.
+     */
     public val schema: Set<KClass<out RealmObject>>
+
+    /**
+     * The log configuration used for the realm instance.
+     */
     public val log: LogConfiguration
+
+    /**
+     * Maximum number of active versions.
+     *
+     * Holding references to objects from previous version of the data in the realm will also
+     * require keeping the data in the actual file. This can cause growth of the file. See
+     * [Builder.maxNumberOfActiveVersions] for details.
+     */
     public val maxNumberOfActiveVersions: Long
+
+    /**
+     * The coroutine dispatcher for internal handling of notification registration and delivery.
+     */
     public val notificationDispatcher: CoroutineDispatcher
+
+    /**
+     * The coroutine dispatcher used for all write operations.
+     */
     public val writeDispatcher: CoroutineDispatcher
+
+    /**
+     * The schema version.
+     */
     public val schemaVersion: Long
+
+    /**
+     * Flag indicating whether the realm will be deleted if the schema has changed in a way that
+     * requires schema migration.
+     */
     public val deleteRealmIfMigrationNeeded: Boolean
 
     // Internal properties used by other Realm components, but does not make sense for the end user to know about

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -33,7 +33,6 @@ import kotlin.reflect.KClass
 /**
  * Configuration for log events created by a Realm instance.
  */
-// FIXME Any reason for this to be public?
 public data class LogConfiguration(
     /**
      * The [LogLevel] for which all log events of equal or higher priority will be reported.

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -33,6 +33,7 @@ import kotlin.reflect.KClass
 /**
  * Configuration for log events created by a Realm instance.
  */
+// FIXME Any reason for this to be public?
 public data class LogConfiguration(
     /**
      * The [LogLevel] for which all log events of equal or higher priority will be reported.
@@ -46,6 +47,16 @@ public data class LogConfiguration(
     public val loggers: List<RealmLogger>
 )
 
+/**
+ * A _Realm Configuration_ defining specific setup and configuration for a Realm instance.
+ *
+ * The RealmConfiguration can, for simple uses cases, be created directly through the constructor,
+ * while more advanced setup requires building the RealmConfiguration through
+ * [RealmConfiguration.Builder.build].
+ *
+ * @see Realm.open
+ * @see RealmConfiguration.Builder
+ */
 @Suppress("LongParameterList")
 public class RealmConfiguration private constructor(
     companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>,

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -229,9 +229,31 @@ public class RealmConfiguration private constructor(
         private var deleteRealmIfMigrationNeeded: Boolean = false
         private var schemaVersion: Long = 0
 
+        /**
+         * Sets the absolute path of the realm file.
+         */
         fun path(path: String) = apply { this.path = path }
+
+        /**
+         * Sets the filename of the realm file.
+         */
         fun name(name: String) = apply { this.name = name }
+
+        /**
+         * Sets the classes of the schema.
+         *
+         * The elements of the set must be direct class literals.
+         *
+         * @param classes The set of classes that the schema consists of.
+         */
         fun schema(classes: Set<KClass<out RealmObject>>) = apply { this.schema = classes }
+        /**
+         * Sets the classes of the schema.
+         *
+         * The `classes` arguments must be direct class literals.
+         *
+         * @param classes The classes that the schema consists of.
+         */
         fun schema(vararg classes: KClass<out RealmObject>) =
             apply { this.schema = setOf(*classes) }
 
@@ -328,6 +350,11 @@ public class RealmConfiguration private constructor(
          */
         internal fun removeSystemLogger() = apply { this.removeSystemLogger = true }
 
+        /**
+         * Creates the RealmConfiguration based on the builder properties.
+         *
+         * @return the created RealmConfiguration.
+         */
         fun build(): RealmConfiguration {
             REPLACED_BY_IR()
         }

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -30,6 +30,14 @@ import kotlin.reflect.KClass
  */
 interface RealmObject
 
+/**
+ * Returns whether the object is frozen or not.
+ *
+ * A frozen object is tied to a specific version of the data in the realm and fields retrieved
+ * from this object instance will not update even if the object is updated in the Realm.
+ *
+ * @return true if the object is frozen, false otherwise.
+ */
 public fun RealmObject.isFrozen(): Boolean {
     val internalObject = this as RealmObjectInternal
     internalObject.`$realm$ObjectPointer`?.let {
@@ -57,6 +65,12 @@ public var RealmObject.version: VersionId
         throw UnsupportedOperationException("Setter is required by the Kotlin Compiler, but should not be called directly")
     }
 
+/**
+ * Deletes the RealmObject.
+ *
+ * @throws InvalidArgumentException if invoked on an invalid object
+ * @throws RuntimeException if invoked outside of a [Realm.write] or [Realm.writeBlocking] block.
+ */
 // FIXME API Currently just adding these as extension methods as putting them directly into
 //  RealmModel would break compiler plugin. Reiterate along with
 //  https://github.com/realm/realm-kotlin/issues/83

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
@@ -90,8 +90,9 @@ class RealmResults<T : RealmObject> : AbstractList<T>, Queryable<T> {
     /**
      * Perform a query on the objects of this result using the Realm Query Language.
      *
-     * See [these docs][https://docs.mongodb.com/realm-sdks/java/latest/io/realm/RealmQuery.html#rawPredicate-java.lang.String-java.lang.Object...-]
-     * for a description and [these docs][https://docs.mongodb.com/realm-sdks/js/latest/tutorial-query-language.html]
+     * See [these docs](https://docs.mongodb.com/realm-sdks/java/latest/io/realm/RealmQuery.html#rawPredicate-java.lang.String-java.lang.Object...-)
+     * for a description of the equivalent realm-java API and
+     * [these docs](https://docs.mongodb.com/realm-sdks/js/latest/tutorial-query-language.html)
      * for a more detailed description of the actual Realm Query Language.
      *
      * Ex.:

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
@@ -30,6 +30,12 @@ import kotlin.reflect.KClass
 //  - Lazy API makes it harded to debug
 //  - Postponing execution to actually accessing the elements also prevents query parser errors to
 //    be raised. Maybe we can get an option to prevalidate queries in the C-API?
+/**
+ * A _Realm Result_ holds the results of querying the Realm.
+ *
+ * @see Realm.objects
+ * @see MutableRealm.objects
+ */
 class RealmResults<T : RealmObject> : AbstractList<T>, Queryable<T> {
 
     private val mode: Mode

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
@@ -69,6 +69,9 @@ class RealmResults<T : RealmObject> : AbstractList<T>, Queryable<T> {
         }
     }
 
+    /**
+     * The current version of the data in this Realm.
+     */
     public fun version(): VersionId {
         return realm.owner.version
     }
@@ -84,10 +87,20 @@ class RealmResults<T : RealmObject> : AbstractList<T>, Queryable<T> {
         return model as T
     }
 
-    // Query string follows the Swift/JS filter/sort-syntax as described in
-    // https://realm.io/docs/javascript/latest/#filtering
-    // Ex.:
-    //   'color = "tan" AND name BEGINSWITH "B" SORT(name DESC) LIMIT(5)'
+    /**
+     * Perform a query on the objects of this result using the Realm Query Language.
+     *
+     * See [these docs][https://docs.mongodb.com/realm-sdks/java/latest/io/realm/RealmQuery.html#rawPredicate-java.lang.String-java.lang.Object...-]
+     * for a description and [these docs][https://docs.mongodb.com/realm-sdks/js/latest/tutorial-query-language.html]
+     * for a more detailed description of the actual Realm Query Language.
+     *
+     * Ex.:
+     *  `'color = "tan" AND name BEGINSWITH "B" SORT(name DESC) LIMIT(5)`
+     *
+     * @param query The query string to use for filtering and sort.
+     * @param args The query parameters.
+     * @return new result according to the query and query arguments.
+     */
     @Suppress("SpreadOperator")
     override fun query(query: String, vararg args: Any): RealmResults<T> {
         return fromQuery(

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
@@ -124,6 +124,9 @@ class RealmResults<T : RealmObject> : AbstractList<T>, Queryable<T> {
         return realm.owner.registerResultsObserver(this)
     }
 
+    /**
+     * Delete all objects from this result from the realm.
+     */
     fun delete() {
         // TODO OPTIMIZE Are there more efficient ways to do this? realm_query_delete_all is not
         //  available in C-API yet, but should probably await final query design

--- a/packages/library/src/commonMain/kotlin/io/realm/VersionId.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/VersionId.kt
@@ -16,6 +16,8 @@
 package io.realm
 
 /**
+ * A `VersionId` representing the transactional id of the Realm itself or it's objects.
+ *
  * Realm is an [MVCC](https://en.wikipedia.org/wiki/Multiversion_concurrency_control) database. This means that at any
  * given time, multiple version of data can be visible. This class describes the version of such data.
  *

--- a/packages/library/src/commonMain/kotlin/io/realm/info.md
+++ b/packages/library/src/commonMain/kotlin/io/realm/info.md
@@ -1,0 +1,4 @@
+# Package io.realm
+
+Core functions and types.
+

--- a/packages/library/src/commonMain/kotlin/io/realm/log/LogLevel.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/log/LogLevel.kt
@@ -1,10 +1,14 @@
 package io.realm.log
 
+import io.realm.RealmConfiguration
+
 /**
  * Enum describing the log levels available to Realms internal logger.
  *
  * Each log entry is assigned a priority between [TRACE] and [WTF]. If the log level is equal or higher
  * than the priority defined in [io.realm.RealmConfiguration.Builder.logLevel] the event will be logged.
+ *
+ * @see RealmConfiguration.Builder.log
  */
 @Suppress("MagicNumber")
 public enum class LogLevel(internal val priority: Int) {

--- a/packages/library/src/commonMain/kotlin/io/realm/log/RealmLogger.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/log/RealmLogger.kt
@@ -1,7 +1,10 @@
 package io.realm.log
 
+import io.realm.RealmConfiguration
 /**
  * Interface describing a logger implementation.
+ *
+ * @see [RealmConfiguration.Builder.log]
  */
 interface RealmLogger {
 

--- a/packages/library/src/commonMain/kotlin/io/realm/log/RealmLogger.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/log/RealmLogger.kt
@@ -4,7 +4,7 @@ import io.realm.RealmConfiguration
 /**
  * Interface describing a logger implementation.
  *
- * @see [RealmConfiguration.Builder.log]
+ * @see RealmConfiguration.Builder.log
  */
 interface RealmLogger {
 

--- a/packages/library/src/commonMain/kotlin/io/realm/log/info.md
+++ b/packages/library/src/commonMain/kotlin/io/realm/log/info.md
@@ -1,0 +1,4 @@
+# Package io.realm.log
+
+Logging related functions and types.
+

--- a/test/src/androidTest/kotlin/io/realm/shared/RealmTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/RealmTests.kt
@@ -67,7 +67,7 @@ class RealmTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = configuration
-        realm = Realm.open(configuration)
+        realm = Realm(configuration)
     }
 
     @AfterTest
@@ -382,7 +382,6 @@ class RealmTests {
     }
 
     @Test
-    @Ignore // We currently do not keep track of all intermediate versions
     fun closeClosesAllVersions() {
         runBlocking {
             realm.write { copyToRealm(Parent()) }


### PR DESCRIPTION
Cleaned up package info (#318) and first line doc for classes (#317). 

Still lacking overall descriptive content for `io.realm` and especially `Realm`.

Questions
- [x] Package info.md in root of `packages` or inside `src/commonMain/kotlin`? - Ended up putting package specific info inside package directory. 
- [x] Realm constructor or `Realm.open` ... or both? - Fixed `Realm` constructor, so both works for now
- [x] Internal only (at least for now, or maybe required for native?)
  - [x] Queryable? - Kept is but marked likely for change and referenced issue
  - [x] Cancellable? - Internalized until we expose callback based API as I expect the iOS samples to be updated to use flows 
  - [x] Callback<T>? - Internalized until we expose callback based API as I expect the iOS samples to be updated to use flows
- [ ] Should we try do a check for existing primary key objects to throw on duplicate until C-API is throwing #192 - Will try to see if I can make a quick fix in another PR