### PR TITLE
Revert to Kotlin 1.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ This new architecture is intended to make it easier to consume and work with Rea
 
 ### Internal
 * Updated `com.gradle.plugin-publish` to 0.15.0.
-* Reverted to Kotlin `1.5.10` to fix a compatibility issue.
 * Updated to Realm Core commit: 4cf63d689ba099057345f122265cbb880a8eb19d.
 * Updated to Android NDK: 22.1.7171670.
 * Introduced usage of `kotlinx.atomicfu`: 0.16.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,27 @@
 ## 0.4.0 (YYYY-MM-DD)
 
-This release contains a big depature in the architectural design of how Realm is currently implemented. At a high level it moves from "Thread-confined, Live Objects" to "Frozen Objects". The reasons for this shift are discussed [here](https://docs.google.com/document/d/1bGfjbKLD6DSBpTiVwyorSBcMqkUQWedAmmS_VAhL8QU/edit#heading=h.fzlh39twuifc). 
+This release contains a big departure in the architectural design of how Realm is currently implemented. At a high level it moves from "Thread-confined, Live Objects" to "Frozen Objects". The reasons for this shift are discussed [here](https://docs.google.com/document/d/1bGfjbKLD6DSBpTiVwyorSBcMqkUQWedAmmS_VAhL8QU/edit#heading=h.fzlh39twuifc).
 
 At a high level this has a number of implications:
 
-    1. Only one Realm instance (per `RealmConfiguration`) is needed across the entire application. 
+    1. Only one Realm instance (per `RealmConfiguration`) is needed across the entire application.
     2. The only reason for closing the Realm instance is if the Realm file itself needs to be deleted or compacted.
     3. Realm objects can be freely moved and read across threads.
-    4. Changes to objects can only be observered through Kotlin Flows. Standard change listener support will come in a future release.
-    5. In order to modify Realm Objects, they need to be "live". It is possible to convert a frozen object to a live object inside a 
+    4. Changes to objects can only be observed through Kotlin Flows. Standard change listener support will come in a future release.
+    5. In order to modify Realm Objects, they need to be "live". It is possible to convert a frozen object to a live object inside a
        write transaction using the `MutableRealm.findLatest(obj)` API. Live objects are not accessible outside write transactions.
 
 This new architecture is intended to make it easier to consume and work with Realm, but at the same time, it also introduces a few caveats:
 
     1. Storing a strong reference to a Realm Object can cause an issue known as "Version pinning". Realm tracks the "distance" between the oldest known version and the latest. So if you store a reference for too long, when other writes are happening, Realm might run out of native memory and crash, or it can lead to an increased file size. It is possible to detect this problem by setting `RealmConfiguration.Builder.maxNumberOfActiveVersions()`. It can be worked around by copying the data out of the Realm and store that instead.
 
-    2. With multiple versions being accessible across threads, it is possible to accidentially compare data from different versions. This could be a potential problem for certain buisness logic if two objects do not agree on a particular state. If you suspect this is an issue, a `version()` method has been added to all Realm Objects, so it can be inspected for debugging. Previously, Realms thread-confined objects guaranteed this would not happen.
-    
-    3. Since the threading model has changed, there is no longer a guarantee that running the same query twice in a row will return the same result. E.g. if a background write executed between them, the result might change. Previously, this would have resulted in the same result as the Realm state for a particular thread would only update as part of the event loop.
+    2. With multiple versions being accessible across threads, it is possible to accidentally compare data from different versions. This could be a potential problem for certain business logic if two objects do not agree on a particular state. If you suspect this is an issue, a `version()` method has been added to all Realm Objects, so it can be inspected for debugging. Previously, Realms thread-confined objects guaranteed this would not happen.
+
+    3. Since the threading model has changed, there is no longer a guarantee that running the same query twice in a row will return the same result. E.g. if a background write is executed between them, the result might change. Previously, this would have resulted in the same result as the Realm state for a particular thread would only update as part of the event loop.
 
 
 ### Breaking Changes
-* The Realm instance itself is now thread safe and can be accessed from any thread. 
+* The Realm instance itself is now thread safe and can be accessed from any thread.
 * Objects queried outside write transactions are now frozen by default and can be freely read from any thread.
 * As a consequence of the above, when a change listener fires, the changed data can only be observed in the new object received, not in the original, which was possible before this release.
 * Removed `Realm.open(configuration: RealmConfiguration)`. Use the interchangeable `Realm(configuration: RealmConfiguration)`-constructor instead.
@@ -29,7 +29,7 @@ This new architecture is intended to make it easier to consume and work with Rea
 
 ### Enhancements
 * A `version()` method has been added to `Realm`, `RealmResults` and `RealmObject`. This returns the version of the data contained. New versions are obtained by observing changes to the object.
-* `Realm.observe()`, `RealmResults.observe()` and `RealmObject.observe()` has been added and expose a Flow of updates to the object.
+* `Realm.observe()`, `RealmResults.observe()` and `RealmObject.observe()` have been added and expose a Flow of updates to the object.
 * Add support for suspending writes executed on the Realm Write Dispatcher with `suspend fun <R> write(block: MutableRealm.() -> R): R`
 * Add support for setting background write and notification dispatchers with `RealmConfigruation.Builder.notificationDispatcher(dispatcher: CoroutineDispatcher)` and `RealmConfiguration.Builder.writeDispatcher(dispatcher: CoroutineDispatcher)`
 * Add support for retrieving the latest version of an object inside a write transaction with `<T : RealmObject> MutableRealm.findLatests(obj: T?): T?`
@@ -38,11 +38,11 @@ This new architecture is intended to make it easier to consume and work with Rea
 * None.
 
 ### Compatibility
-* This release is compatible with Kotlin 1.5.20 and Coroutines 1.5.0.
+* This release is compatible with Kotlin 1.5.10 and Coroutines 1.5.0.
 
 ### Internal
 * Updated `com.gradle.plugin-publish` to 0.15.0.
-* Updated Kotlin support to 1.5.20.
+* Reverted to Kotlin `1.5.10` to fix a compatibility issue.
 * Updated to Realm Core commit: 4cf63d689ba099057345f122265cbb880a8eb19d.
 * Updated to Android NDK: 22.1.7171670.
 * Introduced usage of `kotlinx.atomicfu`: 0.16.1.

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -71,7 +71,7 @@ object Versions {
     const val gradlePluginPublishPlugin = "0.15.0" // https://plugins.gradle.org/plugin/com.gradle.plugin-publish
     const val junit = "4.13.2" // https://mvnrepository.com/artifact/junit/junit
     const val jvmTarget = "1.8"
-    const val kotlin = "1.5.20" // https://github.com/JetBrains/kotlin
+    const val kotlin = "1.5.10" // https://github.com/JetBrains/kotlin
     const val kotlinCompileTesting = "1.4.2" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlintPlugin = "10.1.0" // https://github.com/jlleitschuh/ktlint-gradle
     const val ktlintVersion = "0.41.0" // https://github.com/pinterest/ktlint


### PR DESCRIPTION
Kotlin 1.5.20 causing some incompatibility issues with the Bookshelf app 
```
e: Could not find "/Users/nabil/.gradle/caches/modules-2/files-2.1/io.realm.kotlin/library-iosx64/0.45.0-SNAPSHOT/9f6174f4f610fd23472aa2f0e2d9879584c9ecb5/library.klib" in [/Users/nabil/Dev/realm/KMP/master-2/realm-kotlin-samples/Bookshelf, /Users/nabil/.konan/klib, /Users/nabil/.konan/kotlin-native-prebuilt-macos-1.5.10/klib/common, /Users/nabil/.konan/kotlin-native-prebuilt-macos-1.5.10/klib/platform/ios_x64]

The message received from the daemon indicates that the daemon has disappeared.
Build request sent: Build{id=9ff73205-f03d-4bcd-99a6-25f7b424d5f7, currentDir=/Users/nabil/Dev/realm/KMP/master-2/realm-kotlin-samples/Bookshelf}
Attempting to read last messages from the daemon log...
Daemon pid: 47119
  log file: /Users/nabil/.gradle/daemon/7.0.2/daemon-47119.out.log
----- Last  20 lines from daemon log file - daemon-47119.out.log -----
2021-07-13T14:16:00.759+0100 [DEBUG] [org.gradle.launcher.daemon.server.DaemonStateCoordinator] daemon is running. Sleeping until state changes.
2021-07-13T14:16:00.759+0100 [INFO] [org.gradle.launcher.daemon.server.exec.StartBuildOrRespondWithBusy] Daemon is about to start building Build{id=9ff73205-f03d-4bcd-99a6-25f7b424d5f7, currentDir=/Users/nabil/Dev/realm/KMP/master-2/realm-kotlin-samples/Bookshelf}. Dispatching build started information...
2021-07-13T14:16:00.760+0100 [DEBUG] [org.gradle.launcher.daemon.server.SynchronizedDispatchConnection] thread 29: dispatching org.gradle.launcher.daemon.protocol.BuildStarted@70073589
2021-07-13T14:16:00.760+0100 [DEBUG] [org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment] Configuring env variables: [PATH, JAVA_HOME, GITHUB_DOCKER_TOKEN, TERM, COMMAND_MODE, __INTELLIJ_COMMAND_HISTFILE__, ANDROID_HOME, NDK_HOME, GITHUB_DOCKER_USER, P9K_TTY, LOGNAME, APP_NAME_47126, XPC_SERVICE_NAME, PWD, __CFBundleIdentifier, SHELL, PAGER, LSCOLORS, ANDROID_NDK_HOME, OLDPWD, USER, ANDROID_SDK_ROOT, ANDROID_NDK, ZSH, JAVA_MAIN_CLASS_47126, P9K_SSH, TERMINAL_EMULATOR, LOGIN_SHELL, TMPDIR, SSH_AUTH_SOCK, XPC_FLAGS, __CF_USER_TEXT_ENCODING, LESS, LC_CTYPE, APP_ICON_47126, HOME, SHLVL]
2021-07-13T14:16:00.761+0100 [DEBUG] [org.gradle.launcher.daemon.server.exec.LogToClient] About to start relaying all logs to the client via the connection.
2021-07-13T14:16:00.761+0100 [INFO] [org.gradle.launcher.daemon.server.exec.LogToClient] The client will now receive all logging from the daemon (pid: 47119). The daemon log file: /Users/nabil/.gradle/daemon/7.0.2/daemon-47119.out.log
2021-07-13T14:16:00.762+0100 [INFO] [org.gradle.launcher.daemon.server.exec.LogAndCheckHealth] Starting 2nd build in daemon [uptime: 5.694 secs, performance: 100%]
2021-07-13T14:16:00.762+0100 [DEBUG] [org.gradle.launcher.daemon.server.exec.ExecuteBuild] The daemon has started executing the build.
2021-07-13T14:16:00.762+0100 [DEBUG] [org.gradle.launcher.daemon.server.exec.ExecuteBuild] Executing build with daemon context: DefaultDaemonContext[uid=2286acb4-4b03-4b46-92b4-f8869ba8241e,javaHome=/Library/Java/JavaVirtualMachines/jdk-11.0.11.jdk/Contents/Home,daemonRegistryDir=/Users/nabil/.gradle/daemon,pid=47119,idleTimeout=10800000,priority=NORMAL,daemonOpts=--add-opens,java.base/java.util=ALL-UNNAMED,--add-opens,java.base/java.lang=ALL-UNNAMED,--add-opens,java.base/java.lang.invoke=ALL-UNNAMED,--add-opens,java.base/java.util=ALL-UNNAMED,--add-opens,java.prefs/java.util.prefs=ALL-UNNAMED,--add-opens,java.prefs/java.util.prefs=ALL-UNNAMED,--add-opens,java.base/java.nio.charset=ALL-UNNAMED,--add-opens,java.base/java.net=ALL-UNNAMED,--add-opens,java.base/java.util.concurrent.atomic=ALL-UNNAMED,-Xmx2048M,-Dfile.encoding=UTF-8,-Duser.country=GB,-Duser.language=en,-Duser.variant]
ComposeOptions.kotlinCompilerVersion is deprecated. Compose now uses the kotlin compiler defined in your buildscript.
Kotlin Multiplatform Projects are an Alpha feature. See: https://kotlinlang.org/docs/reference/evolution/components-stability.html. To hide this message, add 'kotlin.mpp.stability.nowarn=true' to the Gradle properties.

Warning: The 'kotlin-android-extensions' Gradle plugin is deprecated. Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.

The Kotlin source set androidAndroidTestRelease was configured but not added to any Kotlin compilation. You can add a source set to a target's compilation by connecting it with the compilation's default source set using 'dependsOn'.
See https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#connecting-source-sets
Unable to strip the following libraries, packaging them as they are: libc++_shared.so, librealm-ffi-dbg.so, librealmc.so.
w: skipping /Users/nabil/.gradle/caches/modules-2/files-2.1/io.realm.kotlin/library-iosx64/0.45.0-SNAPSHOT/9f6174f4f610fd23472aa2f0e2d9879584c9ecb5/library.klib. Incompatible abi version. The current default is '1.4.2', found '1.5.0'. The library produced by 1.5.20 compiler
e: Could not find "/Users/nabil/.gradle/caches/modules-2/files-2.1/io.realm.kotlin/library-iosx64/0.45.0-SNAPSHOT/9f6174f4f610fd23472aa2f0e2d9879584c9ecb5/library.klib" in [/Users/nabil/Dev/realm/KMP/master-2/realm-kotlin-samples/Bookshelf, /Users/nabil/.konan/klib, /Users/nabil/.konan/kotlin-native-prebuilt-macos-1.5.10/klib/common, /Users/nabil/.konan/kotlin-native-prebuilt-macos-1.5.10/klib/platform/ios_x64]
Daemon vm is shutting down... The daemon has exited normally or was terminated in response to a user interrupt.
----- End of the daemon log -----


FAILURE: Build failed with an exception.

```