### PR TITLE
Enable incremental builds on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,6 @@ def runScm() {
             [$class: 'CleanCheckout'],
         ]       
     }
-    echo repoExtensions
     checkout([
             $class           : 'GitSCM',
             branches         : scm.branches,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,10 +58,10 @@ pipeline {
         }
      }
     // The Gradle cache is re-used between stages, in order to avoid builds interleave,
-    // and potentially corrupt each others cache, we grab a global lock for the entire
-    // build.
+    // and potentially corrupt each others cache, we grab a node lock for the entire
+    // build. 
     options {
-        lock resource: 'kotlin_build_lock'
+        lock resource: "${env.NODE_NAME}-kotlin_build_lock"
         timeout(time: 15, activity: true, unit: 'MINUTES')
     }
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import groovy.json.JsonOutput
 
 @Library('realm-ci') _

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,7 +206,7 @@ def runBuild() {
             }
             sh """
                   cd packages
-                  chmod +x gradlew && ./gradlew clean assemble ${signingFlags} --info --stacktrace --no-daemon
+                  chmod +x gradlew && ./gradlew assemble ${signingFlags} --info --stacktrace --no-daemon
                """
         }
     }
@@ -293,7 +293,7 @@ def runCompilerPluginTest() {
     withEnv(['PATH+USER_BIN=/usr/local/bin']) {
         sh """
             cd packages
-            ./gradlew --no-daemon clean :plugin-compiler:test --info --stacktrace
+            ./gradlew --no-daemon :plugin-compiler:test --info --stacktrace
         """
         step([ $class: 'JUnitResultArchiver', allowEmptyResults: true, testResults: "packages/plugin-compiler/build/**/TEST-*.xml"])
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -406,7 +406,7 @@ def runBuildAndroidApp() {
         sh """
             cd examples/kmm-sample
             java -version
-            ./gradlew :androidApp:clean :androidApp:assembleDebug --stacktrace --no-daemon
+            ./gradlew :androidApp:assembleDebug --stacktrace --no-daemon
         """
     } catch (err) {
         currentBuild.result = 'FAILURE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,9 +80,9 @@ pipeline {
           JAVA_11='/Library/Java/JavaVirtualMachines/jdk-11.0.12.jdk/Contents/Home'
           JAVA_HOME="${JAVA_11}"
           CCACHE_CPP2=true
-          CCACHE_COMPILERCHECK=content
-          CC="ccache clang"
-          CXX="ccache clang++"
+          CCACHE_COMPILERCHECK='content'
+          CC='ccache clang'
+          CXX='ccache clang++'
     }
     stages {
         stage('Prepare CI') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,15 +155,21 @@ pipeline {
 }
 
 def runScm() {
+    def repoExtensions = [
+        [$class: 'SubmoduleOption', recursiveSubmodules: true]
+    ]
+    if (isReleaseBranch) {
+        repoExtensions += [          
+            [$class: 'WipeWorkspace'],
+            [$class: 'CleanCheckout'],
+        ]       
+    }
+    echo repoExtensions
     checkout([
             $class           : 'GitSCM',
             branches         : scm.branches,
             gitTool          : 'native git',
-            extensions       : scm.extensions + [
-                    [$class: 'WipeWorkspace'],
-                    [$class: 'CleanCheckout'],
-                    [$class: 'SubmoduleOption', recursiveSubmodules: true]
-            ],
+            extensions       : scm.extensions + repoExtensions,
             userRemoteConfigs: scm.userRemoteConfigs
     ])
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,10 +79,6 @@ pipeline {
           JAVA_8='/Library/Java/JavaVirtualMachines/jdk1.8.0_301.jdk/Contents/Home'
           JAVA_11='/Library/Java/JavaVirtualMachines/jdk-11.0.12.jdk/Contents/Home'
           JAVA_HOME="${JAVA_11}"
-          CCACHE_CPP2=true
-          CCACHE_COMPILERCHECK='content'
-          CC='ccache clang'
-          CXX='ccache clang++'
     }
     stages {
         stage('Prepare CI') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,10 @@ pipeline {
           JAVA_8='/Library/Java/JavaVirtualMachines/jdk1.8.0_301.jdk/Contents/Home'
           JAVA_11='/Library/Java/JavaVirtualMachines/jdk-11.0.12.jdk/Contents/Home'
           JAVA_HOME="${JAVA_11}"
+          CCACHE_CPP2=true
+          CCACHE_COMPILERCHECK=content
+          CC="ccache clang"
+          CXX="ccache clang++"
     }
     stages {
         stage('Prepare CI') {

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -253,6 +253,8 @@ android {
         externalNativeBuild {
             cmake {
                 arguments("-DANDROID_STL=c++_shared")
+                arguments("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
+                arguments("-DCMAKE_C_COMPILER_LAUNCHER=ccache")
                 targets.add("realmc")
             }
         }
@@ -301,6 +303,8 @@ fun Task.build_C_API_Macos_Universal(releaseBuild: Boolean = false) {
             commandLine(
                 "cmake",
                 "-DCMAKE_TOOLCHAIN_FILE=$absoluteCorePath/tools/cmake/macosx.toolchain.cmake",
+                "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                 "-DCMAKE_BUILD_TYPE=$buildType",
                 "-DREALM_ENABLE_SYNC=1",
                 "-DREALM_NO_TESTS=1",
@@ -334,6 +338,8 @@ fun Task.build_C_API_Simulator_Universal(releaseBuild: Boolean = false) {
             workingDir(project.file(directory))
             commandLine(
                 "cmake", "-DCMAKE_TOOLCHAIN_FILE=$absoluteCorePath/tools/cmake/ios.toolchain.cmake",
+                "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                 "-DCMAKE_INSTALL_PREFIX=.",
                 "-DCMAKE_BUILD_TYPE=$buildType",
                 "-DREALM_NO_TESTS=1",
@@ -379,6 +385,8 @@ fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
             commandLine(
                 "cmake", "-DCMAKE_TOOLCHAIN_FILE=$absoluteCorePath/tools/cmake/ios.toolchain.cmake",
                 "-DCMAKE_INSTALL_PREFIX=.",
+                "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                 "-DCMAKE_BUILD_TYPE=$buildType",
                 "-DREALM_NO_TESTS=1",
                 "-DREALM_ENABLE_SYNC=1",


### PR DESCRIPTION
Closes #454 

This PR does two things:

- Enable CCache support
- Don't wipe the workspace between PR builds .These options clear all files not part of the repo, including those in `.gitignore`. In our case, this specifically means any `.gradle` or `.cxx` caches already built.

By keeping those around, we can significantly increase build times for PR's, but it relies on the build script being able to handle incremental builds. Some changes needed for this were added in #452 (zip file handling), so this PR will fail until that PR is merged.

With multiple nodes also present, I had to refactor how we do locking. Turns out that locking on a node is rather difficult, but fortunately doesn't seem needed either. But I did had to refactor the pipeline to make sure that all steps run on the same node.

### Metrics

With this change:

If `packages` are not modified and we hit the Gradle cache the `build` step goes from 15-17 minutes to 1-2 minutes. 

On a clean build where we hit the CCache, a full build goes from ~30 minutes to ~20 minutes.
