### PR TITLE
Revert using Result as transport for resulting data on sync calls

### DIFF
--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/App.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/App.kt
@@ -32,7 +32,7 @@ interface App {
     // FIXME Reevaluate Result api to surface App errors more explicitly
     //  https://github.com/realm/realm-kotlin/pull/447#discussion_r707344044
     //  https://github.com/realm/realm-kotlin/issues/241
-    suspend fun login(credentials: Credentials): Result<User>
+    suspend fun login(credentials: Credentials): User
 
     companion object {
         /**

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppImpl.kt
@@ -20,6 +20,7 @@ import io.realm.internal.interop.CinteropCallback
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.platform.appFilesDirectory
+import io.realm.internal.util.Validation
 import io.realm.mongodb.App
 import io.realm.mongodb.Credentials
 import io.realm.mongodb.User
@@ -40,8 +41,7 @@ internal class AppImpl(
         )
 
     override suspend fun login(credentials: Credentials): User {
-        val credentialsInternal: CredentialImpl =
-            io.realm.internal.util.Validation.checkType(credentials, "credentials")
+        val credentialsInternal: CredentialImpl = Validation.checkType(credentials, "credentials")
         return suspendCoroutine { continuation ->
             RealmInterop.realm_app_log_in_with_credentials(
                 nativePointer,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppImpl.kt
@@ -39,24 +39,23 @@ internal class AppImpl(
             basePath = appFilesDirectory()
         )
 
-    override suspend fun login(credentials: Credentials): Result<User> {
-        val credentialsInternal: CredentialImpl = io.realm.internal.util.Validation.checkType(credentials, "credentials")
-        return RealmInterop.runCatching {
-            suspendCoroutine { continuation ->
-                realm_app_log_in_with_credentials(
-                    nativePointer,
-                    (credentials as CredentialImpl).nativePointer,
-                    object : CinteropCallback {
-                        override fun onSuccess(pointer: NativePointer) {
-                            continuation.resume(UserImpl(pointer))
-                        }
-
-                        override fun onError(throwable: Throwable) {
-                            continuation.resumeWithException(throwable)
-                        }
+    override suspend fun login(credentials: Credentials): User {
+        val credentialsInternal: CredentialImpl =
+            io.realm.internal.util.Validation.checkType(credentials, "credentials")
+        return suspendCoroutine { continuation ->
+            RealmInterop.realm_app_log_in_with_credentials(
+                nativePointer,
+                (credentials as CredentialImpl).nativePointer,
+                object : CinteropCallback {
+                    override fun onSuccess(pointer: NativePointer) {
+                        continuation.resume(UserImpl(pointer))
                     }
-                )
-            }
+
+                    override fun onError(throwable: Throwable) {
+                        continuation.resumeWithException(throwable)
+                    }
+                }
+            )
         }
     }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -49,7 +49,7 @@ class AppTests {
     @Test
     fun loginAnonymous() {
         runBlocking {
-            app.login(Credentials.anonymous()).getOrThrow()
+            app.login(Credentials.anonymous())
         }
     }
 
@@ -58,7 +58,7 @@ class AppTests {
         // Create test user through REST admin api until we have EmailPasswordAuth.registerUser in place
         app.asTestApp.createUser("asdf@asdf.com", "asdfasdf")
         runBlocking {
-            app.login(Credentials.emailPassword("asdf@asdf.com", "asdfasdf")).getOrThrow()
+            app.login(Credentials.emailPassword("asdf@asdf.com", "asdfasdf"))
         }
     }
 
@@ -81,7 +81,7 @@ class AppTests {
             // TODO Should be AppException (ErrorCode.INVALID_EMAIL_PASSWORD, ex.errorCode)
             //  https://github.com/realm/realm-kotlin/issues/426
             assertFailsWith<RuntimeException> {
-                app.login(credentials).getOrThrow()
+                app.login(credentials)
             }
         }
     }


### PR DESCRIPTION
Error handling in sync calls would follow the standard error catching. This PR reverts from using `Result` to throwing exceptions.

Users can at any moment wrap the calls with `runCatching` to convert the data/exceptions in a `Result` instance.