### PR TITLE
Sync login method to throw AppException instead of RuntimeException

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/mongodb/AppException.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/mongodb/AppException.kt
@@ -16,7 +16,6 @@
 
 package io.realm.mongodb
 
+@Suppress("ForbiddenComment")
 // TODO: implement actual AppException with sync error codes hierarchy
-// https://github.com/realm/realm-kotlin/issues/426
-
 class AppException : Exception()

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/mongodb/AppException.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/mongodb/AppException.kt
@@ -19,4 +19,4 @@ package io.realm.mongodb
 // TODO: implement actual AppException with sync error codes hierarchy
 // https://github.com/realm/realm-kotlin/issues/426
 
-class AppException: Exception()
+class AppException : Exception()

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/mongodb/Errors.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/mongodb/Errors.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.mongodb
+
+// TODO: implement actual AppException with sync error codes hierarchy
+// https://github.com/realm/realm-kotlin/issues/426
+
+class AppException: Exception()

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -21,6 +21,7 @@ package io.realm.internal.interop
 import io.realm.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
 import io.realm.internal.interop.sync.AuthProvider
 import io.realm.internal.interop.sync.NetworkTransport
+import io.realm.mongodb.AppException
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.cinterop.BooleanVar
@@ -42,7 +43,6 @@ import kotlinx.cinterop.get
 import kotlinx.cinterop.getBytes
 import kotlinx.cinterop.invoke
 import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.readBytes
 import kotlinx.cinterop.refTo
@@ -95,8 +95,6 @@ private fun throwOnError() {
         }
     }
 }
-
-private fun toKException(error: realm_error_t): Throwable = RuntimeException("[${error.error}]: ${error.message?.toKString()}")
 
 private fun checkedBooleanResult(boolean: Boolean): Boolean {
     if (!boolean) throwOnError(); return boolean
@@ -912,7 +910,7 @@ actual object RealmInterop {
                 if (error == null) {
                     callback.onSuccess(CPointerWrapper(user))
                 } else {
-                    callback.onError(toKException(error.pointed))
+                    callback.onError(AppException())
                 }
             },
             StableRef.create(callback).asCPointer(),

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -235,15 +235,11 @@ void register_login_cb(realm_app_t *app, realm_app_credentials_t *credentials, j
                 } else if (error) {
                     // TODO OPTIMIZE Make central global reference table of classes
                     //  https://github.com/realm/realm-kotlin/issues/460
-                    jclass exception_class = jenv->FindClass("java/lang/RuntimeException");
+                    jclass exception_class = jenv->FindClass("io/realm/mongodb/AppException");
                     static jmethodID exception_constructor = jenv->GetMethodID(exception_class, "<init>",
-                                                                               "(Ljava/lang/String;)V");
+                                                                               "()V");
 
-                    std::string message("[" + std::to_string(error->error) + "]: " +
-                                        (error->message ? std::string(error->message) : ""));
-
-                    jobject throwable = jenv->NewObject(exception_class, exception_constructor,
-                                                        jenv->NewStringUTF(message.c_str()));
+                    jobject throwable = jenv->NewObject(exception_class, exception_constructor);
 
                     jenv->CallVoidMethod(static_cast<jobject>(userdata),
                                          on_error_method,

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -17,6 +17,7 @@
 package io.realm.test.mongodb.shared
 
 import io.realm.mongodb.App
+import io.realm.mongodb.AppException
 import io.realm.mongodb.AuthenticationProvider
 import io.realm.mongodb.Credentials
 import io.realm.test.mongodb.TestApp
@@ -78,9 +79,9 @@ class AppTests {
     fun loginInvalidUserThrows() {
         val credentials = Credentials.emailPassword("foo", "bar")
         runBlocking {
-            // TODO Should be AppException (ErrorCode.INVALID_EMAIL_PASSWORD, ex.errorCode)
+            // TODO AppException (ErrorCode.INVALID_EMAIL_PASSWORD, ex.errorCode)
             //  https://github.com/realm/realm-kotlin/issues/426
-            assertFailsWith<RuntimeException> {
+            assertFailsWith<AppException> {
                 app.login(credentials).getOrThrow()
             }
         }


### PR DESCRIPTION
This PR introduces the AppException as the exception thrown by sync methods.

It is not fully implemented and it requires it to implement the full sync error hierarchy.