### PR TITLE
Abstract version into interface and share implementation of RealmLifeCycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Breaking Changes
 * Moved `@PrimaryKey` annotation from `io.realm.PrimaryKey` to `io.realm.annotations.PrimaryKey`.
+* Changed `version` into method `version()` and moved it to `Versioned` interface.
 
 ### Enhancements
 * Add support for excluding properties from the Realm schema. This is done by either using JVM `@Transient` or the newly added `@io.realm.kotlin.Ignore` annotation. (Issue [#278](https://github.com/realm/realm-kotlin/issues/278)).

--- a/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/BaseRealm.kt
@@ -19,17 +19,11 @@ import kotlin.reflect.KClass
 /**
  * Base class for all Realm instances ([Realm] and [MutableRealm]).
  */
-interface BaseRealm {
+interface BaseRealm : Versioned {
     /**
      * Configuration used to configure this Realm instance.
      */
     val configuration: RealmConfiguration
-
-    /**
-     * The current version of the data in this realm.
-     */
-    // TODO Could be abstracted into base implementation of RealmLifeCycle!?
-    var version: VersionId
 
     /**
      * Returns the results of querying for all objects of a specific type.

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmList.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmList.kt
@@ -38,6 +38,7 @@ import kotlin.reflect.KClass
  * that inject values into a class. Unmanaged elements in a list can be added to a Realm using the
  * [MutableRealm.copyToRealm] method.
  */
+// FIXME Implement Versioned, RealmLifeCycle or what ever suits
 class RealmList<E> private constructor(
     delegate: MutableList<E>
 ) : MutableList<E> by delegate {
@@ -50,7 +51,7 @@ class RealmList<E> private constructor(
     /**
      * Constructs a RealmList in managed mode. For internal use only.
      */
-    constructor(
+    internal constructor(
         listPtr: NativePointer,
         metadata: OperatorMetadata
     ) : this(ManagedListDelegate(listPtr, metadata))
@@ -58,7 +59,7 @@ class RealmList<E> private constructor(
     /**
      * Metadata needed to correctly instantiate a list operator. For internal use only.
      */
-    data class OperatorMetadata(
+    internal data class OperatorMetadata(
         val clazz: KClass<*>,
         val isRealmObject: Boolean,
         val mediator: Mediator,

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -21,6 +21,7 @@ import io.realm.internal.MutableRealmImpl
 import io.realm.internal.RealmObjectInternal
 import io.realm.internal.RealmReference
 import io.realm.internal.link
+import io.realm.internal.realmObjectInternal
 import io.realm.interop.Link
 import io.realm.interop.RealmInterop
 import kotlinx.coroutines.flow.Flow
@@ -29,6 +30,8 @@ import kotlin.reflect.KClass
 /**
  * Marker interface to define a model (managed by Realm).
  */
+// FIXME Can we implement extensions method by adding Versioned or maybe public counter part of
+//  RealmLifeCycle
 interface RealmObject
 
 /**
@@ -40,31 +43,15 @@ interface RealmObject
  * @return true if the object is frozen, false otherwise.
  */
 public fun RealmObject.isFrozen(): Boolean {
-    val internalObject = this as RealmObjectInternal
-    internalObject.`$realm$ObjectPointer`?.let {
-        return RealmInterop.realm_is_frozen(it)
-    } ?: throw IllegalArgumentException("Cannot get version from an unmanaged object.")
+    return realmObjectInternal().isFrozen()
 }
 
 /**
  * Returns the Realm version of this object. This version number is tied to the transaction the object was read from.
  */
-// TODO Should probably be a function as it can potentially change over time and can throw?
-public var RealmObject.version: VersionId
-    get() {
-        val internalObject = this as RealmObjectInternal
-        internalObject.`$realm$Owner`?.let {
-            // FIXME This check is required as realm_get_version_id doesn't throw if closed!? Core bug?
-            val dbPointer = it.dbPointer
-            if (RealmInterop.realm_is_closed(dbPointer)) {
-                throw IllegalStateException("Cannot access properties on closed realm")
-            }
-            return VersionId(RealmInterop.realm_get_version_id(dbPointer))
-        } ?: throw IllegalArgumentException("Cannot get version from an unmanaged object.")
-    }
-    private set(_) {
-        throw UnsupportedOperationException("Setter is required by the Kotlin Compiler, but should not be called directly")
-    }
+public fun RealmObject.version(): VersionId {
+    return realmObjectInternal().version()
+}
 
 /**
  * Deletes the RealmObject.
@@ -87,8 +74,7 @@ fun RealmObject.delete() {
  * Realm.
  */
 fun RealmObject.isManaged(): Boolean {
-    val internalObject = this as RealmObjectInternal
-    return internalObject.`$realm$IsManaged`
+    return realmObjectInternal().`$realm$IsManaged`
 }
 
 /**

--- a/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/RealmResults.kt
@@ -8,12 +8,7 @@ import kotlinx.coroutines.flow.Flow
  * @see Realm.objects
  * @see MutableRealm.objects
  */
-interface RealmResults<T : RealmObject> : List<T>, Queryable<T> {
-
-    /**
-     * The current version of the data in this Realm.
-     */
-    fun version(): VersionId
+interface RealmResults<T : RealmObject> : List<T>, Queryable<T>, Versioned {
 
     /**
      * Perform a query on the objects of this result using the Realm Query Language.

--- a/packages/library/src/commonMain/kotlin/io/realm/Versioned.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/Versioned.kt
@@ -1,27 +1,23 @@
 /*
  * Copyright 2021 Realm Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
  * http://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-package test
+package io.realm
 
-import io.realm.RealmObject
-
-class Nullability : RealmObject {
-    // TODO Need to test for all types, but requires more thought on how to structure tests to ensure
-    //  that we break all tests when introducing new types, etc.
-    //  https://github.com/realm/realm-kotlin/issues/133
-    var stringNullable: String? = null
-    var stringNonNullable: String = ""
+interface Versioned {
+    /**
+     * Returns the Realm version of this object. This version number is tied to the transaction the object was read from.
+     */
+    fun version(): VersionId
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/Mediator.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/Mediator.kt
@@ -19,7 +19,7 @@ package io.realm.internal
 import io.realm.RealmObject
 import kotlin.reflect.KClass
 
-interface Mediator {
+internal interface Mediator {
     fun createInstanceOf(clazz: KClass<*>): RealmObjectInternal
     fun companionOf(clazz: KClass<out RealmObject>): RealmObjectCompanion
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
-class MutableRealmImpl : BaseRealmImpl, MutableRealm {
+internal class MutableRealmImpl : BaseRealmImpl, MutableRealm {
 
     // TODO Also visible as a companion method to allow for `RealmObject.delete()`, but this
     //  has drawbacks. See https://github.com/realm/realm-kotlin/issues/181

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlin.reflect.KClass
 
 // TODO API-PUBLIC Document platform specific internals (RealmInitializer, etc.)
-class RealmImpl private constructor(configuration: RealmConfigurationImpl, dbPointer: NativePointer) :
+internal class RealmImpl private constructor(configuration: RealmConfigurationImpl, dbPointer: NativePointer) :
     BaseRealmImpl(configuration, dbPointer), Realm {
 
     internal val realmScope: CoroutineScope =
@@ -150,10 +150,10 @@ class RealmImpl private constructor(configuration: RealmConfigurationImpl, dbPoi
     private suspend fun updateRealmPointer(newRealmReference: RealmReference) {
         realmPointerMutex.withLock {
             val newVersion = newRealmReference.version()
-            log.debug("Updating Realm version: $version -> $newVersion")
+            log.debug("Updating Realm version: ${version()} -> $newVersion")
             // If we advance to a newer version then we should keep track of the preceding one,
             // otherwise just track the new one directly.
-            val untrackedReference = if (newVersion >= version) {
+            val untrackedReference = if (newVersion >= version()) {
                 val previousRealmReference = realmReference
                 realmReference = newRealmReference
                 previousRealmReference

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmLifeCycle.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmLifeCycle.kt
@@ -17,12 +17,46 @@
 package io.realm.internal
 
 import io.realm.VersionId
+import io.realm.Versioned
 
 /**
  * A RealmLifeCycle exposes common methods to query the state of any Realm object.
  */
-internal interface RealmLifeCycle {
-    fun version(): VersionId
+// FIXME Should we have a public interface with a subset of these or split even further into
+//  Closeable, etc.
+internal interface RealmLifeCycle : Versioned {
     fun isFrozen(): Boolean
     fun isClosed(): Boolean
+}
+
+// Singleton instance acting as implementation for all unmanaged objects
+object UnmanagedLifeCycle : RealmLifeCycle {
+    override fun version(): VersionId {
+        throw IllegalArgumentException("Cannot access life cycle information on unmanaged object")
+    }
+
+    override fun isFrozen(): Boolean {
+        throw IllegalArgumentException("Cannot access life cycle information on unmanaged object")
+    }
+
+    override fun isClosed(): Boolean {
+        throw IllegalArgumentException("Cannot access life cycle information on unmanaged object")
+    }
+}
+
+// Default implementation for all objects that can provide a realmLifeCycle instance
+internal interface RealmLifeCycleHolder : RealmLifeCycle {
+    fun realmLifeCycle(): RealmLifeCycle
+
+    override fun version(): VersionId {
+        return realmLifeCycle().version()
+    }
+
+    override fun isFrozen(): Boolean {
+        return realmLifeCycle().isFrozen()
+    }
+
+    override fun isClosed(): Boolean {
+        return realmLifeCycle().isClosed()
+    }
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -34,7 +34,7 @@ object RealmObjectHelper {
 
     // Consider inlining
     @Suppress("unused") // Called from generated code
-    fun <R> getValue(obj: RealmObjectInternal, col: String): Any? {
+    internal fun <R> getValue(obj: RealmObjectInternal, col: String): Any? {
         obj.checkValid()
         val realm = obj.`$realm$Owner` ?: throw IllegalStateException("Invalid/deleted object")
         val o = obj.`$realm$ObjectPointer` ?: throw IllegalStateException("Invalid/deleted object")
@@ -44,7 +44,7 @@ object RealmObjectHelper {
 
     // Return type should be R? but causes compilation errors for native
     @Suppress("unused") // Called from generated code
-    inline fun <reified R : RealmObject> getObject(
+    internal inline fun <reified R : RealmObject> getObject(
         obj: RealmObjectInternal,
         col: String,
     ): Any? {
@@ -67,7 +67,7 @@ object RealmObjectHelper {
     }
 
     // Return type should be RealmList<R?> but causes compilation errors for native
-    inline fun <reified R> getList(
+    internal inline fun <reified R> getList(
         obj: RealmObjectInternal,
         col: String,
         isRealmObject: Boolean = false
@@ -90,7 +90,7 @@ object RealmObjectHelper {
 
     // Consider inlining
     @Suppress("unused") // Called from generated code
-    fun <R> setValue(obj: RealmObjectInternal, col: String, value: R) {
+    internal fun <R> setValue(obj: RealmObjectInternal, col: String, value: R) {
         obj.checkValid()
         val realm = obj.`$realm$Owner` ?: throw IllegalStateException("Invalid/deleted object")
         val o = obj.`$realm$ObjectPointer` ?: throw IllegalStateException("Invalid/deleted object")
@@ -104,7 +104,7 @@ object RealmObjectHelper {
     }
 
     @Suppress("unused") // Called from generated code
-    inline fun <reified R : RealmObjectInternal> setObject(
+    internal inline fun <reified R : RealmObjectInternal> setObject(
         obj: RealmObjectInternal,
         col: String,
         value: R?
@@ -116,7 +116,7 @@ object RealmObjectHelper {
         setValue(obj, col, newValue)
     }
 
-    fun setList(obj: RealmObjectInternal, col: String, list: RealmList<Any?>) {
+    internal fun setList(obj: RealmObjectInternal, col: String, list: RealmList<Any?>) {
         TODO()
     }
 }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -17,6 +17,7 @@
 package io.realm.internal
 
 import io.realm.RealmObject
+import io.realm.VersionId
 import io.realm.isValid
 
 /**
@@ -27,7 +28,7 @@ import io.realm.isValid
  * [RealmObject].
  */
 @Suppress("VariableNaming")
-interface RealmObjectInternal : RealmObject, io.realm.interop.RealmObjectInterop {
+internal interface RealmObjectInternal : RealmObject, RealmLifeCycleHolder, io.realm.interop.RealmObjectInterop {
     // Names must match identifiers in compiler plugin (plugin-compiler/io.realm.compiler.Identifiers.kt)
 
     // Reference to the public Realm instance and internal transaction to which the object belongs.
@@ -35,9 +36,21 @@ interface RealmObjectInternal : RealmObject, io.realm.interop.RealmObjectInterop
     var `$realm$TableName`: String?
     var `$realm$IsManaged`: Boolean
     var `$realm$Mediator`: Mediator?
+
+    override fun realmLifeCycle(): RealmLifeCycle {
+        return `$realm$Owner` ?: UnmanagedLifeCycle
+    }
+
+    override fun version(): VersionId {
+        return super<RealmLifeCycleHolder>.version()
+    }
 }
 
-fun RealmObjectInternal.checkValid() {
+internal inline fun RealmObject.realmObjectInternal(): RealmObjectInternal {
+    return this as RealmObjectInternal
+}
+
+internal fun RealmObjectInternal.checkValid() {
     if (!this.isValid()) {
         throw IllegalStateException("Cannot perform this operation on an invalid/deleted object")
     }

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
 
 // TODO API-INTERNAL
 // We could inline this
-fun <T : RealmObject> RealmObjectInternal.manage(
+internal fun <T : RealmObject> RealmObjectInternal.manage(
     realm: RealmReference,
     mediator: Mediator,
     type: KClass<T>,
@@ -42,7 +42,7 @@ fun <T : RealmObject> RealmObjectInternal.manage(
 }
 
 // TODO API-INTERNAL
-fun <T : RealmObject> RealmObjectInternal.link(
+internal fun <T : RealmObject> RealmObjectInternal.link(
     realm: RealmReference,
     mediator: Mediator,
     type: KClass<T>,
@@ -63,7 +63,7 @@ fun <T : RealmObject> RealmObjectInternal.link(
  *
  * @param frozenRealm Pointer to frozen Realm to which the frozen copy should belong.
  */
-fun <T : RealmObject> RealmObjectInternal.freeze(frozenRealm: RealmReference): T {
+internal fun <T : RealmObject> RealmObjectInternal.freeze(frozenRealm: RealmReference): T {
     @Suppress("UNCHECKED_CAST")
     val type: KClass<T> = this::class as KClass<T>
     val mediator = `$realm$Mediator`!!

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
@@ -22,7 +22,7 @@ import io.realm.interop.RealmInterop
  * NOTE: There should never be multiple RealmReferences with the same `dbPointer` as the underlying
  * C++ SharedRealm is closed when the RealmReference is no longer referenced by the [Realm].
  */
-data class RealmReference(
+internal data class RealmReference(
     val owner: BaseRealmImpl,
     val dbPointer: NativePointer
     // FIXME Should we keep a debug flag to assert that we have the right liveness state

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmResultsImpl.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmResultsImpl.kt
@@ -20,7 +20,6 @@ import io.realm.Callback
 import io.realm.Cancellable
 import io.realm.RealmObject
 import io.realm.RealmResults
-import io.realm.VersionId
 import io.realm.interop.Link
 import io.realm.interop.NativePointer
 import io.realm.interop.RealmInterop
@@ -32,7 +31,7 @@ import kotlin.reflect.KClass
 //  - Postponing execution to actually accessing the elements also prevents query parser errors to
 //    be raised. Maybe we can get an option to prevalidate queries in the C-API?
 
-class RealmResultsImpl<T : RealmObject> : AbstractList<T>, RealmResults<T> {
+internal class RealmResultsImpl<T : RealmObject> : AbstractList<T>, RealmResults<T>, RealmLifeCycleHolder {
 
     private val mode: Mode
     private val realm: RealmReference
@@ -65,11 +64,8 @@ class RealmResultsImpl<T : RealmObject> : AbstractList<T>, RealmResults<T> {
         }
     }
 
-    /**
-     * The current version of the data in this Realm.
-     */
-    override fun version(): VersionId {
-        return realm.owner.version
+    override fun realmLifeCycle(): RealmLifeCycle {
+        return realm
     }
 
     override val size: Int

--- a/packages/library/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -41,7 +41,7 @@ internal fun checkRealmClosed(realm: RealmReference) {
 }
 
 @Suppress("TooGenericExceptionCaught") // Remove when errors are properly typed in https://github.com/realm/realm-kotlin/issues/70
-fun <T : RealmObject> create(mediator: Mediator, realm: RealmReference, type: KClass<T>): T {
+internal fun <T : RealmObject> create(mediator: Mediator, realm: RealmReference, type: KClass<T>): T {
     // FIXME Does not work with obfuscation. We should probably supply the static meta data through
     //  the companion (accessible through schema) or might even have a cached version of the key in
     //  some runtime container of an open realm.
@@ -66,7 +66,7 @@ fun <T : RealmObject> create(mediator: Mediator, realm: RealmReference, type: KC
 }
 
 @Suppress("TooGenericExceptionCaught") // Remove when errors are properly typed in https://github.com/realm/realm-kotlin/issues/70
-fun <T : RealmObject> create(
+internal fun <T : RealmObject> create(
     mediator: Mediator,
     realm: RealmReference,
     type: KClass<T>,
@@ -105,7 +105,7 @@ fun <T : RealmObject> create(
     }
 }
 
-fun <T : RealmObject> copyToRealm(
+internal fun <T : RealmObject> copyToRealm(
     mediator: Mediator,
     realmPointer: RealmReference,
     instance: T,

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
@@ -20,7 +20,6 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.realm.RealmObject
 import io.realm.internal.RealmObjectCompanion
-import io.realm.internal.RealmObjectInternal
 import io.realm.interop.ClassFlag
 import io.realm.interop.NativePointer
 import io.realm.interop.PropertyType
@@ -132,6 +131,7 @@ class GenerationExtensionTest {
     }
 
     @Test
+    @Suppress("invisible_member", "invisible_reference")
     fun `implement RealmObjectInternal and generate internal properties`() {
         val inputs = Files("/sample")
 
@@ -143,7 +143,7 @@ class GenerationExtensionTest {
         val sampleModel = kClazz.newInstance()!!
 
         assertTrue(sampleModel is RealmObject)
-        assertTrue(sampleModel is RealmObjectInternal)
+        assertTrue(sampleModel is io.realm.internal.RealmObjectInternal)
 
         // Accessing getters/setters
         sampleModel.`$realm$IsManaged` = true
@@ -242,6 +242,7 @@ class GenerationExtensionTest {
     }
 
     @Test
+    @Suppress("invisible_member", "invisible_reference")
     fun `modify accessors to call cinterop`() {
         val inputs = Files("/sample")
 
@@ -254,7 +255,7 @@ class GenerationExtensionTest {
         val nameProperty = sampleModel::class.members.find { it.name == "stringField" }
             ?: fail("Couldn't find property name of class Sample")
         assertTrue(nameProperty is KMutableProperty<*>)
-        assertTrue(sampleModel is RealmObjectInternal)
+        assertTrue(sampleModel is io.realm.internal.RealmObjectInternal)
 
         // In un-managed mode return only the backing field
         sampleModel.`$realm$IsManaged` = false

--- a/test/src/androidTest/kotlin/io/realm/shared/RealmObjectTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/RealmObjectTests.kt
@@ -64,20 +64,20 @@ class RealmObjectTests : RealmLifeCycleTests {
 
     @Test
     override fun version() {
-        assertEquals(EXPECTED_VERSION, parent.version)
+        assertEquals(EXPECTED_VERSION, parent.version())
     }
 
     override fun version_throwsOnUnmanagedObject() {
         val unmanagedParent = Parent()
         assertFailsWith<IllegalArgumentException> {
-            unmanagedParent.version
+            unmanagedParent.version()
         }
     }
 
     @Test
     override fun version_throwsIfRealmIsClosed() {
         realm.close()
-        assertFailsWith<IllegalStateException> { parent.version }
+        assertFailsWith<IllegalStateException> { parent.version() }
     }
 
     @Test

--- a/test/src/androidTest/kotlin/io/realm/shared/notifications/RealmNotificationsTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/notifications/RealmNotificationsTests.kt
@@ -42,13 +42,13 @@ class RealmNotificationsTests : NotificationTests {
     override fun initialElement() {
         runBlocking {
             val c = Channel<Realm>(1)
-            val startingVersion = realm.version
+            val startingVersion = realm.version()
             val observer = async {
                 realm.observe().collect {
                     c.send(it)
                 }
             }
-            assertEquals(startingVersion, c.receive().version)
+            assertEquals(startingVersion, c.receive().version())
             observer.cancel()
             c.close()
         }
@@ -58,15 +58,15 @@ class RealmNotificationsTests : NotificationTests {
     override fun observe() {
         runBlocking {
             val c = Channel<Realm>(1)
-            val startingVersion = realm.version
+            val startingVersion = realm.version()
             val observer = async {
                 realm.observe().collect {
                     c.send(it)
                 }
             }
-            assertEquals(startingVersion, c.receive().version)
+            assertEquals(startingVersion, c.receive().version())
             realm.write { /* Do nothing */ }
-            c.receive().version.let { updatedVersion ->
+            c.receive().version().let { updatedVersion ->
                 assertEquals(VersionId(startingVersion.version + 1), updatedVersion)
             }
             observer.cancel()

--- a/test/src/androidTest/kotlin/io/realm/shared/notifications/SystemNotificationTests.kt
+++ b/test/src/androidTest/kotlin/io/realm/shared/notifications/SystemNotificationTests.kt
@@ -56,7 +56,7 @@ class SystemNotificationTests {
     @Test
     fun multipleSchedulersOnSameThread() {
         Utils.printlntid("main")
-        val baseRealm = Realm.openBlocking(configuration)
+        val baseRealm = Realm.openBlocking(configuration) as io.realm.internal.RealmImpl
         val dispatcher = singleThreadDispatcher("background")
         val writer1 = io.realm.internal.SuspendableWriter(baseRealm, dispatcher)
         val writer2 = io.realm.internal.SuspendableWriter(baseRealm, dispatcher)

--- a/test/src/commonMain/kotlin/io/realm/util/Utils.kt
+++ b/test/src/commonMain/kotlin/io/realm/util/Utils.kt
@@ -19,7 +19,6 @@ package io.realm.util
 
 import io.realm.Realm
 import io.realm.RealmObject
-import io.realm.internal.RealmObjectInternal
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -53,7 +52,8 @@ object Utils {
  * This method control its own write transaction, so cannot be called inside a write transaction
  */
 suspend fun <T : RealmObject> T.update(block: T.() -> Unit): T {
-    val realm = ((this as RealmObjectInternal).`$realm$Owner`!!).owner as Realm
+    @Suppress("invisible_reference", "invisible_member")
+    val realm = ((this as io.realm.internal.RealmObjectInternal).`$realm$Owner`!!).owner as Realm
     return realm.write {
         val liveObject: T = findLatest(this@update)!!
         block(liveObject)

--- a/test/src/macosTest/kotlin/io/realm/InstrumentedTests.kt
+++ b/test/src/macosTest/kotlin/io/realm/InstrumentedTests.kt
@@ -20,10 +20,7 @@ package io.realm
 
 // FIXME API-CLEANUP Do we actually want to expose this. Test should probably just be reeavluated
 //  or moved.
-import io.realm.internal.BaseRealmImpl
 import io.realm.internal.RealmConfigurationImpl
-import io.realm.internal.RealmObjectInternal
-import io.realm.internal.RealmReference
 import io.realm.interop.NativePointer
 import kotlinx.cinterop.COpaquePointerVar
 import kotlinx.cinterop.CPointed
@@ -43,12 +40,14 @@ class InstrumentedTests {
     //  require the native wrapper to be api dependency from cinterop/library. Don't know if the
     //  test is needed at all at this level
     class CPointerWrapper(val ptr: CPointer<out CPointed>?, managed: Boolean = true) : NativePointer
+
     @Test
+    @Suppress("invisible_reference", "invisible_member")
     fun testRealmObjectInternalPropertiesGenerated() {
         val p = Sample()
 
         @Suppress("CAST_NEVER_SUCCEEDS")
-        val realmModel: RealmObjectInternal = p as? RealmObjectInternal
+        val realmModel: io.realm.internal.RealmObjectInternal = p as? io.realm.internal.RealmObjectInternal
             ?: error("Supertype RealmObjectInternal was not added to Sample class")
 
         memScoped {
@@ -61,8 +60,8 @@ class InstrumentedTests {
 
             val realmPointer: NativePointer = CPointerWrapper(ptr2.ptr)
             val configuration = RealmConfiguration.Builder(schema = setOf(Sample::class)).build()
-            @Suppress("invisible_member")
-            realmModel.`$realm$Owner` = RealmReference(object : BaseRealmImpl(configuration as RealmConfigurationImpl, realmPointer) {}, realmPointer)
+            val owner = object : io.realm.internal.BaseRealmImpl(configuration as RealmConfigurationImpl, realmPointer) {}
+            realmModel.`$realm$Owner` = io.realm.internal.RealmReference(owner, realmPointer)
             realmModel.`$realm$TableName` = "Sample"
 
             assertEquals(true, realmModel.`$realm$IsManaged`)


### PR DESCRIPTION
This adds common:
- `Versioned` interface with `version(): VersionID`
- Internal default implementation of`RealmLifeCycle` through `RealmLifeCycleHolder` with common internal life cycle methods. 

The public `RealmObject` still does not implement versioned as this requires adding the synthetic methods and overrides in the compiler plugin. The extension methods are however adjusted to match and is using the same shared implementation. 