### PR TITLE
Fix realm changed notification on native.

### DIFF
--- a/packages/library/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -43,9 +43,9 @@ internal class SuspendableNotifier(private val owner: Realm, private val dispatc
         }
     }
 
-    // FIXME Work-around for the global Realm changed listener not working. Adding extra buffer
-    //  capacity as the realm is processing updates on the same dispatcher, thus cannot make
-    //  rendezvous one the same thread. Should be reworked when global changed listener is in place.
+    // FIXME Work-around for the global Realm changed listener not working.
+    // FIXME Adding extra buffer capacity as we are otherwise never able to emit anything. Needs to
+    //  be investigated.
     // This Flow exposes a stream of changes to the owner Realm
     private val _realmChanged = MutableSharedFlow<RealmReference>(onBufferOverflow = BufferOverflow.SUSPEND, extraBufferCapacity = 1)
 

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -43,9 +43,11 @@ internal class SuspendableNotifier(private val owner: Realm, private val dispatc
         }
     }
 
-    // FIXME Work-around for the global Realm changed listener not working
+    // FIXME Work-around for the global Realm changed listener not working. Adding extra buffer
+    //  capacity as the realm is processing updates on the same dispatcher, thus cannot make
+    //  rendezvous one the same thread. Should be reworked when global changed listener is in place.
     // This Flow exposes a stream of changes to the owner Realm
-    private val _realmChanged = MutableSharedFlow<RealmReference>(onBufferOverflow = BufferOverflow.SUSPEND)
+    private val _realmChanged = MutableSharedFlow<RealmReference>(onBufferOverflow = BufferOverflow.SUSPEND, extraBufferCapacity = 1)
 
     // Must only be accessed from the dispatchers thread
     private val realm: BaseRealm by lazy {


### PR DESCRIPTION
Log message on native introduced in #345 seems to be because the flow cannot deliver events unless `extraBufferCapacity ` is more than 0. Have to investigate why this is the case, but setting to 1 eliminates the error. 