### PR TITLE
Add support for running Sync Integration Tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -334,7 +334,7 @@ def testWithServer(dir, task) {
 
     try {
         testAndCollect(dir, task)
-    } catch (err) {
+    } finally {
         // We assume that creating these containers and the docker network can be considered an atomic operation.
         if (mongoDbRealmContainer != null && mongoDbRealmCommandServerContainer != null) {
             archiveServerLogs(mongoDbRealmContainer.id, mongoDbRealmCommandServerContainer.id)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -330,8 +330,8 @@ def testWithServer(dir, task) {
 
     // FIXME Using named containers mean that we cannot run on CI machines with multiple executors
     sh "docker network create ${dockerNetworkId}"
-    mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000 --name mongodb-realm")
-    mongoDbRealmCommandServerContainer = commandServerEnv.run("--rm -i -t -d --network container:${mongoDbRealmContainer.id} -v$tempDir:/apps  --name mongodb-realm-command-server mongodb-realm-command-server")
+    mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000")
+    mongoDbRealmCommandServerContainer = commandServerEnv.run("--rm -i -t -d --network container:${mongoDbRealmContainer.id} -v$tempDir:/apps")
 
     sh "timeout 60 sh -c \"while [[ ! -f $tempDir/testapp1/app_id || ! -f $tempDir/testapp2/app_id ]]; do echo 'Waiting for server to start'; sleep 1; done\""
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ mongoDbRealmCommandServerContainer = null
 
 
 // Mac CI dedicated machine
-node_label = 'osx_kotlin'
+node_label = 'kotlin_machine_test' //'osx_kotlin'
 
 // When having multiple executors available, Jenkins might append @2/@3/etc. to workspace folders in order
 // to allow multiple parallel builds on the same branch. Unfortunately this breaks Ninja and thus us

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -461,3 +461,7 @@ def archiveServerLogs(String mongoDbRealmContainerId, String commandServerContai
     ])
     sh 'rm mongodb.log'
 }
+
+def runCommand(String command){
+  return sh(script: command, returnStdout: true).trim()
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,11 +81,11 @@ pipeline {
                 runScm()
             }
         }
-        stage('Build') {
-            steps {
-                runBuild()
-            }
-        }
+//         stage('Build') {
+//             steps {
+//                 runBuild()
+//             }
+//         }
 //         stage('Static Analysis') {
 //             when { expression { runTests } }
 //             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ mongoDbRealmContainer = null
 mongoDbRealmCommandServerContainer = null
 
 // Mac CI dedicated machine
-node_label = 'kotlin_machine_test' //'osx_kotlin'
+node_label = 'osx_kotlin'
 
 // When having multiple executors available, Jenkins might append @2/@3/etc. to workspace folders in order
 // to allow multiple parallel builds on the same branch. Unfortunately this breaks Ninja and thus us
@@ -170,8 +170,8 @@ def runScm() {
             branches         : scm.branches,
             gitTool          : 'native git',
             extensions       : scm.extensions + [
-//                     [$class: 'WipeWorkspace'],
-//                     [$class: 'CleanCheckout'],
+                    [$class: 'WipeWorkspace'],
+                    [$class: 'CleanCheckout'],
                     [$class: 'SubmoduleOption', recursiveSubmodules: true]
             ],
             userRemoteConfigs: scm.userRemoteConfigs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -327,11 +327,9 @@ def testWithServer(dir, task) {
     // TODO: How much of this logic can be moved to start_server.sh for shared logic with local testing.
     def tempDir = runCommand('mktemp -d -t app_config.XXXXXXXXXX')
     sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template testapp1 testapp2"
-//     sh "docker network create ${dockerNetworkId}"
-//     mongoDbRealmContainer = mdbRealmImage.run("--network ${dockerNetworkId} -v$tempDir:/apps")
-    mongoDbRealmContainer = mdbRealmImage.run("--network host -v$tempDir:/apps")
-//    mongoDbRealmCommandServerContainer = commandServerEnv.run("--network container:${mongoDbRealmContainer.id} -v$tempDir:/apps")
-    mongoDbRealmCommandServerContainer = commandServerEnv.run("--network host -v$tempDir:/apps")
+    sh "docker network create ${dockerNetworkId}"
+    mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000")
+    mongoDbRealmCommandServerContainer = commandServerEnv.run("--rm -i -t -d --network container:${mongoDbRealmContainer.id} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000")
     sh "timeout 60 sh -c \"while [[ ! -f $tempDir/testapp1/app_id || ! -f $tempDir/testapp2/app_id ]]; do echo 'Waiting for server to start'; sleep 1; done\""
 
     try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -313,8 +313,8 @@ def testWithServer(dir, task) {
         sh "security -v unlock-keychain -p $PASSWORD"
     }
 
-    buildEnv = buildDockerEnv("ci/realm-java:master", push: currentBranch == 'master-do-not-cache')
-    def props = readProperties file: 'dependencies.list'
+//     buildEnv = buildDockerEnv("ci/realm-java:master", push: currentBranch == 'master-do-not-cache')
+//     def props = readProperties file: 'dependencies.list'
     echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
     def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")
     docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -314,7 +314,7 @@ def testWithServer(dir, task) {
     }
 
 //     buildEnv = buildDockerEnv("ci/realm-java:master", push: currentBranch == 'master-do-not-cache')
-//     def props = readProperties file: 'dependencies.list'
+    def props = readProperties file: 'dependencies.list'
     echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
     def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")
     docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ isReleaseBranch = releaseBranches.contains(currentBranch)
 
 // References to Docker containers holding the MongoDB Test server and infrastructure for
 // controlling it.
+dockerNetworkId = UUID.randomUUID().toString()
 mongoDbRealmContainer = null
 mongoDbRealmCommandServerContainer = null
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -433,29 +433,29 @@ boolean shouldPublishSnapshot(version) {
 
 def archiveServerLogs(String mongoDbRealmContainerId, String commandServerContainerId) {
     sh "docker logs ${commandServerContainerId} > ./command-server.log"
+    sh 'rm command-server-log.zip'
     zip([
         'zipFile': 'command-server-log.zip',
         'archive': true,
-        'overwrite': true,
-        'glob' : 'command-server.log'
+        'glob': 'command-server.log'
     ])
     sh 'rm command-server.log'
 
     sh "docker cp ${mongoDbRealmContainerId}:/var/log/stitch.log ./stitch.log"
+    sh 'rm stitchlog.zip'
     zip([
         'zipFile': 'stitchlog.zip',
         'archive': true,
-        'overwrite': true,
-        'glob' : 'stitch.log'
+        'glob': 'stitch.log'
     ])
     sh 'rm stitch.log'
 
     sh "docker cp ${mongoDbRealmContainerId}:/var/log/mongodb.log ./mongodb.log"
+    sh 'rm mongodb.zip'
     zip([
         'zipFile': 'mongodb.zip',
         'archive': true,
-        'overwrite': true,
-        'glob' : 'mongodb.log'
+        'glob': 'mongodb.log'
     ])
     sh 'rm mongodb.log'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,11 +246,13 @@ def runStaticAnalysis() {
                 rsync -a --delete --ignore-errors packages/gradle-plugin/build/reports/detekt/ /tmp/detekt/plugin-gradle/ || true
                 rsync -a --delete --ignore-errors packages/runtime-api/build/reports/detekt/ /tmp/detekt/runtime-api/ || true
             '''
+        sh 'rm ktlint.zip || true'
         zip([
                 'zipFile': 'ktlint.zip',
                 'archive': true,
                 'dir'    : '/tmp/ktlint'
         ])
+        sh 'rm detekt.zip || true'
         zip([
                 'zipFile': 'detekt.zip',
                 'archive': true,
@@ -433,7 +435,7 @@ boolean shouldPublishSnapshot(version) {
 
 def archiveServerLogs(String mongoDbRealmContainerId, String commandServerContainerId) {
     sh "docker logs ${commandServerContainerId} > ./command-server.log"
-    sh 'rm command-server-log.zip'
+    sh 'rm command-server-log.zip || true'
     zip([
         'zipFile': 'command-server-log.zip',
         'archive': true,
@@ -442,7 +444,7 @@ def archiveServerLogs(String mongoDbRealmContainerId, String commandServerContai
     sh 'rm command-server.log'
 
     sh "docker cp ${mongoDbRealmContainerId}:/var/log/stitch.log ./stitch.log"
-    sh 'rm stitchlog.zip'
+    sh 'rm stitchlog.zip || true'
     zip([
         'zipFile': 'stitchlog.zip',
         'archive': true,
@@ -451,7 +453,7 @@ def archiveServerLogs(String mongoDbRealmContainerId, String commandServerContai
     sh 'rm stitch.log'
 
     sh "docker cp ${mongoDbRealmContainerId}:/var/log/mongodb.log ./mongodb.log"
-    sh 'rm mongodb.zip'
+    sh 'rm mongodb.zip || true'
     zip([
         'zipFile': 'mongodb.zip',
         'archive': true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -327,7 +327,7 @@ def testWithServer(dir, task) {
     // TODO: How much of this logic can be moved to start_server.sh for shared logic with local testing.
     def tempDir = runCommand('mktemp -d -t app_config.XXXXXXXXXX')
     sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template testapp1 testapp2"
-    sh "docker network create ${dockerNetworkId}"
+//     sh "docker network create ${dockerNetworkId}"
 //     mongoDbRealmContainer = mdbRealmImage.run("--network ${dockerNetworkId} -v$tempDir:/apps")
     mongoDbRealmContainer = mdbRealmImage.run("--network host -v$tempDir:/apps")
 //    mongoDbRealmCommandServerContainer = commandServerEnv.run("--network container:${mongoDbRealmContainer.id} -v$tempDir:/apps")
@@ -343,7 +343,7 @@ def testWithServer(dir, task) {
             archiveServerLogs(mongoDbRealmContainer.id, mongoDbRealmCommandServerContainer.id)
             mongoDbRealmContainer.stop()
             mongoDbRealmCommandServerContainer.stop()
-            sh "docker network rm ${dockerNetworkId}"
+//             sh "docker network rm ${dockerNetworkId}"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -306,11 +306,6 @@ def runCompilerPluginTest() {
 }
 
 def testWithServer(dir, task) {
-    buildEnv = buildDockerEnv("ci/realm-kotlin:master", push: currentBranch == currentBranch)
-    def props = readProperties file: 'dependencies.list'
-    echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
-    def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")
-
     // Work-around for https://github.com/docker/docker-credential-helpers/issues/82
     withCredentials([
             [$class: 'StringBinding', credentialsId: 'realm-kotlin-ci-password', variable: 'PASSWORD'],
@@ -318,6 +313,10 @@ def testWithServer(dir, task) {
         sh "security -v unlock-keychain -p $PASSWORD"
     }
 
+    buildEnv = buildDockerEnv("ci/realm-kotlin:master", push: currentBranch == currentBranch)
+    def props = readProperties file: 'dependencies.list'
+    echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
+    def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")
     docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {
       mdbRealmImage.pull()
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,7 +329,7 @@ def testWithServer(dir, task) {
     sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template testapp1 testapp2"
     sh "docker network create ${dockerNetworkId}"
     mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000")
-    mongoDbRealmCommandServerContainer = commandServerEnv.run("--rm -i -t -d --network container:${mongoDbRealmContainer.id} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000")
+    mongoDbRealmCommandServerContainer = commandServerEnv.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000")
     sh "timeout 60 sh -c \"while [[ ! -f $tempDir/testapp1/app_id || ! -f $tempDir/testapp2/app_id ]]; do echo 'Waiting for server to start'; sleep 1; done\""
 
     try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,72 +86,72 @@ pipeline {
                 runBuild()
             }
         }
-//         stage('Static Analysis') {
-//             when { expression { runTests } }
-//             steps {
-//                 runStaticAnalysis()
-//             }
-//         }
-//         stage('Tests Compiler Plugin') {
-//             when { expression { runTests } }
-//             steps {
-//                 runCompilerPluginTest()
-//             }
-//         }
-//         stage('Tests Macos - Unit Tests') {
-//             when { expression { runTests } }
-//             steps {
-//                 testAndCollect("packages", "macosTest")
-//             }
-//         }
+        stage('Static Analysis') {
+            when { expression { runTests } }
+            steps {
+                runStaticAnalysis()
+            }
+        }
+        stage('Tests Compiler Plugin') {
+            when { expression { runTests } }
+            steps {
+                runCompilerPluginTest()
+            }
+        }
+        stage('Tests Macos - Unit Tests') {
+            when { expression { runTests } }
+            steps {
+                testAndCollect("packages", "macosTest")
+            }
+        }
         stage('Tests Macos - Integration Tests') {
             when { expression { runTests } }
             steps {
                 testWithServer("test", "macosTest")
             }
         }
-//         stage('Tests Android') {
-//             when { expression { runTests } }
-//             steps {
-//                 testAndCollect("packages", "connectedAndroidTest")
-//                 testAndCollect("test",     "connectedAndroidTest")
-//             }
-//         }
-//         stage('Tests JVM (compiler only)') {
-//             when { expression { runTests } }
-//             steps {
-//                 testAndCollect("test", 'jvmTest --tests "io.realm.test.compiler*"')
-//             }
-//         }
-//         stage('Tests Android Sample App') {
-//             when { expression { runTests } }
-//             steps {
-//                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-//                     runMonkey()
-//                 }
-//             }
-//         }
-//         stage('Build Android on Java 8') {
-//             when { expression { runTests } }
-//             environment {
-//                 JAVA_HOME="${JAVA_8}"
-//             }
-//             steps {
-//                 runBuildAndroidApp()
-//             }
-//         }
-//         stage('Publish SNAPSHOT to Maven Central') {
-//             when { expression { shouldPublishSnapshot(version) } }
-//             steps {
-//                 runPublishSnapshotToMavenCentral()
-//             }
-//         }
-//         stage('Publish Release to Maven Central') {
-//             when { expression { publishBuild } }
-//             steps {
-//                 runPublishReleaseOnMavenCentral()
-//             }
-//         }
+        stage('Tests Android') {
+            when { expression { runTests } }
+            steps {
+                testAndCollect("packages", "connectedAndroidTest")
+                testAndCollect("test",     "connectedAndroidTest")
+            }
+        }
+        stage('Tests JVM (compiler only)') {
+            when { expression { runTests } }
+            steps {
+                testAndCollect("test", 'jvmTest --tests "io.realm.test.compiler*"')
+            }
+        }
+        stage('Tests Android Sample App') {
+            when { expression { runTests } }
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    runMonkey()
+                }
+            }
+        }
+        stage('Build Android on Java 8') {
+            when { expression { runTests } }
+            environment {
+                JAVA_HOME="${JAVA_8}"
+            }
+            steps {
+                runBuildAndroidApp()
+            }
+        }
+        stage('Publish SNAPSHOT to Maven Central') {
+            when { expression { shouldPublishSnapshot(version) } }
+            steps {
+                runPublishSnapshotToMavenCentral()
+            }
+        }
+        stage('Publish Release to Maven Central') {
+            when { expression { publishBuild } }
+            steps {
+                runPublishReleaseOnMavenCentral()
+            }
+        }
     }
     post {
         failure {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -419,7 +419,11 @@ def startEmulatorInBgIfNeeded() {
     def command = '$ANDROID_SDK_ROOT/platform-tools/adb shell pidof com.android.phone'
     def returnStatus = sh(returnStatus: true, script: command)
     if (returnStatus != 0) {
+        // Changing the name of the emulator image requires that this emulator image is
+        // present on both atlanta_host13 and atlanta_host14.
         sh '/usr/local/Cellar/daemonize/1.7.8/sbin/daemonize  -E JENKINS_NODE_COOKIE=dontKillMe  $ANDROID_SDK_ROOT/emulator/emulator -avd Pixel_2_API_30_x86_64 -no-boot-anim -no-window -wipe-data -noaudio -partition-size 4098'
+    } else {
+        throw
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -313,7 +313,7 @@ def testWithServer(dir, task) {
         sh "security -v unlock-keychain -p $PASSWORD"
     }
 
-    buildEnv = buildDockerEnv("ci/realm-kotlin:master", push: currentBranch == currentBranch)
+    buildEnv = buildDockerEnv("ci/realm-java:master", push: currentBranch == currentBranch)
     def props = readProperties file: 'dependencies.list'
     echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
     def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -422,8 +422,6 @@ def startEmulatorInBgIfNeeded() {
         // Changing the name of the emulator image requires that this emulator image is
         // present on both atlanta_host13 and atlanta_host14.
         sh '/usr/local/Cellar/daemonize/1.7.8/sbin/daemonize  -E JENKINS_NODE_COOKIE=dontKillMe  $ANDROID_SDK_ROOT/emulator/emulator -avd Pixel_2_API_30_x86_64 -no-boot-anim -no-window -wipe-data -noaudio -partition-size 4098'
-    } else {
-        throw
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -313,7 +313,7 @@ def testWithServer(dir, task) {
         sh "security -v unlock-keychain -p $PASSWORD"
     }
 
-    buildEnv = buildDockerEnv("ci/realm-java:master", push: currentBranch == currentBranch)
+    buildEnv = buildDockerEnv("ci/realm-java:master", push: currentBranch == 'master-do-not-cache')
     def props = readProperties file: 'dependencies.list'
     echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
     def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -310,6 +310,14 @@ def testWithServer(dir, task) {
     def props = readProperties file: 'dependencies.list'
     echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
     def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")
+
+    // Work-around for https://github.com/docker/docker-credential-helpers/issues/82
+    withCredentials([
+            [$class: 'StringBinding', credentialsId: 'realm-kotlin-ci-password', variable: 'PASSWORD'],
+    ]) {
+        sh "security -v unlock-keychain -p $PASSWORD"
+    }
+
     docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {
       mdbRealmImage.pull()
     }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -25,7 +25,6 @@ import io.realm.mongodb.internal.KtorNetworkTransport
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 const val TEST_APP_1 = "testapp1" // Id for the default test app
 const val BASE_URL = "http://127.0.0.1:9090"
@@ -33,6 +32,7 @@ const val BASE_URL = "http://127.0.0.1:9090"
 // Cannot run on CI yet, as it requires sync server to be started with
 // tools/sync_test_server/start_server.sh and manual creation of a user "asdf@asdf.com"/"asdfasdf"
 // through the web ui
+@Ignore
 class AppTests {
 
     @Test
@@ -55,12 +55,12 @@ class AppTests {
                 else -> throw IllegalStateException(response.toString())
             }
         }
-        assertTrue(applicationId.startsWith("testapp1"))
-//        val configuration: AppConfiguration = appConfigurationOf(applicationId, BASE_URL, singleThreadDispatcher("asdf"))
-//        val app = App.create(configuration)
-//
-//        runBlocking {
-//            app.login(EmailPassword("asdf@asdf.com", "asdfasdf")).getOrThrow()
-//        }
+
+        val configuration: AppConfiguration = appConfigurationOf(applicationId, BASE_URL, singleThreadDispatcher("asdf"))
+        val app = App.create(configuration)
+
+        runBlocking {
+            app.login(EmailPassword("asdf@asdf.com", "asdfasdf")).getOrThrow()
+        }
     }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -32,7 +32,6 @@ const val BASE_URL = "http://127.0.0.1:9090"
 // Cannot run on CI yet, as it requires sync server to be started with
 // tools/sync_test_server/start_server.sh and manual creation of a user "asdf@asdf.com"/"asdfasdf"
 // through the web ui
-@Ignore
 class AppTests {
 
     @Test
@@ -55,12 +54,12 @@ class AppTests {
                 else -> throw IllegalStateException(response.toString())
             }
         }
-
-        val configuration: AppConfiguration = appConfigurationOf(applicationId, BASE_URL, singleThreadDispatcher("asdf"))
-        val app = App.create(configuration)
-
-        runBlocking {
-            app.login(EmailPassword("asdf@asdf.com", "asdfasdf")).getOrThrow()
-        }
+        assertTrue(application.startsWith("testapp1"))
+//        val configuration: AppConfiguration = appConfigurationOf(applicationId, BASE_URL, singleThreadDispatcher("asdf"))
+//        val app = App.create(configuration)
+//
+//        runBlocking {
+//            app.login(EmailPassword("asdf@asdf.com", "asdfasdf")).getOrThrow()
+//        }
     }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -25,6 +25,7 @@ import io.realm.mongodb.internal.KtorNetworkTransport
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 const val TEST_APP_1 = "testapp1" // Id for the default test app
 const val BASE_URL = "http://127.0.0.1:9090"
@@ -54,7 +55,7 @@ class AppTests {
                 else -> throw IllegalStateException(response.toString())
             }
         }
-        assertTrue(application.startsWith("testapp1"))
+        assertTrue(applicationId.startsWith("testapp1"))
 //        val configuration: AppConfiguration = appConfigurationOf(applicationId, BASE_URL, singleThreadDispatcher("asdf"))
 //        val app = App.create(configuration)
 //


### PR DESCRIPTION
This PR starts the Docker container on Jenkins that contains the MongoDB Test Server and run Sync integration tests on it.

### TODO
- [x] See how much logic can be moved to shell scripts so it can be shared with local testing -> CONCLUSION: Doesn't seem immediate obvious how, so punting to another issue.
- [x] Figure out if it would be easy to split Sync and Base tests into two different test runs -> CONCLUSION: Looks like we need to create two `test-xxx` projects. That is too much work for this PR, so punting to another PR.