### PR TITLE
Throw errors when importing objects with duplicate primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* Throw exception when violating primary key uniqeness constrain when importing objects with `copyToRealm`.
 
 ### Compatibility
 * This release is compatible with Kotlin 1.5.10 and Coroutines 1.5.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* Throw exception when violating primary key uniqeness constrain when importing objects with `copyToRealm`.
+* Throw exception when violating primary key uniqeness constraint when importing objects with `copyToRealm`.
 
 ### Compatibility
 * This release is compatible with Kotlin 1.5.10 and Coroutines 1.5.0.

--- a/packages/build.gradle.kts
+++ b/packages/build.gradle.kts
@@ -32,6 +32,5 @@ allprojects {
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         kotlinOptions.jvmTarget = "${Versions.jvmTarget}"
-        kotlinOptions.freeCompilerArgs += "-XXLanguage:+InlineClasses"
     }
 }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/interop/RealmInterop.kt
@@ -22,8 +22,10 @@ import kotlin.jvm.JvmInline
 // FIXME API-INTERNAL Consider adding marker interfaces NativeRealm, NativeRealmConfig, etc. as type parameter
 //  to NativePointer. NOTE Verify that it is supported for Kotlin Native!
 
+// Wrapper for the C-API realm_class_key_t uniquely identifying the class/table in the schema
 @JvmInline
 value class ClassKey(val key: Long)
+// Wrapper for the C-API realm_property_key_t uniquely identifying the property within a class/table
 @JvmInline
 value class ColumnKey(val key: Long)
 

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/interop/RealmInterop.kt
@@ -17,11 +17,15 @@
 package io.realm.interop
 
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.jvm.JvmInline
 
 // FIXME API-INTERNAL Consider adding marker interfaces NativeRealm, NativeRealmConfig, etc. as type parameter
 //  to NativePointer. NOTE Verify that it is supported for Kotlin Native!
 
-inline class ColumnKey(val key: Long)
+@JvmInline
+value class ClassKey(val key: Long)
+@JvmInline
+value class ColumnKey(val key: Long)
 
 @Suppress("FunctionNaming", "LongParameterList")
 expect object RealmInterop {
@@ -77,9 +81,9 @@ expect object RealmInterop {
 
     // FIXME API-INTERNAL Maybe keep full realm_class_info_t/realm_property_info_t representation in Kotlin
     // FIXME API-INTERNAL How to return boolean 'found'? Currently throwing runtime exceptions
-    fun realm_find_class(realm: NativePointer, name: String): Long
-    fun realm_object_create(realm: NativePointer, key: Long): NativePointer
-    fun realm_object_create_with_primary_key(realm: NativePointer, key: Long, primaryKey: Any?): NativePointer
+    fun realm_find_class(realm: NativePointer, name: String): ClassKey
+    fun realm_object_create(realm: NativePointer, classKey: ClassKey): NativePointer
+    fun realm_object_create_with_primary_key(realm: NativePointer, classKey: ClassKey, primaryKey: Any?): NativePointer
     fun realm_object_is_valid(obj: NativePointer): Boolean
     fun realm_object_freeze(liveObject: NativePointer, frozenRealm: NativePointer): NativePointer
     fun realm_object_thaw(frozenObject: NativePointer, liveRealm: NativePointer): NativePointer?
@@ -113,6 +117,8 @@ expect object RealmInterop {
     fun <T> realm_results_get(results: NativePointer, index: Long): Link
 
     fun realm_get_object(realm: NativePointer, link: Link): NativePointer
+
+    fun realm_object_find_with_primary_key(realm: NativePointer, classKey: ClassKey, primaryKey: Any?): NativePointer?
 
     // delete
     fun realm_results_delete_all(results: NativePointer)

--- a/packages/cinterop/src/nativeCommon/realm.def
+++ b/packages/cinterop/src/nativeCommon/realm.def
@@ -43,6 +43,9 @@ static bool realm_list_add_by_ref(realm_list_t* list, size_t index, realm_value_
 static bool realm_list_set_by_ref(realm_list_t* list, size_t index, realm_value_t* value) {
     return realm_list_set(list, index, *value);
 }
+static realm_object_t* realm_object_find_with_primary_key_by_ref(const realm_t* realm, realm_class_key_t table, realm_value_t* pk, bool* out_found) {
+    return realm_object_find_with_primary_key(realm, table, *pk, out_found);
+}
 
 // These functions are a work around to avoid anonymous union not being supported in Kotlin/Native https://youtrack.jetbrains.com/issue/KT-43833
 // which will call to `realm_wrapper.realm_set_value` using a `cValue<realm_value>` throw a

--- a/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -128,10 +128,10 @@ class MutableRealm : BaseRealm {
      *
      * @param instance The object to create a copy from.
      * @return The managed version of the `instance`.
+     *
+     * @throws RuntimeException if the class has a primary key field and an object with the same
+     * primary key already exists.
      */
-    // FIXME Due to lack of throwing C-API this will not throw on duplicate keys, so this
-    //  currently effectively mimics the copyOrUpdate API from realm-java.
-    //  https://github.com/realm/realm-kotlin/issues/192
     fun <T : RealmObject> copyToRealm(instance: T): T {
         return io.realm.internal.copyToRealm(configuration.mediator, realmReference, instance)
     }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -85,6 +85,9 @@ fun <T : RealmObject> create(
         //  https://github.com/realm/realm-core/issues/4595
         val existingPrimaryKeyObject = RealmInterop.realm_object_find_with_primary_key(realm.dbPointer, key, primaryKey)
         existingPrimaryKeyObject?.let {
+            // FIXME Throw proper exception
+            //  https://github.com/realm/realm-kotlin/issues/70
+            @Suppress("TooGenericExceptionThrown")
             throw RuntimeException("Cannot create object with existing primary key")
         }
         val managedModel = mediator.createInstanceOf(type)

--- a/test/src/androidTest/kotlin/io/realm/shared/PrimaryKeyTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/PrimaryKeyTests.kt
@@ -133,7 +133,6 @@ class PrimaryKeyTests {
         }
     }
 
-
     @Test
     @OptIn(ExperimentalStdlibApi::class)
     fun verifyPrimaryKeyTypeSupport() {

--- a/test/src/androidTest/kotlin/io/realm/shared/PrimaryKeyTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/PrimaryKeyTests.kt
@@ -91,30 +91,26 @@ class PrimaryKeyTests {
     }
 
     @Test
-    @Ignore // https://github.com/realm/realm-core/issues/4595
     fun duplicatePrimaryKeyThrows() {
         realm.writeBlocking {
-            copyToRealm(PrimaryKeyString().apply { primaryKey = PRIMARY_KEY })
+            val obj = PrimaryKeyString().apply { primaryKey = PRIMARY_KEY }
+            copyToRealm(obj)
             assertFailsWith<RuntimeException> {
-                // C-API semantics is currently to return any existing object if already present
-                copyToRealm(PrimaryKeyString().apply { primaryKey = PRIMARY_KEY })
+                copyToRealm(obj)
             }
-            cancelWrite()
         }
 
         assertEquals(PRIMARY_KEY, realm.objects(PrimaryKeyString::class)[0].primaryKey)
     }
 
     @Test
-    @Ignore // https://github.com/realm/realm-core/issues/4595
     fun duplicateNullPrimaryKeyThrows() {
         realm.writeBlocking {
-            copyToRealm(PrimaryKeyStringNullable().apply { primaryKey = null })
+            val obj = PrimaryKeyStringNullable().apply { primaryKey = null }
+            copyToRealm(obj)
             assertFailsWith<RuntimeException> {
-                // C-API semantics is currently to return any existing object if already present
-                copyToRealm(PrimaryKeyStringNullable().apply { primaryKey = null })
+                copyToRealm(obj)
             }
-            cancelWrite()
         }
 
         val objects = realm.objects(PrimaryKeyStringNullable::class)
@@ -123,29 +119,20 @@ class PrimaryKeyTests {
     }
 
     @Test
-    fun importUnmanagedWithPrimaryKey() {
-        val o = PrimaryKeyString().apply { primaryKey = PRIMARY_KEY }
+    // Maybe prevent updates of primary key fields completely by forcing it to be vals, but if it
+    // is somehow possible (maybe from dynamic API), we should at least throw errors. Filed
+    // https://github.com/realm/realm-core/issues/4808
+    @Ignore
+    fun updateWithDuplicatePrimaryKeyThrows() {
         realm.writeBlocking {
-            copyToRealm(o)
-        }
-
-        assertEquals(PRIMARY_KEY, realm.objects(PrimaryKeyString::class)[0].primaryKey)
-    }
-
-    @Test
-    @Ignore // https://github.com/realm/realm-core/issues/4595
-    fun importUnmanagedWithDuplicatePrimaryKeyThrows() {
-        val o = PrimaryKeyString()
-        realm.writeBlocking {
-            copyToRealm(o)
+            val first = copyToRealm(PrimaryKeyString().apply { primaryKey = PRIMARY_KEY })
+            val second = copyToRealm(PrimaryKeyString().apply { primaryKey = "Other key" })
             assertFailsWith<RuntimeException> {
-                copyToRealm(o)
+                second.primaryKey = PRIMARY_KEY
             }
         }
-
-        val objects = realm.objects(PrimaryKeyString::class)
-        assertEquals(1, objects.size)
     }
+
 
     @Test
     @OptIn(ExperimentalStdlibApi::class)


### PR DESCRIPTION
This is adding a manual check for conflicting primary keys before adding new objects. 

Closes #192