### PR TITLE
Fail CI if we can't build the shared lib for iOS (sample)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,6 +146,14 @@ pipeline {
                         }
                     }
                 }
+                stage('iOS Sample App Builds') {
+                    when { expression { runTests } }
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            packForXcode()
+                        }
+                    }
+                }
                 stage('Build Android on Java 8') {
                     when { expression { runTests } }
                     environment {
@@ -424,6 +432,18 @@ def runBuildAndroidApp() {
             cd examples/kmm-sample
             java -version
             ./gradlew :androidApp:assembleDebug --stacktrace --no-daemon
+        """
+    } catch (err) {
+        currentBuild.result = 'FAILURE'
+        currentBuild.stageResult = 'FAILURE'
+    }
+}
+
+def packForXcode() {
+    try {
+        sh """
+            cd examples/kmm-sample
+            ./gradlew :shared:packForXcode --stacktrace --no-daemon
         """
     } catch (err) {
         currentBuild.result = 'FAILURE'


### PR DESCRIPTION
building the sample app now throws, this PR adds a step to catch it on CI
```
he /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld command returned non-zero exit code: 1.
output:
ld: warning: ignoring file /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.0.0/lib/darwin//libclang_rt.ios.a, missing required architecture x86_64 in file /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.0.0/lib/darwin//libclang_rt.ios.a (4 slices)
Undefined symbols for architecture x86_64:
  "___isPlatformVersionAtLeast", referenced from:
      realm::util::terminate_internal(std::__1::basic_stringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) in libio.realm.kotlin:cinterop-cache.a(terminate.o)
      realm::util::DispatchQueueScheduler::DispatchQueueScheduler(dispatch_queue_s*) in libio.realm.kotlin:cinterop-cache.a(scheduler.o)
      realm::util::(anonymous namespace)::ensure_reclaimer_thread_runs() in libio.realm.kotlin:cinterop-cache.a(file_mapper.o)
      realm::util::network::SecureTransportErrorCategory::message(int) const in libio.realm.kotlin:cinterop-cache.a(network_ssl.o)
      realm::util::network::ssl::Stream::verify_peer() in libio.realm.kotlin:cinterop-cache.a(network_ssl.o)
  "___cpu_model", referenced from:
      polyHash_x86(int, unsigned short const*) in libstdlib-cache.a(result.o)
ld: symbol(s) not found for architecture x86_64
```

This should be caught by the CI (I believe we broke this when adding sync)