### PR TITLE
Linked shared test folder instead of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,23 +286,16 @@ Inside `tests/` there are 3 locations the files can be placed in:
 * `test/src/androidTest`
 * `test/src/macosTest`
 
-Ideally all shared tests should be in `commonTest` with specific platform tests in `androidTest`/`macosTest`. However IntelliJ does not yet allow you run you to run common tests on Android from within the IDE](https://youtrack.jetbrains.com/issue/KT-46452), so we
+Ideally all shared tests should be in `commonTest` with specific platform tests in `androidTest`/`macosTest`. However IntelliJ does not yet allow you to run common tests on Android from within the IDE](https://youtrack.jetbrains.com/issue/KT-46452), so we
 are using the following work-around:
 
-1) All "common" tests should be placed in the `test/src/androidtest/kotlin/io/realm/shared` folder. They should be written using only common API's. I'e. use Kotlin Test, not JUnit. This `io.realm.shared` package should only contain tests we plan to eventually move to `commontTest`.
+1) All "common" tests should be placed in the `test/src/androidtest/kotlin/io/realm/shared` folder. They should be written using only common API's. I'e. use Kotlin Test, not JUnit. This `io.realm.shared` package should only contain tests we plan to eventually move to `commonTest`.
 
 
-2) When adding a new test file to `androidTest` we need to re-create the symlinks for macOS. This can be done, using the following command on Mac:
-
-```
-cd test/src/macosTest/kotlin/io/realm/shared
-ln -sf ../../../../../androidTest/kotlin/io/realm/shared/* ./
-``` 
-
-3) Both the real test file and the symlink must be committed to Git.
+2) The `macosTest` shared tests would automatically be picked up from the `androidTests` as it is symlinked to `test/src/androidtest/kotlin/io/realm/shared`.
 
 
-4) This allows us to run and debug unit tests on both macOS and Android. It is easier getting the imports correctly using the macOS sourceset as the Android code will default to using JUnit.
+3) This allows us to run and debug unit tests on both macOS and Android. It is easier getting the imports correctly using the macOS sourceset as the Android code will default to using JUnit.
  
 
 All platform specific tests should be placed outside the `io.realm.shared` package, the default being `io.realm`.

--- a/test/src/macosTest/kotlin/io/realm/shared
+++ b/test/src/macosTest/kotlin/io/realm/shared
@@ -1,0 +1,1 @@
+../../../../androidTest/kotlin/io/realm/shared

--- a/test/src/macosTest/kotlin/io/realm/shared/ImportTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/ImportTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/ImportTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/LinkTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/LinkTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/LinkTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/LogTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/LogTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/LogTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/MigrationTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/MigrationTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/MigrationTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/ModuleTest.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/ModuleTest.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/ModuleTest.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/MutableRealmTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/MutableRealmTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/MutableRealmTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/NullabilityTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/NullabilityTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/NullabilityTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/PrimaryKeyTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/PrimaryKeyTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/PrimaryKeyTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/RealmConfigurationTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/RealmConfigurationTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/RealmConfigurationTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/RealmListTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/RealmListTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/RealmListTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/RealmObjectTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/RealmObjectTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/RealmObjectTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/RealmResultsTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/RealmResultsTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/RealmResultsTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/RealmTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/RealmTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/RealmTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/SampleTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/SampleTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/SampleTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/SchemaTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/SchemaTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/SchemaTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/VersionIdTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/shared/VersionIdTests.kt
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/VersionIdTests.kt

--- a/test/src/macosTest/kotlin/io/realm/shared/notifications
+++ b/test/src/macosTest/kotlin/io/realm/shared/notifications
@@ -1,1 +1,0 @@
-../../../../../androidTest/kotlin/io/realm/shared/notifications


### PR DESCRIPTION
Symlink the shared platform test folder instead of individual tests.