### PR TITLE
Sync - config builder

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/CoreLogger.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/CoreLogger.kt
@@ -1,0 +1,5 @@
+package io.realm.internal.interop
+
+public interface CoreLogger {
+    fun log(level: Short, message: String)
+}

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -157,5 +157,5 @@ expect object RealmInterop {
     fun realm_auth_credentials_get_provider(credentials: NativePointer): AuthProvider
 
     // Sync config
-    fun realm_sync_config_new(user: NativePointer?, partition: String): NativePointer
+    fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer
 }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -157,5 +157,5 @@ expect object RealmInterop {
     fun realm_auth_credentials_get_provider(credentials: NativePointer): AuthProvider
 
     // Sync config
-    fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer
+    fun realm_sync_config_new(user: NativePointer?, partition: String): NativePointer
 }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -142,7 +142,7 @@ expect object RealmInterop {
         appConfig: NativePointer,
         syncClientConfig: NativePointer,
         basePath: String,
-    ): NativePointer // TODO sync config shouldn't be null
+    ): NativePointer
     fun realm_app_log_in_with_credentials(app: NativePointer, credentials: NativePointer, callback: CinteropCallback)
 
     // Sync client config

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -147,10 +147,6 @@ expect object RealmInterop {
 
     // Sync client config
     fun realm_sync_client_config_new(): NativePointer
-    fun realm_sync_client_config_set_logger_factory(
-        syncClientConfig: NativePointer,
-        loggerFactory: () -> CoreLogger
-    )
 
     // AppConfig
     fun realm_network_transport_new(networkTransport: NetworkTransport): NativePointer

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -140,8 +140,19 @@ expect object RealmInterop {
     fun realm_list_add_notification_callback(list: NativePointer, callback: Callback): NativePointer
 
     // App
-    fun realm_app_new(appConfig: NativePointer, basePath: String): NativePointer // TODO sync config shouldn't be null
+    fun realm_app_new(
+        appConfig: NativePointer,
+        syncClientConfig: NativePointer,
+        basePath: String,
+    ): NativePointer // TODO sync config shouldn't be null
     fun realm_app_log_in_with_credentials(app: NativePointer, credentials: NativePointer, callback: CinteropCallback)
+
+    // Sync client config
+    fun realm_sync_client_config_new(): NativePointer
+    fun realm_sync_client_config_set_logger_factory(
+        syncClientConfig: NativePointer,
+        loggerFactory: () -> Any
+    )
 
     // AppConfig
     fun realm_app_config_new(

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -158,4 +158,5 @@ expect object RealmInterop {
 
     // Sync config
     fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer
+    fun realm_config_set_sync_config(realmConfiguration: NativePointer, syncConfiguration: NativePointer)
 }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -151,7 +151,7 @@ expect object RealmInterop {
     fun realm_sync_client_config_new(): NativePointer
     fun realm_sync_client_config_set_logger_factory(
         syncClientConfig: NativePointer,
-        loggerFactory: () -> Any
+        loggerFactory: () -> CoreLogger
     )
 
     // AppConfig

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/sync/NetworkTransport.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/sync/NetworkTransport.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.interop.sync
 
 interface NetworkTransport {

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/sync/PartitionValue.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/sync/PartitionValue.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.interop.sync
+
+class PartitionValue private constructor(
+    private val stringValue: String? = null,
+    private val longValue: Long? = null
+) {
+
+    constructor(stringValue: String) : this(stringValue = stringValue, longValue = null)
+    constructor(longValue: Long) : this(stringValue = null, longValue = longValue)
+
+    private enum class ValueType {
+        STRING, LONG
+    }
+
+    private val valueType: ValueType = when {
+        stringValue != null -> ValueType.STRING
+        longValue != null -> ValueType.LONG
+        else -> throw IllegalStateException("Wrong partition value")
+    }
+
+    fun asSyncPartition(): String {
+        return when (valueType) {
+            ValueType.STRING -> """"${asString()}""""
+            ValueType.LONG -> """{"${'$'}numberLong":"${asLong()}"}"""
+        }
+    }
+    private fun asLong(): Long = checkValidType(ValueType.LONG).let { longValue!! }
+
+    private fun asString(): String = checkValidType(ValueType.STRING).let { stringValue!! }
+
+    private fun checkValidType(expectedValueType: ValueType) {
+        if (expectedValueType != valueType) {
+            throw IllegalStateException("This partition value is not a ${expectedValueType.name} but a ${valueType.name}")
+        }
+        when (valueType) {
+            ValueType.STRING ->
+                if (stringValue == null) throw IllegalStateException("String value cannot be null")
+            ValueType.LONG ->
+                if (longValue == null) throw IllegalStateException("Long value cannot be null")
+        }
+    }
+}

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/sync/PartitionValue.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/sync/PartitionValue.kt
@@ -40,9 +40,10 @@ class PartitionValue private constructor(
             ValueType.LONG -> """{"${'$'}numberLong":"${asLong()}"}"""
         }
     }
-    private fun asLong(): Long = checkValidType(ValueType.LONG).let { longValue!! }
 
-    private fun asString(): String = checkValidType(ValueType.STRING).let { stringValue!! }
+    fun asLong(): Long = checkValidType(ValueType.LONG).let { longValue!! }
+
+    fun asString(): String = checkValidType(ValueType.STRING).let { stringValue!! }
 
     private fun checkValidType(expectedValueType: ValueType) {
         if (expectedValueType != valueType) {

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -892,7 +892,11 @@ actual object RealmInterop {
     }
 
     // TODO sync config shouldn't be null
-    actual fun realm_app_new(appConfig: NativePointer, basePath: String): NativePointer {
+    actual fun realm_app_new(
+        appConfig: NativePointer,
+        syncClientConfig: NativePointer,
+        basePath: String
+    ): NativePointer {
         val syncClientConfig = realm_wrapper.realm_sync_client_config_new()
         realm_wrapper.realm_sync_client_config_set_base_file_path(syncClientConfig, basePath)
 
@@ -971,6 +975,17 @@ actual object RealmInterop {
                 }
             }
         }
+    }
+
+    actual fun realm_sync_client_config_new(): NativePointer {
+        TODO()
+    }
+
+    actual fun realm_sync_client_config_set_logger_factory(
+        syncClientConfig: NativePointer,
+        loggerFactory: () -> Any
+    ) {
+        TODO()
     }
 
     actual fun realm_app_config_new(

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -1028,7 +1028,7 @@ actual object RealmInterop {
     actual fun realm_auth_credentials_get_provider(credentials: NativePointer): AuthProvider {
         return AuthProvider.of(realm_wrapper.realm_auth_credentials_get_provider(credentials.cptr()))
     }
-    actual fun realm_sync_config_new(user: NativePointer?, partition: String): NativePointer {
+    actual fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer {
         TODO()
     }
 

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -1028,7 +1028,7 @@ actual object RealmInterop {
     actual fun realm_auth_credentials_get_provider(credentials: NativePointer): AuthProvider {
         return AuthProvider.of(realm_wrapper.realm_auth_credentials_get_provider(credentials.cptr()))
     }
-    actual fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer {
+    actual fun realm_sync_config_new(user: NativePointer?, partition: String): NativePointer {
         TODO()
     }
 

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -1028,8 +1028,13 @@ actual object RealmInterop {
     actual fun realm_auth_credentials_get_provider(credentials: NativePointer): AuthProvider {
         return AuthProvider.of(realm_wrapper.realm_auth_credentials_get_provider(credentials.cptr()))
     }
+
     actual fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer {
-        TODO()
+        return CPointerWrapper(realm_wrapper.realm_sync_config_new(user.cptr(), partition))
+    }
+
+    actual fun realm_config_set_sync_config(realmConfiguration: NativePointer, syncConfiguration: NativePointer) {
+        realm_wrapper.realm_config_set_sync_config(realmConfiguration.cptr(), syncConfiguration.cptr())
     }
 
     private fun MemScope.classInfo(realm: NativePointer, table: String): realm_class_info_t {

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -477,13 +477,6 @@ actual object RealmInterop {
         return LongPointerWrapper(realmc.realm_sync_client_config_new())
     }
 
-    actual fun realm_sync_client_config_set_logger_factory(
-        syncClientConfig: NativePointer,
-        loggerFactory: () -> CoreLogger
-    ) {
-        realmc.sync_config_set_logger(syncClientConfig.cptr(), loggerFactory)
-    }
-
     actual fun realm_network_transport_new(networkTransport: NetworkTransport): NativePointer {
         return LongPointerWrapper(realmc.realm_network_transport_new(networkTransport))
     }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -17,7 +17,6 @@
 package io.realm.internal.interop
 
 import io.realm.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
-import io.realm.internal.interop.RealmInterop.cptr
 import kotlinx.coroutines.CoroutineDispatcher
 
 // FIXME API-CLEANUP Rename io.realm.interop. to something with platform?
@@ -477,7 +476,7 @@ actual object RealmInterop {
     }
 
     actual fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer {
-        TODO()
+        return LongPointerWrapper(realmc.realm_sync_config_new(user.cptr(), partition))
     }
 
     private fun classInfo(realm: NativePointer, table: String): realm_class_info_t {

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -453,13 +453,17 @@ actual object RealmInterop {
     }
 
     // TODO sync config shouldn't be null
-    actual fun realm_app_new(appConfig: NativePointer, basePath: String): NativePointer {
-        val syncClientConfig = realmc.realm_sync_client_config_new()
-        realmc.realm_sync_client_config_set_base_file_path(syncClientConfig, basePath)
+    actual fun realm_app_new(
+        appConfig: NativePointer,
+        syncClientConfig: NativePointer,
+        basePath: String
+    ): NativePointer {
+//        val syncClientConfig = realm_sync_client_config_new().cptr()
+        realmc.realm_sync_client_config_set_base_file_path(syncClientConfig.cptr(), basePath)
 
         // TODO add metadata mode to config
-        realmc.realm_sync_client_config_set_metadata_mode(syncClientConfig, realm_sync_client_metadata_mode_e.RLM_SYNC_CLIENT_METADATA_MODE_DISABLED)
-        return LongPointerWrapper(realmc.realm_app_new(appConfig.cptr(), syncClientConfig))
+        realmc.realm_sync_client_config_set_metadata_mode(syncClientConfig.cptr(), realm_sync_client_metadata_mode_e.RLM_SYNC_CLIENT_METADATA_MODE_DISABLED)
+        return LongPointerWrapper(realmc.realm_app_new(appConfig.cptr(), syncClientConfig.cptr()))
     }
 
     actual fun realm_app_log_in_with_credentials(app: NativePointer, credentials: NativePointer, callback: CinteropCallback) {
@@ -469,6 +473,17 @@ actual object RealmInterop {
             credentials.cptr(),
             callback
         )
+    }
+
+    actual fun realm_sync_client_config_new(): NativePointer {
+        return LongPointerWrapper(realmc.realm_sync_client_config_new())
+    }
+
+    actual fun realm_sync_client_config_set_logger_factory(
+        syncClientConfig: NativePointer,
+        loggerFactory: () -> Any
+    ) {
+        realmc.sync_config_set_logger(syncClientConfig.cptr(), loggerFactory)
     }
 
     actual fun realm_app_config_new(

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -488,6 +488,10 @@ actual object RealmInterop {
         return LongPointerWrapper(realmc.realm_sync_config_new(user.cptr(), partition))
     }
 
+    actual fun realm_config_set_sync_config(realmConfiguration: NativePointer, syncConfiguration: NativePointer) {
+        realmc.realm_config_set_sync_config(realmConfiguration.cptr(), syncConfiguration.cptr())
+    }
+
     private fun classInfo(realm: NativePointer, table: String): realm_class_info_t {
         val found = booleanArrayOf(false)
         val classInfo = realm_class_info_t()

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -484,7 +484,7 @@ actual object RealmInterop {
         return AuthProvider.of(realmc.realm_auth_credentials_get_provider(credentials.cptr()))
     }
 
-    actual fun realm_sync_config_new(user: NativePointer?, partition: String): NativePointer {
+    actual fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer {
         return LongPointerWrapper(realmc.realm_sync_config_new(user.cptr(), partition))
     }
 

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -17,7 +17,6 @@
 package io.realm.internal.interop
 
 import io.realm.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
-import io.realm.internal.interop.RealmInterop.cptr
 import io.realm.internal.interop.sync.AuthProvider
 import kotlinx.coroutines.CoroutineDispatcher
 
@@ -485,7 +484,7 @@ actual object RealmInterop {
         return AuthProvider.of(realmc.realm_auth_credentials_get_provider(credentials.cptr()))
     }
 
-    actual fun realm_sync_config_new(user: NativePointer, partition: String): NativePointer {
+    actual fun realm_sync_config_new(user: NativePointer?, partition: String): NativePointer {
         return LongPointerWrapper(realmc.realm_sync_config_new(user.cptr(), partition))
     }
 

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -458,7 +458,6 @@ actual object RealmInterop {
         syncClientConfig: NativePointer,
         basePath: String
     ): NativePointer {
-//        val syncClientConfig = realm_sync_client_config_new().cptr()
         realmc.realm_sync_client_config_set_base_file_path(syncClientConfig.cptr(), basePath)
 
         // TODO add metadata mode to config
@@ -481,7 +480,7 @@ actual object RealmInterop {
 
     actual fun realm_sync_client_config_set_logger_factory(
         syncClientConfig: NativePointer,
-        loggerFactory: () -> Any
+        loggerFactory: () -> CoreLogger
     ) {
         realmc.sync_config_set_logger(syncClientConfig.cptr(), loggerFactory)
     }

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -158,7 +158,6 @@ struct realm_size_t {
 %ignore "realm_get_values";
 %ignore "realm_set_values";
 // Not yet available in library
-%ignore "realm_config_set_sync_config";
 %ignore "realm_update_schema_advanced";
 %ignore "realm_config_set_audit_factory";
 %ignore "_realm_get_schema_native";

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -59,7 +59,7 @@ return $jnicall;
 %apply void* { realm_t*, realm_config_t*, realm_schema_t*, realm_object_t* , realm_query_t*,
                realm_results_t*, realm_notification_token_t*, realm_object_changes_t*,
                realm_list_t*, realm_app_credentials_t*, realm_app_config_t*, realm_app_t*,
-               realm_sync_client_config_t*, realm_user_t* };
+               realm_sync_client_config_t*, realm_user_t*, realm_sync_config_t* };
 
 // For all functions returning a pointer or bool, check for null/false and throw an error if
 // realm_get_last_error returns true.

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -416,16 +416,3 @@ realm_http_transport_t *realm_network_transport_new(jobject network_transport) {
             &network_request_lambda_function);
 
 }
-
-void
-sync_config_set_logger(realm_sync_client_config_t* sync_config, jobject logger_factory) {
-    auto jenv = get_env();
-    return realm_sync_client_config_set_logger_factory(sync_config,
-                                                       &new_logger_lambda_function,
-                                                       static_cast<jobject>(jenv->NewGlobalRef(logger_factory)),
-                                                       [](void *userdata) {
-                                                           get_env(true)->DeleteGlobalRef(
-                                                                   static_cast<jobject>(userdata));
-                                                       }
-    );
-}

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -33,6 +33,9 @@ register_object_notification_cb(realm_object_t *object, jobject callback);
 realm_app_config_t *
 new_app_config(const char* app_id, jobject app_instance);
 
+void
+sync_config_set_logger(realm_sync_client_config_t* sync_config, jobject logger_factory);
+
 realm_t* open_realm_with_scheduler(int64_t config_ptr, jobject dispatchScheduler);
 
 void invoke_core_notify_callback(int64_t core_notify_function);

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -32,9 +32,6 @@ register_object_notification_cb(realm_object_t *object, jobject callback);
 
 realm_http_transport_t *realm_network_transport_new(jobject network_transport);
 
-void
-sync_config_set_logger(realm_sync_client_config_t* sync_config, jobject logger_factory);
-
 realm_t* open_realm_with_scheduler(int64_t config_ptr, jobject dispatchScheduler);
 
 void invoke_core_notify_callback(int64_t core_notify_function);

--- a/packages/library-base/src/androidMain/kotlin/io/realm/internal/platform/Coroutine.kt
+++ b/packages/library-base/src/androidMain/kotlin/io/realm/internal/platform/Coroutine.kt
@@ -5,6 +5,8 @@ import android.os.HandlerThread
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.android.asCoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 
 actual fun singleThreadDispatcher(id: String): CoroutineDispatcher {
@@ -12,6 +14,9 @@ actual fun singleThreadDispatcher(id: String): CoroutineDispatcher {
     thread.start()
     return Handler(thread.looper).asCoroutineDispatcher()
 }
+
+actual fun multiThreadDispatcher(size: Int): CoroutineDispatcher =
+    Executors.newFixedThreadPool(size).asCoroutineDispatcher()
 
 // Expose platform runBlocking through common interface
 public actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -16,10 +16,11 @@
 
 package io.realm
 
-import io.realm.RealmConfiguration.Builder
+import io.realm.internal.Mediator
 import io.realm.internal.REPLACED_BY_IR
 import io.realm.internal.RealmConfigurationImpl
 import io.realm.internal.RealmObjectCompanion
+import io.realm.internal.interop.NativePointer
 import io.realm.internal.platform.createDefaultSystemLogger
 import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.log.LogLevel
@@ -352,4 +353,10 @@ interface RealmConfiguration {
             )
         }
     }
+}
+
+interface InternalRealmConfiguration {
+    val mapOfKClassWithCompanion: Map<KClass<out RealmObject>, RealmObjectCompanion>
+    val mediator: Mediator
+    val nativeConfig: NativePointer
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -16,11 +16,9 @@
 
 package io.realm
 
-import io.realm.internal.Mediator
 import io.realm.internal.REPLACED_BY_IR
 import io.realm.internal.RealmConfigurationImpl
 import io.realm.internal.RealmObjectCompanion
-import io.realm.internal.interop.NativePointer
 import io.realm.internal.platform.createDefaultSystemLogger
 import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.log.LogLevel
@@ -132,6 +130,9 @@ interface RealmConfiguration {
         }
     }
 
+    /**
+     * TODO
+     */
     abstract class SharedBuilder<S>(
         var path: String? = null, // Full path for Realm (directory + name)
         var name: String = Realm.DEFAULT_FILE_NAME, // Optional Realm name (default is 'default')
@@ -353,10 +354,4 @@ interface RealmConfiguration {
             )
         }
     }
-}
-
-interface InternalRealmConfiguration {
-    val mapOfKClassWithCompanion: Map<KClass<out RealmObject>, RealmObjectCompanion>
-    val mediator: Mediator
-    val nativeConfig: NativePointer
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -130,13 +130,7 @@ interface RealmConfiguration {
         }
     }
 
-    /**
-     * Used to create a [RealmConfiguration]. For common use cases, a [RealmConfiguration] can be created directly
-     * using the [RealmConfiguration] constructor.
-     */
-    // TODO so far this is the least-effort implementation for supporting sync configurations too
-    //  though interfacing the builder is also an option
-    open class Builder(
+    abstract class SharedBuilder<S>(
         var path: String? = null, // Full path for Realm (directory + name)
         var name: String = Realm.DEFAULT_FILE_NAME, // Optional Realm name (default is 'default')
         var schema: Set<KClass<out RealmObject>> = setOf()
@@ -153,9 +147,30 @@ interface RealmConfiguration {
         protected var encryptionKey: ByteArray? = null
 
         /**
+         * Creates the RealmConfiguration based on the builder properties.
+         *
+         * @return the created RealmConfiguration.
+         */
+        abstract fun build(): RealmConfiguration
+
+//        /**
+//         * Creates the RealmConfiguration based on the builder properties.
+//         *
+//         * @return the created RealmConfiguration.
+//         */
+//        fun build(): RealmConfiguration {
+//            REPLACED_BY_IR()
+//        }
+
+        // Called from the compiler plugin
+        // FIXME children should implement this without defining it here so that it is internal
+        //  regardless. Handle bypass between build() and this function via IR
+        abstract fun build(companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>): RealmConfiguration
+
+        /**
          * Sets the absolute path of the realm file.
          */
-        fun path(path: String) = apply { this.path = path }
+        fun path(path: String): S = apply { this.path = path } as S
 
         /**
          * Sets the filename of the realm file.
@@ -170,6 +185,7 @@ interface RealmConfiguration {
          * @param classes The set of classes that the schema consists of.
          */
         fun schema(classes: Set<KClass<out RealmObject>>) = apply { this.schema = classes }
+
         /**
          * Sets the classes of the schema.
          *
@@ -284,17 +300,46 @@ interface RealmConfiguration {
          */
         internal fun removeSystemLogger() = apply { this.removeSystemLogger = true }
 
+        protected fun validateSchemaVersion(schemaVersion: Long): Long {
+            if (schemaVersion < 0) {
+                throw IllegalArgumentException("Realm schema version numbers must be 0 (zero) or higher. Yours was: $schemaVersion")
+            }
+            return schemaVersion
+        }
+
+        protected fun validateEncryptionKey(encryptionKey: ByteArray): ByteArray {
+            if (encryptionKey.size != Realm.ENCRYPTION_KEY_LENGTH) {
+                throw IllegalArgumentException("The provided key must be ${Realm.ENCRYPTION_KEY_LENGTH} bytes. The provided key was ${encryptionKey.size} bytes.")
+            }
+            return encryptionKey
+        }
+    }
+
+    /**
+     * Used to create a [RealmConfiguration]. For common use cases, a [RealmConfiguration] can be created directly
+     * using the [RealmConfiguration] constructor.
+     */
+    // TODO so far this is the least-effort implementation for supporting sync configurations too
+    //  though interfacing the builder is also an option
+    class Builder(
+        path: String? = null, // Full path for Realm (directory + name)
+        name: String = Realm.DEFAULT_FILE_NAME, // Optional Realm name (default is 'default')
+        schema: Set<KClass<out RealmObject>> = setOf()
+    ) : SharedBuilder<Builder>(path, name, schema) {
+
         /**
          * Creates the RealmConfiguration based on the builder properties.
          *
          * @return the created RealmConfiguration.
          */
-        fun build(): RealmConfiguration {
+        override fun build(): RealmConfiguration {
             REPLACED_BY_IR()
         }
 
         // Called from the compiler plugin
-        internal fun build(companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>): RealmConfiguration {
+        override fun build(
+            companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>
+        ): RealmConfiguration {
             val allLoggers = mutableListOf<RealmLogger>()
             if (!removeSystemLogger) {
                 allLoggers.add(createDefaultSystemLogger(Realm.DEFAULT_LOG_TAG))
@@ -313,20 +358,6 @@ interface RealmConfiguration {
                 deleteRealmIfMigrationNeeded,
                 encryptionKey
             )
-        }
-
-        protected fun validateSchemaVersion(schemaVersion: Long): Long {
-            if (schemaVersion < 0) {
-                throw IllegalArgumentException("Realm schema version numbers must be 0 (zero) or higher. Yours was: $schemaVersion")
-            }
-            return schemaVersion
-        }
-
-        protected fun validateEncryptionKey(encryptionKey: ByteArray): ByteArray {
-            if (encryptionKey.size != Realm.ENCRYPTION_KEY_LENGTH) {
-                throw IllegalArgumentException("The provided key must be ${Realm.ENCRYPTION_KEY_LENGTH} bytes. The provided key was ${encryptionKey.size} bytes.")
-            }
-            return encryptionKey
         }
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -134,21 +134,23 @@ interface RealmConfiguration {
      * Used to create a [RealmConfiguration]. For common use cases, a [RealmConfiguration] can be created directly
      * using the [RealmConfiguration] constructor.
      */
-    class Builder(
+    // TODO so far this is the least-effort implementation for supporting sync configurations too
+    //  though interfacing the builder is also an option
+    open class Builder(
         var path: String? = null, // Full path for Realm (directory + name)
         var name: String = Realm.DEFAULT_FILE_NAME, // Optional Realm name (default is 'default')
         var schema: Set<KClass<out RealmObject>> = setOf()
     ) {
 
-        private var logLevel: LogLevel = LogLevel.WARN
-        private var removeSystemLogger: Boolean = false
-        private var userLoggers: List<RealmLogger> = listOf()
-        private var maxNumberOfActiveVersions: Long = Long.MAX_VALUE
-        private var notificationDispatcher: CoroutineDispatcher? = null
-        private var writeDispatcher: CoroutineDispatcher? = null
-        private var deleteRealmIfMigrationNeeded: Boolean = false
-        private var schemaVersion: Long = 0
-        private var encryptionKey: ByteArray? = null
+        protected var logLevel: LogLevel = LogLevel.WARN
+        protected var removeSystemLogger: Boolean = false
+        protected var userLoggers: List<RealmLogger> = listOf()
+        protected var maxNumberOfActiveVersions: Long = Long.MAX_VALUE
+        protected var notificationDispatcher: CoroutineDispatcher? = null
+        protected var writeDispatcher: CoroutineDispatcher? = null
+        protected var deleteRealmIfMigrationNeeded: Boolean = false
+        protected var schemaVersion: Long = 0
+        protected var encryptionKey: ByteArray? = null
 
         /**
          * Sets the absolute path of the realm file.
@@ -313,14 +315,14 @@ interface RealmConfiguration {
             )
         }
 
-        private fun validateSchemaVersion(schemaVersion: Long): Long {
+        protected fun validateSchemaVersion(schemaVersion: Long): Long {
             if (schemaVersion < 0) {
                 throw IllegalArgumentException("Realm schema version numbers must be 0 (zero) or higher. Yours was: $schemaVersion")
             }
             return schemaVersion
         }
 
-        private fun validateEncryptionKey(encryptionKey: ByteArray): ByteArray {
+        protected fun validateEncryptionKey(encryptionKey: ByteArray): ByteArray {
             if (encryptionKey.size != Realm.ENCRYPTION_KEY_LENGTH) {
                 throw IllegalArgumentException("The provided key must be ${Realm.ENCRYPTION_KEY_LENGTH} bytes. The provided key was ${encryptionKey.size} bytes.")
             }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -16,6 +16,7 @@
 
 package io.realm
 
+import io.realm.RealmConfiguration.Builder
 import io.realm.internal.REPLACED_BY_IR
 import io.realm.internal.RealmConfigurationImpl
 import io.realm.internal.RealmObjectCompanion
@@ -152,15 +153,6 @@ interface RealmConfiguration {
          * @return the created RealmConfiguration.
          */
         abstract fun build(): RealmConfiguration
-
-//        /**
-//         * Creates the RealmConfiguration based on the builder properties.
-//         *
-//         * @return the created RealmConfiguration.
-//         */
-//        fun build(): RealmConfiguration {
-//            REPLACED_BY_IR()
-//        }
 
         // Called from the compiler plugin
         // FIXME children should implement this without defining it here so that it is internal

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/BaseRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/BaseRealmImpl.kt
@@ -18,7 +18,6 @@ package io.realm.internal
 import io.realm.BaseRealm
 import io.realm.Callback
 import io.realm.Cancellable
-import io.realm.InternalRealmConfiguration
 import io.realm.RealmConfiguration
 import io.realm.RealmObject
 import io.realm.RealmResults

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/BaseRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/BaseRealmImpl.kt
@@ -18,6 +18,8 @@ package io.realm.internal
 import io.realm.BaseRealm
 import io.realm.Callback
 import io.realm.Cancellable
+import io.realm.InternalRealmConfiguration
+import io.realm.RealmConfiguration
 import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.internal.interop.NativePointer
@@ -26,8 +28,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
 @Suppress("UnnecessaryAbstractClass")
-internal abstract class BaseRealmImpl internal constructor(
-    override val configuration: RealmConfigurationImpl,
+abstract class BaseRealmImpl internal constructor(
+    final override val configuration: RealmConfiguration,
     dbPointer: NativePointer
 ) : BaseRealm, RealmStateHolder {
 
@@ -74,7 +76,7 @@ internal abstract class BaseRealmImpl internal constructor(
                 "TRUEPREDICATE"
             ),
             clazz,
-            configuration.mediator
+            (configuration as InternalRealmConfiguration).mediator
         )
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalRealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalRealmConfiguration.kt
@@ -2,6 +2,7 @@ package io.realm.internal
 
 import io.realm.RealmObject
 import io.realm.internal.interop.NativePointer
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.reflect.KClass
 
 /**
@@ -13,4 +14,6 @@ interface InternalRealmConfiguration {
     val mapOfKClassWithCompanion: Map<KClass<out RealmObject>, RealmObjectCompanion>
     val mediator: Mediator
     val nativeConfig: NativePointer
+    val notificationDispatcher: CoroutineDispatcher
+    val writeDispatcher: CoroutineDispatcher
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalRealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalRealmConfiguration.kt
@@ -7,8 +7,8 @@ import kotlin.reflect.KClass
 
 /**
  * An InternalRealmConfiguration abstracts access to internal properties from a
- * [RealmConfiguration]. This is needed to make "agnostic" configurations from the base-sync point
- * of view.
+ * [io.realm.RealmConfiguration]. This is needed to make "agnostic" configurations from the
+ * base-sync point of view.
  */
 interface InternalRealmConfiguration {
     val mapOfKClassWithCompanion: Map<KClass<out RealmObject>, RealmObjectCompanion>

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalRealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalRealmConfiguration.kt
@@ -1,0 +1,16 @@
+package io.realm.internal
+
+import io.realm.RealmObject
+import io.realm.internal.interop.NativePointer
+import kotlin.reflect.KClass
+
+/**
+ * An InternalRealmConfiguration abstracts access to internal properties from a
+ * [RealmConfiguration]. This is needed to make "agnostic" configurations from the base-sync point
+ * of view.
+ */
+interface InternalRealmConfiguration {
+    val mapOfKClassWithCompanion: Map<KClass<out RealmObject>, RealmObjectCompanion>
+    val mediator: Mediator
+    val nativeConfig: NativePointer
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/Mediator.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/Mediator.kt
@@ -19,7 +19,7 @@ package io.realm.internal
 import io.realm.RealmObject
 import kotlin.reflect.KClass
 
-internal interface Mediator {
+interface Mediator {
     fun createInstanceOf(clazz: KClass<*>): RealmObjectInternal
     fun companionOf(clazz: KClass<out RealmObject>): RealmObjectCompanion
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
@@ -17,7 +17,6 @@ package io.realm.internal
 
 import io.realm.Callback
 import io.realm.Cancellable
-import io.realm.InternalRealmConfiguration
 import io.realm.MutableRealm
 import io.realm.RealmConfiguration
 import io.realm.RealmObject

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
@@ -17,7 +17,9 @@ package io.realm.internal
 
 import io.realm.Callback
 import io.realm.Cancellable
+import io.realm.InternalRealmConfiguration
 import io.realm.MutableRealm
+import io.realm.RealmConfiguration
 import io.realm.RealmObject
 import io.realm.internal.interop.RealmCoreException
 import io.realm.internal.interop.RealmInterop
@@ -55,8 +57,14 @@ internal class MutableRealmImpl : BaseRealmImpl, MutableRealm {
      * - Native: Either a scheduler dispatching to the supplied dispatcher or the default Darwin
      * scheduler, that delivers notifications on the main run loop.
      */
-    internal constructor(configuration: RealmConfigurationImpl, dispatcher: CoroutineDispatcher? = null) :
-        super(configuration, RealmInterop.realm_open(configuration.nativeConfig, dispatcher))
+    internal constructor(configuration: RealmConfiguration, dispatcher: CoroutineDispatcher? = null) :
+        super(
+            configuration,
+            RealmInterop.realm_open(
+                (configuration as InternalRealmConfiguration).nativeConfig,
+                dispatcher
+            )
+        )
 
     internal fun beginTransaction() {
         try {
@@ -102,7 +110,11 @@ internal class MutableRealmImpl : BaseRealmImpl, MutableRealm {
     }
 
     override fun <T : RealmObject> copyToRealm(instance: T): T {
-        return io.realm.internal.copyToRealm(configuration.mediator, realmReference, instance)
+        return copyToRealm(
+            (configuration as InternalRealmConfiguration).mediator,
+            realmReference,
+            instance
+        )
     }
 
     override fun <T : RealmObject> delete(obj: T) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/Observable.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/Observable.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.Flow
 //    fun emitFrozenUpdate(frozenRealm: RealmReference, change: NativePointer, channel: SendChannel<T>): ChannelResult<Unit>?
 //  - Public Observable
 //    fun observe(): Flow<T>
-internal interface Observable<T> {
+interface Observable<T> {
     fun freeze(frozenRealm: RealmReference): Observable<T>
     fun thaw(liveRealm: RealmReference): Observable<T>?
     fun registerForNotification(callback: Callback): NativePointer

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/Observable.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/Observable.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.Flow
 //  - Public Observable
 //    fun observe(): Flow<T>
 interface Observable<T> {
-    fun freeze(frozenRealm: RealmReference): Observable<T>
+    fun freeze(frozenRealm: RealmReference): Observable<T>?
     fun thaw(liveRealm: RealmReference): Observable<T>?
     fun registerForNotification(callback: Callback): NativePointer
     // FIXME Needs elaborate doc on how to signal and close channel

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
@@ -16,7 +16,6 @@
 
 package io.realm.internal
 
-import io.realm.InternalRealmConfiguration
 import io.realm.LogConfiguration
 import io.realm.RealmConfiguration
 import io.realm.RealmObject

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.reflect.KClass
 
 @Suppress("LongParameterList")
-public class RealmConfigurationImpl internal constructor(
+public class RealmConfigurationImpl constructor(
     companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>,
     path: String?,
     name: String,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
@@ -51,10 +51,6 @@ class RealmConfigurationImpl constructor(
 
     override val maxNumberOfActiveVersions: Long
 
-    val notificationDispatcher: CoroutineDispatcher
-
-    val writeDispatcher: CoroutineDispatcher
-
     override val schemaVersion: Long
 
     override val deleteRealmIfMigrationNeeded: Boolean
@@ -66,6 +62,10 @@ class RealmConfigurationImpl constructor(
     override val mediator: Mediator
 
     override val nativeConfig: NativePointer = RealmInterop.realm_config_new()
+
+    override val notificationDispatcher: CoroutineDispatcher
+
+    override val writeDispatcher: CoroutineDispatcher
 
     init {
         this.path = if (path == null || path.isEmpty()) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
@@ -16,6 +16,7 @@
 
 package io.realm.internal
 
+import io.realm.InternalRealmConfiguration
 import io.realm.LogConfiguration
 import io.realm.RealmConfiguration
 import io.realm.RealmObject
@@ -27,7 +28,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.reflect.KClass
 
 @Suppress("LongParameterList")
-public class RealmConfigurationImpl constructor(
+class RealmConfigurationImpl constructor(
     companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>,
     path: String?,
     name: String,
@@ -39,7 +40,7 @@ public class RealmConfigurationImpl constructor(
     schemaVersion: Long,
     deleteRealmIfMigrationNeeded: Boolean,
     encryptionKey: ByteArray?,
-) : RealmConfiguration {
+) : RealmConfiguration, InternalRealmConfiguration {
 
     override val path: String
 
@@ -61,11 +62,11 @@ public class RealmConfigurationImpl constructor(
 
     override val encryptionKey get(): ByteArray? = RealmInterop.realm_config_get_encryption_key(nativeConfig)
 
-    // Internal properties used by other Realm components, but does not make sense for the end user to know about
-    internal var mapOfKClassWithCompanion: Map<KClass<out RealmObject>, RealmObjectCompanion>
-    internal var mediator: Mediator
+    override val mapOfKClassWithCompanion: Map<KClass<out RealmObject>, RealmObjectCompanion>
 
-    internal val nativeConfig: NativePointer = RealmInterop.realm_config_new()
+    override val mediator: Mediator
+
+    override val nativeConfig: NativePointer = RealmInterop.realm_config_new()
 
     init {
         this.path = if (path == null || path.isEmpty()) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
@@ -30,15 +30,17 @@ internal class RealmImpl private constructor(
     dbPointer: NativePointer
 ) : BaseRealmImpl(configuration, dbPointer), Realm {
 
+    private val realmPointerMutex = Mutex()
+    private val internalConfiguration = configuration as InternalRealmConfiguration
+
     internal val realmScope =
-        CoroutineScope(SupervisorJob() + (configuration as RealmConfigurationImpl).notificationDispatcher)
+        CoroutineScope(SupervisorJob() + internalConfiguration.notificationDispatcher)
     private val realmFlow =
         MutableSharedFlow<RealmImpl>(replay = 1) // Realm notifications emit their initial state when subscribed to
     private val notifier =
-        SuspendableNotifier(this, (configuration as RealmConfigurationImpl).notificationDispatcher)
+        SuspendableNotifier(this, internalConfiguration.notificationDispatcher)
     private val writer =
-        SuspendableWriter(this, (configuration as RealmConfigurationImpl).writeDispatcher)
-    private val realmPointerMutex = Mutex()
+        SuspendableWriter(this, internalConfiguration.writeDispatcher)
 
     private var updatableRealm: AtomicRef<RealmReference> = atomic(RealmReference(this, dbPointer))
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
@@ -2,7 +2,6 @@ package io.realm.internal
 
 import io.realm.Callback
 import io.realm.Cancellable
-import io.realm.InternalRealmConfiguration
 import io.realm.MutableRealm
 import io.realm.Realm
 import io.realm.RealmConfiguration

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
@@ -2,6 +2,7 @@ package io.realm.internal
 
 import io.realm.Callback
 import io.realm.Cancellable
+import io.realm.InternalRealmConfiguration
 import io.realm.MutableRealm
 import io.realm.Realm
 import io.realm.RealmConfiguration
@@ -25,8 +26,10 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 // TODO API-PUBLIC Document platform specific internals (RealmInitializer, etc.)
-internal class RealmImpl private constructor(configuration: RealmConfigurationImpl, dbPointer: NativePointer) :
-    BaseRealmImpl(configuration, dbPointer), Realm {
+internal class RealmImpl private constructor(
+    configuration: RealmConfiguration,
+    dbPointer: NativePointer
+) : BaseRealmImpl(configuration, dbPointer), Realm {
 
     internal val realmScope: CoroutineScope =
         CoroutineScope(SupervisorJob() + configuration.notificationDispatcher)
@@ -74,9 +77,9 @@ internal class RealmImpl private constructor(configuration: RealmConfigurationIm
 
     constructor(configuration: RealmConfiguration) :
         this(
-            configuration as RealmConfigurationImpl,
+            configuration,
             try {
-                RealmInterop.realm_open(configuration.nativeConfig)
+                RealmInterop.realm_open((configuration as InternalRealmConfiguration).nativeConfig)
             } catch (exception: RealmCoreException) {
                 throw genericRealmCoreExceptionHandler(
                     "Could not open Realm with the given configuration",

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -35,7 +35,7 @@ import kotlin.reflect.KClass
  * [RealmObject].
  */
 @Suppress("VariableNaming")
-internal interface RealmObjectInternal : RealmObject, RealmStateHolder, io.realm.internal.interop.RealmObjectInterop, Observable<RealmObjectInternal> {
+interface RealmObjectInternal : RealmObject, RealmStateHolder, io.realm.internal.interop.RealmObjectInterop, Observable<RealmObjectInternal> {
     // Names must match identifiers in compiler plugin (plugin-compiler/io.realm.compiler.Identifiers.kt)
 
     // Reference to the public Realm instance and internal transaction to which the object belongs.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
@@ -22,7 +22,7 @@ import io.realm.internal.interop.RealmInterop
  * NOTE: There should never be multiple RealmReferences with the same `dbPointer` as the underlying
  * C++ SharedRealm is closed when the RealmReference is no longer referenced by the [Realm].
  */
-internal data class RealmReference(
+data class RealmReference(
     val owner: BaseRealmImpl,
     val dbPointer: NativePointer
     // FIXME Should we keep a debug flag to assert that we have the right liveness state

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmState.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmState.kt
@@ -22,7 +22,7 @@ import io.realm.Versioned
 /**
  * A RealmState exposes common methods to query the state of any Realm object.
  */
-internal interface RealmState : Versioned {
+interface RealmState : Versioned {
     fun isFrozen(): Boolean
     fun isClosed(): Boolean
 }
@@ -43,7 +43,7 @@ object UnmanagedState : RealmState {
 }
 
 // Default implementation for all objects that can provide a RealmState instance
-internal interface RealmStateHolder : RealmState {
+interface RealmStateHolder : RealmState {
     fun realmState(): RealmState
 
     override fun version(): VersionId {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -70,7 +70,7 @@ import kotlin.reflect.KProperty1
  * replaced by the Compiler Plugin.
  */
 @Suppress("FunctionNaming")
-internal inline fun REPLACED_BY_IR(
+inline fun REPLACED_BY_IR(
     message: String = "This code should have been replaced by the Realm Compiler Plugin. " +
         "Has the `realm-kotlin` Gradle plugin been applied to the project?"
 ): Nothing = throw AssertionError(message)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -2,6 +2,7 @@ package io.realm.internal
 
 import io.realm.Callback
 import io.realm.Cancellable
+import io.realm.InternalRealmConfiguration
 import io.realm.VersionId
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
@@ -53,7 +54,10 @@ internal class SuspendableNotifier(
 
     // Must only be accessed from the dispatchers thread
     private val realm: BaseRealmImpl by lazy {
-        val dbPointer = RealmInterop.realm_open(owner.configuration.nativeConfig, dispatcher)
+        val dbPointer = RealmInterop.realm_open(
+            (owner.configuration as InternalRealmConfiguration).nativeConfig,
+            dispatcher
+        )
         object : BaseRealmImpl(owner.configuration, dbPointer) {
             /* Realms used by the Notifier is just a basic Live Realm */
         }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -2,7 +2,6 @@ package io.realm.internal
 
 import io.realm.Callback
 import io.realm.Cancellable
-import io.realm.InternalRealmConfiguration
 import io.realm.VersionId
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/platform/CoroutineUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/platform/CoroutineUtils.kt
@@ -11,6 +11,11 @@ import kotlin.coroutines.EmptyCoroutineContext
 expect fun singleThreadDispatcher(id: String): CoroutineDispatcher
 
 /**
+ * Returns a default multithread dispatcher used by Sync.
+ */
+expect fun multiThreadDispatcher(size: Int = 3): CoroutineDispatcher
+
+/**
  * Runs a new coroutine and **blocks** the current thread _interruptibly_ until its completion.
  *
  * This just exposes a common runBlocking for our supported platforms, as this is not available in

--- a/packages/library-base/src/commonMain/kotlin/io/realm/log/RealmLogger.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/log/RealmLogger.kt
@@ -17,4 +17,8 @@ interface RealmLogger {
      * Log an event.
      */
     fun log(level: LogLevel, throwable: Throwable?, message: String?, vararg args: Any?)
+
+    fun log(message: String) {
+        log(LogLevel.ALL, null, message, null)
+    }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/log/RealmLogger.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/log/RealmLogger.kt
@@ -1,12 +1,13 @@
 package io.realm.log
 
 import io.realm.RealmConfiguration
+import io.realm.internal.interop.CoreLogger
 /**
  * Interface describing a logger implementation.
  *
  * @see RealmConfiguration.Builder.log
  */
-interface RealmLogger {
+interface RealmLogger: CoreLogger {
 
     /**
      * Tag that can be used to describe the output.
@@ -19,6 +20,11 @@ interface RealmLogger {
     fun log(level: LogLevel, throwable: Throwable?, message: String?, vararg args: Any?)
 
     fun log(message: String) {
+        log(LogLevel.ALL, null, message, null)
+    }
+
+    // FIXME
+    override fun log(level: Short, message: String) {
         log(LogLevel.ALL, null, message, null)
     }
 }

--- a/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/CoroutineUtils.kt
+++ b/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/CoroutineUtils.kt
@@ -2,11 +2,7 @@ package io.realm.internal.platform
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.newSingleThreadContext
-import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
-import platform.darwin.dispatch_async
-import platform.darwin.dispatch_get_global_queue
 import kotlin.coroutines.CoroutineContext
 
 // Expose platform runBlocking through common interface

--- a/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/CoroutineUtils.kt
+++ b/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/CoroutineUtils.kt
@@ -2,11 +2,18 @@ package io.realm.internal.platform
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.newSingleThreadContext
+import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_global_queue
 import kotlin.coroutines.CoroutineContext
 
 // Expose platform runBlocking through common interface
-public actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
+public actual fun <T> runBlocking(
+    context: CoroutineContext,
+    block: suspend CoroutineScope.() -> T
+): T {
     return kotlinx.coroutines.runBlocking(context, block)
 }
 
@@ -15,4 +22,9 @@ public actual fun <T> runBlocking(context: CoroutineContext, block: suspend Coro
  */
 actual fun singleThreadDispatcher(id: String): CoroutineDispatcher {
     return newSingleThreadContext(id)
+}
+
+actual fun multiThreadDispatcher(size: Int): CoroutineDispatcher {
+    // FIXME https://github.com/realm/realm-kotlin/issues/450
+    return singleThreadDispatcher("singleThreadDispatcher")
 }

--- a/packages/library-base/src/jvmMain/kotlin/io/realm/internal/platform/CoroutineUtils.kt
+++ b/packages/library-base/src/jvmMain/kotlin/io/realm/internal/platform/CoroutineUtils.kt
@@ -11,6 +11,9 @@ public actual fun singleThreadDispatcher(id: String): CoroutineDispatcher {
     return Executors.newSingleThreadExecutor().asCoroutineDispatcher()
 }
 
+public actual fun multiThreadDispatcher(size: Int): CoroutineDispatcher =
+    Executors.newFixedThreadPool(size).asCoroutineDispatcher()
+
 // Expose platform runBlocking through common interface
 public actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
     return kotlinx.coroutines.runBlocking(context, block)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
@@ -16,6 +16,7 @@
 
 package io.realm.mongodb
 
+import io.realm.internal.platform.multiThreadDispatcher
 import io.realm.mongodb.internal.AppConfigurationImpl
 import kotlinx.coroutines.CoroutineDispatcher
 
@@ -23,30 +24,43 @@ import kotlinx.coroutines.CoroutineDispatcher
  * TODO
  */
 interface AppConfiguration {
+
     val appId: String
     val baseUrl: String
     val networkTransportDispatcher: CoroutineDispatcher
 
     companion object {
-        /**
-         * TODO
-         */
         const val DEFAULT_BASE_URL = "https://realm.mongodb.com"
-
-        /**
-         * TODO
-         */
         const val DEFAULT_AUTHORIZATION_HEADER_NAME = "Authorization"
     }
-}
 
-// TODO Create full blown builder for this
-// FIXME Initialize with proper multithreaded dispatcher
-//  https://github.com/realm/realm-kotlin/issues/450
-fun appConfigurationOf(
-    appId: String,
-    baseUrl: String,
-    dispatcher: CoroutineDispatcher
-): AppConfiguration {
-    return AppConfigurationImpl(appId, baseUrl, dispatcher)
+    /**
+     * TODO
+     */
+    class Builder(
+        private val appId: String
+    ) {
+
+        private var baseUrl: String = DEFAULT_BASE_URL
+        private var dispatcher: CoroutineDispatcher = multiThreadDispatcher() // TODO
+
+        /**
+         * TODO
+         */
+        fun baseUrl(url: String) = apply { this.baseUrl = url }
+
+        /**
+         * TODO
+         */
+        fun dispatcher(dispatcher: CoroutineDispatcher) = apply { this.dispatcher = dispatcher }
+
+        /**
+         * TODO
+         */
+        fun build(): AppConfiguration = AppConfigurationImpl(
+            appId = appId,
+            baseUrl = baseUrl,
+            networkTransportDispatcher = dispatcher
+        )
+    }
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
@@ -55,7 +55,7 @@ interface AppConfiguration {
      * @param appId the application id of the MongoDB Realm Application.
      */
     class Builder(
-        val appId: String
+        private val appId: String
     ) {
         private var baseUrl: String = DEFAULT_BASE_URL
         private var dispatcher: CoroutineDispatcher = singleThreadDispatcher("dispatcher-$appId") // TODO

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
@@ -16,19 +16,26 @@
 
 package io.realm.mongodb
 
+import io.realm.LogConfiguration
 import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.RealmObject
+import io.realm.internal.REPLACED_BY_IR
+import io.realm.internal.RealmConfigurationImpl
+import io.realm.internal.RealmObjectCompanion
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.interop.sync.PartitionValue
+import io.realm.internal.platform.createDefaultSystemLogger
+import io.realm.internal.platform.singleThreadDispatcher
+import io.realm.log.RealmLogger
 import io.realm.mongodb.internal.UserImpl
 import kotlin.reflect.KClass
 
 /**
  * TODO
  */
-interface SyncConfiguration/* : RealmConfiguration */ {
+interface SyncConfiguration : RealmConfiguration {
 
     /**
      * TODO
@@ -38,7 +45,7 @@ interface SyncConfiguration/* : RealmConfiguration */ {
     /**
      * TODO
      */
-    val partitionValue: PartitionValue
+    val partitionValue: PartitionValue?
 
     companion object {
         fun defaultConfig(
@@ -46,8 +53,7 @@ interface SyncConfiguration/* : RealmConfiguration */ {
             partitionValue: Int,
             schema: Set<KClass<out RealmObject>>
         ): SyncConfiguration {
-            return Builder(schema = schema, user = user, partitionValue = partitionValue)
-                .buildSync()
+            TODO("REPLACED_BY_IR")
         }
 
         fun defaultConfig(
@@ -55,8 +61,7 @@ interface SyncConfiguration/* : RealmConfiguration */ {
             partitionValue: Long,
             schema: Set<KClass<out RealmObject>>
         ): SyncConfiguration {
-            return Builder(schema = schema, user = user, partitionValue = partitionValue)
-                .buildSync()
+            TODO("REPLACED_BY_IR")
         }
 
         fun defaultConfig(
@@ -64,8 +69,7 @@ interface SyncConfiguration/* : RealmConfiguration */ {
             partitionValue: String,
             schema: Set<KClass<out RealmObject>>
         ): SyncConfiguration {
-            return Builder(schema = schema, user = user, partitionValue = partitionValue)
-                .buildSync()
+            TODO("REPLACED_BY_IR")
         }
     }
 
@@ -78,7 +82,7 @@ interface SyncConfiguration/* : RealmConfiguration */ {
         schema: Set<KClass<out RealmObject>>,
         private var user: User,
         private var partitionValue: PartitionValue
-    ) : RealmConfiguration.Builder(path, name, schema) {
+    ) : RealmConfiguration.SharedBuilder<Builder>(path, name, schema) {
 
         constructor(
             path: String? = null,
@@ -104,53 +108,46 @@ interface SyncConfiguration/* : RealmConfiguration */ {
             partitionValue: String
         ) : this(path, name, schema, user, PartitionValue(partitionValue))
 
-//        /**
-//         * Creates the SyncConfiguration based on the builder properties.
-//         *
-//         * @return the created SyncConfiguration.
-//         */
-//        // TODO missing compiler plugin logic
-//        fun buildConfig(): SyncConfiguration {
-//            val message = "This code should have been replaced by the Realm Compiler Plugin. " +
-//                    "Has the `realm-kotlin` Gradle plugin been applied to the project?"
-//            throw AssertionError(message)
-//        }
-
-        // TODO for testing, remove
-        fun buildSync(): SyncConfiguration {
-            return SyncConfigurationImpl(partitionValue, user as UserImpl)
+        /**
+         * Creates the RealmConfiguration based on the builder properties.
+         *
+         * @return the created RealmConfiguration.
+         */
+        override fun build(): SyncConfiguration {
+            REPLACED_BY_IR()
         }
 
-//        // Called from the compiler plugin
-//        internal fun buildSync(companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>): SyncConfiguration {
-//            val allLoggers = mutableListOf<RealmLogger>()
-//            if (!removeSystemLogger) {
-//                allLoggers.add(createDefaultSystemLogger(Realm.DEFAULT_LOG_TAG))
-//            }
-//            allLoggers.addAll(userLoggers)
-//            val localConfiguration = RealmConfigurationImpl(
-//                companionMap,
-//                path,
-//                name,
-//                schema,
-//                LogConfiguration(logLevel, allLoggers),
-//                maxNumberOfActiveVersions,
-//                notificationDispatcher ?: singleThreadDispatcher(name),
-//                writeDispatcher ?: singleThreadDispatcher(name),
-//                schemaVersion,
-//                deleteRealmIfMigrationNeeded,
-//                encryptionKey,
-//            )
-//            return SyncConfigurationImpl(localConfiguration, partitionValue, user as UserImpl)
-//        }
+        override fun build(
+            companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>
+        ): SyncConfiguration {
+            val allLoggers = mutableListOf<RealmLogger>()
+            if (!removeSystemLogger) {
+                allLoggers.add(createDefaultSystemLogger(Realm.DEFAULT_LOG_TAG))
+            }
+            allLoggers.addAll(userLoggers)
+            val localConfiguration = RealmConfigurationImpl(
+                companionMap,
+                path,
+                name,
+                schema,
+                LogConfiguration(logLevel, allLoggers),
+                maxNumberOfActiveVersions,
+                notificationDispatcher ?: singleThreadDispatcher(name),
+                writeDispatcher ?: singleThreadDispatcher(name),
+                schemaVersion,
+                deleteRealmIfMigrationNeeded,
+                encryptionKey,
+            )
+            return SyncConfigurationImpl(localConfiguration, partitionValue, user as UserImpl)
+        }
     }
 }
 
 internal class SyncConfigurationImpl(
-//    localConfiguration: RealmConfigurationImpl,
+    localConfiguration: RealmConfigurationImpl,
     override val partitionValue: PartitionValue,
     userImpl: UserImpl,
-) : /*RealmConfiguration by localConfiguration,*/ SyncConfiguration {
+) : RealmConfiguration by localConfiguration, SyncConfiguration {
 
     override val user: User
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
@@ -38,10 +38,10 @@ import kotlin.reflect.KClass
  *
  * A minimal [SyncConfiguration] can be found below.
  * ```
- * val app = App.create(AppConfiguration.Builder(appId))
- * val user = app.login(Credentials.anonymous())
- * val config = SyncConfiguration.Builder(user, "partition-value")
- * val realm = Realm.getInstance(config)
+ *      val app = App.create(AppConfiguration.Builder(appId))
+ *      val user = app.login(Credentials.anonymous())
+ *      val config = SyncConfiguration.Builder(user, "partition-value")
+ *      val realm = Realm.getInstance(config)
  * ```
  */
 interface SyncConfiguration : RealmConfiguration {
@@ -76,7 +76,7 @@ interface SyncConfiguration : RealmConfiguration {
     }
 
     /**
-     *
+     * TODO
      */
     class Builder private constructor(
         path: String?, // Full path for Realm (directory + name)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
@@ -45,7 +45,7 @@ interface SyncConfiguration : RealmConfiguration {
     /**
      * TODO
      */
-    val partitionValue: PartitionValue?
+    val partitionValue: PartitionValue
 
     companion object {
         fun defaultConfig(

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
@@ -110,11 +110,6 @@ interface SyncConfiguration : RealmConfiguration {
             partitionValue: String
         ) : this(path, name, schema, user, PartitionValue(partitionValue))
 
-        /**
-         * Creates the RealmConfiguration based on the builder properties.
-         *
-         * @return the created RealmConfiguration.
-         */
         override fun build(): SyncConfiguration {
             REPLACED_BY_IR()
         }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
@@ -30,18 +30,23 @@ import io.realm.mongodb.internal.UserImpl
 import kotlin.reflect.KClass
 
 /**
- * TODO
+ * A [SyncConfiguration] is used to setup a Realm Database that can be synchronized between
+ * devices using MongoDB Realm.
+ *
+ * A valid [User] is required to create a [SyncConfiguration]. See
+ * [Credentials] and [App.login] for more information on how to get a user object.
+ *
+ * A minimal [SyncConfiguration] can be found below.
+ * ```
+ * val app = App.create(AppConfiguration.Builder(appId))
+ * val user = app.login(Credentials.anonymous())
+ * val config = SyncConfiguration.Builder(user, "partition-value")
+ * val realm = Realm.getInstance(config)
+ * ```
  */
 interface SyncConfiguration : RealmConfiguration {
 
-    /**
-     * TODO
-     */
     val user: User
-
-    /**
-     * TODO
-     */
     val partitionValue: PartitionValue
 
     companion object {
@@ -50,7 +55,7 @@ interface SyncConfiguration : RealmConfiguration {
             partitionValue: Int,
             schema: Set<KClass<out RealmObject>>
         ): SyncConfiguration {
-            TODO("REPLACED_BY_IR")
+            TODO("Add compiler plugin IR modification for this method")
         }
 
         fun defaultConfig(
@@ -58,7 +63,7 @@ interface SyncConfiguration : RealmConfiguration {
             partitionValue: Long,
             schema: Set<KClass<out RealmObject>>
         ): SyncConfiguration {
-            TODO("REPLACED_BY_IR")
+            TODO("Add compiler plugin IR modification for this method")
         }
 
         fun defaultConfig(
@@ -66,7 +71,7 @@ interface SyncConfiguration : RealmConfiguration {
             partitionValue: String,
             schema: Set<KClass<out RealmObject>>
         ): SyncConfiguration {
-            TODO("REPLACED_BY_IR")
+            TODO("Add compiler plugin IR modification for this method")
         }
     }
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.mongodb
+
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import io.realm.RealmObject
+import io.realm.internal.interop.NativePointer
+import io.realm.internal.interop.RealmInterop
+import io.realm.internal.interop.sync.PartitionValue
+import io.realm.mongodb.internal.UserImpl
+import kotlin.reflect.KClass
+
+/**
+ * TODO
+ */
+interface SyncConfiguration/* : RealmConfiguration */ {
+
+    /**
+     * TODO
+     */
+    val user: User
+
+    /**
+     * TODO
+     */
+    val partitionValue: PartitionValue
+
+    companion object {
+        fun defaultConfig(
+            user: User,
+            partitionValue: Int,
+            schema: Set<KClass<out RealmObject>>
+        ): SyncConfiguration {
+            return Builder(schema = schema, user = user, partitionValue = partitionValue)
+                .buildSync()
+        }
+
+        fun defaultConfig(
+            user: User,
+            partitionValue: Long,
+            schema: Set<KClass<out RealmObject>>
+        ): SyncConfiguration {
+            return Builder(schema = schema, user = user, partitionValue = partitionValue)
+                .buildSync()
+        }
+
+        fun defaultConfig(
+            user: User,
+            partitionValue: String,
+            schema: Set<KClass<out RealmObject>>
+        ): SyncConfiguration {
+            return Builder(schema = schema, user = user, partitionValue = partitionValue)
+                .buildSync()
+        }
+    }
+
+    /**
+     *
+     */
+    class Builder private constructor(
+        path: String?, // Full path for Realm (directory + name)
+        name: String, // Optional Realm name (default is 'default')
+        schema: Set<KClass<out RealmObject>>,
+        private var user: User,
+        private var partitionValue: PartitionValue
+    ) : RealmConfiguration.Builder(path, name, schema) {
+
+        constructor(
+            path: String? = null,
+            name: String = Realm.DEFAULT_FILE_NAME,
+            schema: Set<KClass<out RealmObject>> = setOf(),
+            user: User,
+            partitionValue: Int
+        ) : this(path, name, schema, user, PartitionValue(partitionValue.toLong()))
+
+        constructor(
+            path: String? = null,
+            name: String = Realm.DEFAULT_FILE_NAME,
+            schema: Set<KClass<out RealmObject>> = setOf(),
+            user: User,
+            partitionValue: Long
+        ) : this(path, name, schema, user, PartitionValue(partitionValue))
+
+        constructor(
+            path: String? = null,
+            name: String = Realm.DEFAULT_FILE_NAME,
+            schema: Set<KClass<out RealmObject>> = setOf(),
+            user: User,
+            partitionValue: String
+        ) : this(path, name, schema, user, PartitionValue(partitionValue))
+
+//        /**
+//         * Creates the SyncConfiguration based on the builder properties.
+//         *
+//         * @return the created SyncConfiguration.
+//         */
+//        // TODO missing compiler plugin logic
+//        fun buildConfig(): SyncConfiguration {
+//            val message = "This code should have been replaced by the Realm Compiler Plugin. " +
+//                    "Has the `realm-kotlin` Gradle plugin been applied to the project?"
+//            throw AssertionError(message)
+//        }
+
+        // TODO for testing, remove
+        fun buildSync(): SyncConfiguration {
+            return SyncConfigurationImpl(partitionValue, user as UserImpl)
+        }
+
+//        // Called from the compiler plugin
+//        internal fun buildSync(companionMap: Map<KClass<out RealmObject>, RealmObjectCompanion>): SyncConfiguration {
+//            val allLoggers = mutableListOf<RealmLogger>()
+//            if (!removeSystemLogger) {
+//                allLoggers.add(createDefaultSystemLogger(Realm.DEFAULT_LOG_TAG))
+//            }
+//            allLoggers.addAll(userLoggers)
+//            val localConfiguration = RealmConfigurationImpl(
+//                companionMap,
+//                path,
+//                name,
+//                schema,
+//                LogConfiguration(logLevel, allLoggers),
+//                maxNumberOfActiveVersions,
+//                notificationDispatcher ?: singleThreadDispatcher(name),
+//                writeDispatcher ?: singleThreadDispatcher(name),
+//                schemaVersion,
+//                deleteRealmIfMigrationNeeded,
+//                encryptionKey,
+//            )
+//            return SyncConfigurationImpl(localConfiguration, partitionValue, user as UserImpl)
+//        }
+    }
+}
+
+internal class SyncConfigurationImpl(
+//    localConfiguration: RealmConfigurationImpl,
+    override val partitionValue: PartitionValue,
+    userImpl: UserImpl,
+) : /*RealmConfiguration by localConfiguration,*/ SyncConfiguration {
+
+    override val user: User
+
+    private val nativeSyncConfig: NativePointer =
+        RealmInterop.realm_sync_config_new(userImpl.nativePointer, partitionValue.asSyncPartition())
+
+    init {
+        user = userImpl
+    }
+}

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
@@ -18,6 +18,7 @@ package io.realm.mongodb.internal
 
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
+import io.realm.internal.interop.sync.NetworkTransport
 import io.realm.internal.platform.freeze
 import io.realm.mongodb.AppConfiguration
 import io.realm.mongodb.AppConfiguration.Companion.DEFAULT_BASE_URL
@@ -29,7 +30,7 @@ internal class AppConfigurationImpl(
     override val networkTransportDispatcher: CoroutineDispatcher
 ) : AppConfiguration {
 
-    private val networkTransport: io.realm.internal.interop.sync.NetworkTransport = KtorNetworkTransport(
+    private val networkTransport: NetworkTransport = KtorNetworkTransport(
         // FIXME Add AppConfiguration.Builder option to set timeout as a Duration with default \
         //  constant in AppConfiguration.Companion
         //  https://github.com/realm/realm-kotlin/issues/408

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppImpl.kt
@@ -33,11 +33,10 @@ internal class AppImpl(
 
     override val configuration: AppConfigurationImpl = configuration
 
-    val nativePointer: NativePointer =
-        RealmInterop.realm_app_new(
-            appConfig = configuration.nativePointer,
-            basePath = appFilesDirectory()
-        )
+    private val nativePointer: NativePointer = RealmInterop.realm_app_new(
+        appConfig = configuration.nativePointer,
+        basePath = appFilesDirectory()
+    )
 
     override suspend fun login(credentials: Credentials): Result<User> {
         return RealmInterop.runCatching {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncConfigurationImpl.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.mongodb.internal
 
 import io.realm.RealmConfiguration

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncConfigurationImpl.kt
@@ -1,29 +1,25 @@
 package io.realm.mongodb.internal
 
-import io.realm.InternalRealmConfiguration
 import io.realm.RealmConfiguration
+import io.realm.internal.InternalRealmConfiguration
 import io.realm.internal.RealmConfigurationImpl
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.interop.sync.PartitionValue
 import io.realm.mongodb.SyncConfiguration
-import io.realm.mongodb.User
 
 internal class SyncConfigurationImpl(
     localConfiguration: RealmConfigurationImpl,
     override val partitionValue: PartitionValue,
-    userImpl: UserImpl,
+    override val user: UserImpl,
 ) : RealmConfiguration by localConfiguration,
     InternalRealmConfiguration by localConfiguration,
     SyncConfiguration {
 
-    override val user: User
-
     private val nativeSyncConfig: NativePointer =
-        RealmInterop.realm_sync_config_new(userImpl.nativePointer, partitionValue.asSyncPartition())
+        RealmInterop.realm_sync_config_new(user.nativePointer, partitionValue.asSyncPartition())
 
     init {
-        user = userImpl
         RealmInterop.realm_config_set_sync_config(localConfiguration.nativeConfig, nativeSyncConfig)
     }
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncConfigurationImpl.kt
@@ -1,0 +1,29 @@
+package io.realm.mongodb.internal
+
+import io.realm.InternalRealmConfiguration
+import io.realm.RealmConfiguration
+import io.realm.internal.RealmConfigurationImpl
+import io.realm.internal.interop.NativePointer
+import io.realm.internal.interop.RealmInterop
+import io.realm.internal.interop.sync.PartitionValue
+import io.realm.mongodb.SyncConfiguration
+import io.realm.mongodb.User
+
+internal class SyncConfigurationImpl(
+    localConfiguration: RealmConfigurationImpl,
+    override val partitionValue: PartitionValue,
+    userImpl: UserImpl,
+) : RealmConfiguration by localConfiguration,
+    InternalRealmConfiguration by localConfiguration,
+    SyncConfiguration {
+
+    override val user: User
+
+    private val nativeSyncConfig: NativePointer =
+        RealmInterop.realm_sync_config_new(userImpl.nativePointer, partitionValue.asSyncPartition())
+
+    init {
+        user = userImpl
+        RealmInterop.realm_config_set_sync_config(localConfiguration.nativeConfig, nativeSyncConfig)
+    }
+}

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
@@ -73,8 +73,10 @@ internal object FqNames {
     val REALM_REFERENCE = FqName("io.realm.internal.RealmReference")
     val REALM_MEDIATOR_INTERFACE = FqName("io.realm.internal.Mediator")
     val REALM_CONFIGURATION = FqName("io.realm.RealmConfiguration")
+    val REALM_SYNC_CONFIGURATION = FqName("io.realm.mongodb.SyncConfiguration")
     val REALM_CONFIGURATION_IMPL = FqName("io.realm.internal.RealmConfigurationImpl")
     val REALM_CONFIGURATION_BUILDER = FqName("io.realm.RealmConfiguration.Builder")
+    val REALM_SYNC_CONFIGURATION_BUILDER = FqName("io.realm.mongodb.SyncConfiguration.Builder")
     // External visible interface of Realm objects
     val KOTLIN_COLLECTIONS_SET = FqName("kotlin.collections.Set")
     val KOTLIN_COLLECTION_LIST = FqName("kotlin.collections.List")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
@@ -76,7 +76,6 @@ internal object FqNames {
     val REALM_SYNC_CONFIGURATION = FqName("io.realm.mongodb.SyncConfiguration")
     val REALM_CONFIGURATION_IMPL = FqName("io.realm.internal.RealmConfigurationImpl")
     val REALM_CONFIGURATION_BUILDER = FqName("io.realm.RealmConfiguration.Builder")
-    val REALM_SYNC_CONFIGURATION_BUILDER = FqName("io.realm.mongodb.SyncConfiguration.Builder")
     // External visible interface of Realm objects
     val KOTLIN_COLLECTIONS_SET = FqName("kotlin.collections.Set")
     val KOTLIN_COLLECTION_LIST = FqName("kotlin.collections.List")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmSchemaLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmSchemaLoweringExtension.kt
@@ -18,6 +18,7 @@ package io.realm.compiler
 
 import io.realm.compiler.FqNames.REALM_CONFIGURATION
 import io.realm.compiler.FqNames.REALM_CONFIGURATION_BUILDER
+import io.realm.compiler.FqNames.REALM_SYNC_CONFIGURATION
 import io.realm.compiler.Names.REALM_CONFIGURATION_BUILDER_BUILD
 import io.realm.compiler.Names.REALM_CONFIGURATION_WITH
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
@@ -82,9 +83,13 @@ class RealmSchemaLoweringExtension : IrGenerationExtension {
             irFile.transformChildrenVoid(object : IrElementTransformerVoid() {
                 override fun visitCall(expression: IrCall): IrExpression {
                     val name = expression.symbol.owner.name
-                    if (expression.type.classFqName == REALM_CONFIGURATION &&
+                    if ((expression.type.classFqName == REALM_CONFIGURATION
+                                || expression.type.classFqName == REALM_SYNC_CONFIGURATION) &&
                         name in setOf(REALM_CONFIGURATION_BUILDER_BUILD, REALM_CONFIGURATION_WITH)
                     ) {
+//                    if (expression.type.classFqName == REALM_CONFIGURATION &&
+//                        name in setOf(REALM_CONFIGURATION_BUILDER_BUILD, REALM_CONFIGURATION_WITH)
+//                    ) {
                         val specifiedModels =
                             mutableListOf<Triple<IrClassifierSymbol, IrType, IrClassSymbol>>()
                         val (receiver, schemaArgument) = when (name) {

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmSchemaLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmSchemaLoweringExtension.kt
@@ -87,9 +87,6 @@ class RealmSchemaLoweringExtension : IrGenerationExtension {
                                 || expression.type.classFqName == REALM_SYNC_CONFIGURATION) &&
                         name in setOf(REALM_CONFIGURATION_BUILDER_BUILD, REALM_CONFIGURATION_WITH)
                     ) {
-//                    if (expression.type.classFqName == REALM_CONFIGURATION &&
-//                        name in setOf(REALM_CONFIGURATION_BUILDER_BUILD, REALM_CONFIGURATION_WITH)
-//                    ) {
                         val specifiedModels =
                             mutableListOf<Triple<IrClassifierSymbol, IrType, IrClassSymbol>>()
                         val (receiver, schemaArgument) = when (name) {

--- a/packages/plugin-compiler/src/test/resources/sample/input/Sample.kt
+++ b/packages/plugin-compiler/src/test/resources/sample/input/Sample.kt
@@ -17,6 +17,7 @@
 package sample.input
 
 import io.realm.realmListOf
+import io.realm.mongodb.SyncConfiguration
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
@@ -78,3 +79,8 @@ class Sample : RealmObject {
 class Child : RealmObject {
     var name: String? = "Child-default"
 }
+
+val configuration = SyncConfiguration.Builder(
+    schema = setOf(Child::class),
+    partitionValue = "ASDF"
+).build()

--- a/packages/plugin-compiler/src/test/resources/sample/input/Sample.kt
+++ b/packages/plugin-compiler/src/test/resources/sample/input/Sample.kt
@@ -79,8 +79,3 @@ class Sample : RealmObject {
 class Child : RealmObject {
     var name: String? = "Child-default"
 }
-
-val configuration = SyncConfiguration.Builder(
-    schema = setOf(Child::class),
-    partitionValue = "ASDF"
-).build()

--- a/packages/plugin-compiler/src/test/resources/schema/input/Schema.kt
+++ b/packages/plugin-compiler/src/test/resources/schema/input/Schema.kt
@@ -16,25 +16,18 @@
 
 package schema.input
 
-//import io.realm.RealmConfiguration
 import io.realm.RealmConfiguration
-import io.realm.mongodb.SyncConfiguration
 import io.realm.RealmObject
 
 class A : RealmObject
 class B : RealmObject
 class C : RealmObject
 
-//val conf1 = RealmConfiguration.Builder()
-//    .schema(A::class, B::class, C::class)
-//    .build()
-//
-//val conf2 = RealmConfiguration.Builder(schema = setOf(A::class, B::class, C::class))
-//        .build()
-//
-//val conf3 = RealmConfiguration.with(schema = setOf(A::class, C::class))
+val conf1 = RealmConfiguration.Builder()
+    .schema(A::class, B::class, C::class)
+    .build()
 
-val syncConfig: RealmConfiguration = SyncConfiguration.Builder(
-    schema = setOf(A::class, B::class, C::class),
-    partitionValue = "ASDF"
-).build()
+val conf2 = RealmConfiguration.Builder(schema = setOf(A::class, B::class, C::class))
+    .build()
+
+val conf3 = RealmConfiguration.with(schema = setOf(A::class, C::class))

--- a/packages/plugin-compiler/src/test/resources/schema/input/Schema.kt
+++ b/packages/plugin-compiler/src/test/resources/schema/input/Schema.kt
@@ -16,18 +16,25 @@
 
 package schema.input
 
+//import io.realm.RealmConfiguration
 import io.realm.RealmConfiguration
+import io.realm.mongodb.SyncConfiguration
 import io.realm.RealmObject
 
 class A : RealmObject
-class C : RealmObject
 class B : RealmObject
+class C : RealmObject
 
-val conf1 = RealmConfiguration.Builder()
-    .schema(A::class, B::class, C::class)
-    .build()
+//val conf1 = RealmConfiguration.Builder()
+//    .schema(A::class, B::class, C::class)
+//    .build()
+//
+//val conf2 = RealmConfiguration.Builder(schema = setOf(A::class, B::class, C::class))
+//        .build()
+//
+//val conf3 = RealmConfiguration.with(schema = setOf(A::class, C::class))
 
-val conf2 = RealmConfiguration.Builder(schema = setOf(A::class, B::class, C::class))
-        .build()
-
-val conf3 = RealmConfiguration.with(schema = setOf(A::class, C::class))
+val syncConfig: RealmConfiguration = SyncConfiguration.Builder(
+    schema = setOf(A::class, B::class, C::class),
+    partitionValue = "ASDF"
+).build()

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmConfigurationTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmConfigurationTests.kt
@@ -71,9 +71,6 @@ class RealmConfigurationTests {
         val config = RealmConfiguration.with(path = realmPath, schema = setOf(Sample::class))
         assertEquals(realmPath, config.path)
 
-        RealmConfiguration.Builder(path = realmPath, schema = setOf(Sample::class))
-            .path
-
         val configFromBuilder: RealmConfiguration =
             RealmConfiguration.Builder(path = realmPath, schema = setOf(Sample::class)).build()
         assertEquals(realmPath, configFromBuilder.path)

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmConfigurationTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmConfigurationTests.kt
@@ -70,6 +70,9 @@ class RealmConfigurationTests {
         val config = RealmConfiguration.with(path = realmPath, schema = setOf(Sample::class))
         assertEquals(realmPath, config.path)
 
+        RealmConfiguration.Builder(path = realmPath, schema = setOf(Sample::class))
+            .path
+
         val configFromBuilder: RealmConfiguration =
             RealmConfiguration.Builder(path = realmPath, schema = setOf(Sample::class)).build()
         assertEquals(realmPath, configFromBuilder.path)

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmObjectTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmObjectTests.kt
@@ -82,7 +82,7 @@ class RealmObjectTests : RealmStateTest {
 
     @Test
     fun isValid() {
-        val unmanagedParent = Parent()
+        val unmanagedParent = Parent().apply { _id = "Foo" }
         assertTrue(unmanagedParent.isValid())
         val obj: Parent = realm.writeBlocking { copyToRealm(unmanagedParent) }
         assertTrue(obj.isValid())
@@ -94,7 +94,7 @@ class RealmObjectTests : RealmStateTest {
     override fun isFrozen() {
         assertTrue { parent.isFrozen() }
         realm.writeBlocking {
-            val parent = copyToRealm(Parent())
+            val parent = copyToRealm(Parent().apply { _id = "Foo" })
             assertFalse { parent.isFrozen() }
         }
     }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmTests.kt
@@ -183,13 +183,13 @@ class RealmTests {
     fun writeBlockingAfterWrite() = runBlocking {
         val name = "Realm"
         val child: Child = realm.write {
-            this.copyToRealm(Child()).apply { this.name = name }
+            this.copyToRealm(Child().apply { _id = "Foo" }).apply { this.name = name }
         }
         assertEquals(name, child.name)
         assertEquals(1, realm.objects<Child>().size)
 
         realm.writeBlocking {
-            this.copyToRealm(Child()).apply { this.name = name }
+            this.copyToRealm(Child().apply { _id = "Bar" }).apply { this.name = name }
         }
         Unit
     }
@@ -214,7 +214,7 @@ class RealmTests {
         val jobs: List<Job> = IntRange(0, 9).map {
             launch {
                 realm.write {
-                    copyToRealm(Parent())
+                    copyToRealm(Parent().apply { _id = "pk$it" })
                 }
             }
         }
@@ -370,12 +370,12 @@ class RealmTests {
         val dispatcher = newSingleThreadContext("background")
         runBlocking {
             realm.write {
-                copyToRealm(Parent())
+                copyToRealm(Parent().apply { _id = "Foo" })
             }
         }
         runBlocking(dispatcher) {
             realm.write {
-                copyToRealm(Parent())
+                copyToRealm(Parent().apply { _id = "Bar" })
             }
         }
         assertEquals(2, realm.objects<Parent>().size)
@@ -384,7 +384,7 @@ class RealmTests {
     @Test
     fun closeClosesAllVersions() {
         runBlocking {
-            realm.write { copyToRealm(Parent()) }
+            realm.write { copyToRealm(Parent().apply { _id = "Foo" }) }
         }
         val parent: Parent = realm.objects<Parent>().first()
         runBlocking {

--- a/test/base/src/commonMain/kotlin/io/realm/entities/link/Child.kt
+++ b/test/base/src/commonMain/kotlin/io/realm/entities/link/Child.kt
@@ -20,7 +20,6 @@ import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 
 class Child : RealmObject {
-    @PrimaryKey
-    var _id: String = ""
+    @PrimaryKey var _id: String = ""
     var name: String = "DEFAULT"
 }

--- a/test/base/src/commonMain/kotlin/io/realm/entities/link/Child.kt
+++ b/test/base/src/commonMain/kotlin/io/realm/entities/link/Child.kt
@@ -17,7 +17,10 @@
 package io.realm.entities.link
 
 import io.realm.RealmObject
+import io.realm.annotations.PrimaryKey
 
 class Child : RealmObject {
+    @PrimaryKey
+    var _id: String = ""
     var name: String = "DEFAULT"
 }

--- a/test/base/src/commonMain/kotlin/io/realm/entities/link/Parent.kt
+++ b/test/base/src/commonMain/kotlin/io/realm/entities/link/Parent.kt
@@ -17,8 +17,10 @@
 package io.realm.entities.link
 
 import io.realm.RealmObject
+import io.realm.annotations.PrimaryKey
 
 class Parent : RealmObject {
+    @PrimaryKey var _id: String = ""
     var name: String = "N.N."
     var child: Child? = null
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -20,10 +20,8 @@ import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.mongodb.App
 import io.realm.mongodb.AppConfiguration
 import io.realm.mongodb.EmailPassword
-import io.realm.mongodb.appConfigurationOf
 import io.realm.mongodb.internal.KtorNetworkTransport
 import kotlinx.coroutines.runBlocking
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 const val TEST_APP_1 = "testapp1" // Id for the default test app
@@ -32,7 +30,7 @@ const val BASE_URL = "http://127.0.0.1:9090"
 // Cannot run on CI yet, as it requires sync server to be started with
 // tools/sync_test_server/start_server.sh and manual creation of a user "asdf@asdf.com"/"asdfasdf"
 // through the web ui
-@Ignore
+//@Ignore
 class AppTests {
 
     @Test
@@ -56,8 +54,11 @@ class AppTests {
             }
         }
 
-        val configuration: AppConfiguration = appConfigurationOf(applicationId, BASE_URL, singleThreadDispatcher("asdf"))
-        val app = App.create(configuration)
+        val app = AppConfiguration.Builder(applicationId)
+            .baseUrl(BASE_URL)
+            .dispatcher(singleThreadDispatcher("test dispatcher"))
+            .build()
+            .let { App.create(it) }
 
         runBlocking {
             app.login(EmailPassword("asdf@asdf.com", "asdfasdf")).getOrThrow()

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -16,9 +16,11 @@
 
 package io.realm.test.mongodb.shared
 
+import io.realm.entities.Sample
 import io.realm.mongodb.App
 import io.realm.mongodb.AuthenticationProvider
 import io.realm.mongodb.Credentials
+import io.realm.mongodb.SyncConfiguration
 import io.realm.test.mongodb.TestApp
 import io.realm.test.mongodb.asTestApp
 import kotlinx.coroutines.runBlocking
@@ -26,6 +28,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 const val TEST_APP_1 = "testapp1" // Id for the default test app
 const val BASE_URL = "http://127.0.0.1:9090"
@@ -91,5 +94,21 @@ class AppTests {
                 app.login(credentials).getOrThrow()
             }
         }
+    }
+
+    @Test
+    fun syncConfig() {
+        app.asTestApp.createUser("asdf@asdf.com", "asdfasdf")
+
+        val user = runBlocking {
+            app.login(Credentials.anonymous()).getOrThrow()
+        }
+
+        val config = SyncConfiguration.Builder(
+            schema = setOf(Sample::class),
+            partitionValue = "ASDF",
+            user = user
+        ).build()
+        assertNotNull(config)
     }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -29,7 +29,7 @@ import kotlin.test.assertFailsWith
 
 class AppTests {
 
-    lateinit var app: App
+    private lateinit var app: App
 
     @BeforeTest
     fun setup() {

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/AppTests.kt
@@ -16,11 +16,9 @@
 
 package io.realm.test.mongodb.shared
 
-import io.realm.entities.Sample
 import io.realm.mongodb.App
 import io.realm.mongodb.AuthenticationProvider
 import io.realm.mongodb.Credentials
-import io.realm.mongodb.SyncConfiguration
 import io.realm.test.mongodb.TestApp
 import io.realm.test.mongodb.asTestApp
 import kotlinx.coroutines.runBlocking
@@ -28,15 +26,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
 
-const val TEST_APP_1 = "testapp1" // Id for the default test app
-const val BASE_URL = "http://127.0.0.1:9090"
-
-// Cannot run on CI yet, as it requires sync server to be started with
-// tools/sync_test_server/start_server.sh and manual creation of a user "asdf@asdf.com"/"asdfasdf"
-// through the web ui
-//@Ignore
 class AppTests {
 
     lateinit var app: App
@@ -94,21 +84,5 @@ class AppTests {
                 app.login(credentials).getOrThrow()
             }
         }
-    }
-
-    @Test
-    fun syncConfig() {
-        app.asTestApp.createUser("asdf@asdf.com", "asdfasdf")
-
-        val user = runBlocking {
-            app.login(Credentials.anonymous()).getOrThrow()
-        }
-
-        val config = SyncConfiguration.Builder(
-            schema = setOf(Sample::class),
-            partitionValue = "ASDF",
-            user = user
-        ).build()
-        assertNotNull(config)
     }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
@@ -208,15 +208,15 @@ class SyncConfigTests {
 //        assertNotEquals(config1.hashCode(), config2.hashCode())
 //    }
 //
-
-    @Test
-    fun equals_syncSpecificFields() {
-        val user = createTestUser()
-        val config = createSyncConfig(user = user, name = DEFAULT_NAME)
-        assertEquals(config.name, DEFAULT_NAME)
-        assertEquals(config.partitionValue.asString(), DEFAULT_PARTITION_VALUE)
-    }
-
+//
+//    @Test
+//    fun equals_syncSpecificFields() {
+//        val user = createTestUser()
+//        val config = createSyncConfig(user = user, name = DEFAULT_NAME)
+//        assertEquals(config.name, DEFAULT_NAME)
+//        assertEquals(config.partitionValue.asString(), DEFAULT_PARTITION_VALUE)
+//    }
+//
 //    @Test
 //    fun name() {
 //        val user: User = createTestUser(app)

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
@@ -54,7 +54,7 @@ class SyncConfigTests {
     }
 
     @AfterTest
-    fun teadDown() {
+    fun tearDown() {
         if (this::app.isInitialized) {
             app.asTestApp.close()
         }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
@@ -97,7 +97,9 @@ class SyncConfigTests {
                 realm.objects(Child::class)
                     .observe()
                     .collect { childResults ->
-                        channel.send(childResults[0])
+                        println("--- RECEIVED CHILD")
+                        val kjhasd = 0
+//                        channel.send(childResults[0])
                     }
             }
 
@@ -106,11 +108,14 @@ class SyncConfigTests {
                 copyToRealm(child)
             }
 
+            println("--- BEFORE RECEIVE")
             val childResult = channel.receive()
+            println("--- AFTER  RECEIVE")
             assertEquals("CHILD_A", childResult._id)
             observer.cancel()
             channel.close()
         }
+        val kjahsd = 0
     }
 
 //    @Test

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
@@ -1,0 +1,985 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.test.mongodb.shared
+
+import io.realm.entities.Sample
+import io.realm.mongodb.App
+import io.realm.mongodb.Credentials
+import io.realm.mongodb.SyncConfiguration
+import io.realm.mongodb.User
+import io.realm.test.mongodb.TestApp
+import io.realm.test.mongodb.asTestApp
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+const val DEFAULT_PARTITION_VALUE = "default"
+
+class SyncConfigTests {
+
+    lateinit var app: App
+
+    @BeforeTest
+    fun setup() {
+        app = TestApp()
+    }
+
+    @AfterTest
+    fun teadDown() {
+        if (this::app.isInitialized) {
+            app.asTestApp.close()
+        }
+    }
+
+    private fun createNewUser(): User {
+        app.asTestApp.createUser("asdf@asdf.com", "asdfasdf")
+        return runBlocking {
+            app.login(Credentials.anonymous()).getOrThrow()
+        }
+    }
+
+    private fun createSyncConfig(
+        user: User,
+        partitionValue: String = DEFAULT_PARTITION_VALUE
+    ): SyncConfiguration = SyncConfiguration.Builder(
+        schema = setOf(Sample::class),
+        user = user,
+        partitionValue = partitionValue
+    ).build()
+
+    @Test
+    fun syncConfig() {
+        val user = createNewUser()
+        val config = SyncConfiguration.Builder(
+            schema = setOf(Sample::class),
+            partitionValue = "ASDF",
+            user = user
+        ).build()
+
+        assertNotNull(config)
+    }
+
+//    // Smoke test for Sync. Waiting for working Sync support.
+//    @Test
+//    fun connectWithInitialSchema() {
+//        val user: User = createNewUser()
+//        val config = createSyncConfig(user)
+//        val realm: Realm = Realm.open(config)
+//        realm.writeBlocking {
+//            with(realm.syncSession) {
+//                uploadAllLocalChanges()
+//                downloadAllServerChanges()
+//            }
+//            assertTrue(isEmpty)
+//        }
+//    }
+//
+//    // Smoke test for Sync
+//    @Test
+//    fun roundTripObjectsNotInServerSchemaObject() {
+//        // User 1 creates an object an uploads it to MongoDB Realm
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createCustomConfig(user1, partitionValue)
+//        Realm.getInstance(config1).use { realm ->
+//            realm.executeTransaction {
+//                for (i in 1..10) {
+//                    it.insert(SyncColor())
+//                }
+//            }
+//            realm.syncSession.uploadAllLocalChanges()
+//            assertEquals(10, realm.where<SyncColor>().count())
+//        }
+//
+//        // User 2 logs and using the same partition key should see the object
+//        val user2: User = createNewUser()
+//        val config2 = createCustomConfig(user2, partitionValue)
+//        Realm.getInstance(config2).use { realm ->
+//            realm.syncSession.downloadAllServerChanges()
+//            realm.refresh()
+//            assertEquals(10, realm.where<SyncColor>().count())
+//        }
+//    }
+//
+//    // Smoke test for sync
+//    // Insert different types with no links between them
+//    @Test
+//    fun roundTripSimpleObjectsInServerSchema() {
+//        // User 1 creates an object an uploads it to MongoDB Realm
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//        Realm.getInstance(config1).use { realm ->
+//            realm.executeTransaction {
+//                val person = SyncPerson()
+//                person.firstName = "Jane"
+//                person.lastName = "Doe"
+//                person.age = 42
+//                realm.insert(person);
+//                for (i in 0..9) {
+//                    val dog = SyncDog()
+//                    dog.name = "Fido $i"
+//                    it.insert(dog)
+//                }
+//            }
+//            realm.syncSession.uploadAllLocalChanges()
+//            assertEquals(10, realm.where<SyncDog>().count())
+//            assertEquals(1, realm.where<SyncPerson>().count())
+//        }
+//
+//        // User 2 logs and using the same partition key should see the object
+//        val user2: User = createNewUser()
+//        val config2 = createSyncConfig(user2, partitionValue)
+//        Realm.getInstance(config2).use { realm ->
+//            realm.syncSession.downloadAllServerChanges()
+//            realm.refresh()
+//            assertEquals(10, realm.where<SyncDog>().count())
+//            assertEquals(1, realm.where<SyncPerson>().count())
+//        }
+//    }
+//
+//    // Smoke test for sync
+//    // Insert objects with links between them
+//    @Test
+//    fun roundTripObjectsWithLists() {
+//        // User 1 creates an object an uploads it to MongoDB Realm
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//        Realm.deleteRealm(config1)
+//        Realm.getInstance(config1).use { realm ->
+//            realm.executeTransaction {
+//                val person = SyncPerson()
+//                person.firstName = "Jane"
+//                person.lastName = "Doe"
+//                person.age = 42
+//                for (i in 0..9) {
+//                    val dog = SyncDog()
+//                    dog.name = "Fido $i"
+//                    person.dogs.add(dog)
+//                }
+//                realm.insert(person)
+//            }
+//            realm.syncSession.uploadAllLocalChanges()
+//            assertEquals(10, realm.where<SyncDog>().count())
+//            assertEquals(1, realm.where<SyncPerson>().count())
+//        }
+//
+//        // User 2 logs and using the same partition key should see the object
+//        val user2: User = createNewUser()
+//        val config2 = createSyncConfig(user2, partitionValue)
+//        Realm.deleteRealm(config2)
+//        Realm.getInstance(config2).use { realm ->
+//            realm.syncSession.downloadAllServerChanges()
+//            realm.refresh()
+//            assertEquals(10, realm.where<SyncDog>().count())
+//            assertEquals(1, realm.where<SyncPerson>().count())
+//        }
+//    }
+//
+//    @Test
+//    fun session() {
+//        val user: User = app.login(Credentials.anonymous())
+//        Realm.getInstance(createSyncConfig(user)).use { realm ->
+//            assertNotNull(realm.syncSession)
+//            assertEquals(SyncSession.State.ACTIVE, realm.syncSession.state)
+//            assertEquals(user, realm.syncSession.user)
+//        }
+//    }
+//
+//    @Test
+//    fun nullPartition() {
+//        val config = configFactory.createSyncConfigurationBuilder(createNewUser(), BsonNull())
+//            .modules(DefaultSyncSchema())
+//            .build()
+//        assertTrue(config.path.endsWith("null.realm"))
+//        Realm.getInstance(config).use { realm ->
+//            realm.syncSession.uploadAllLocalChanges() // Ensures that we can actually connect
+//        }
+//    }
+//
+//    @Test
+//    @Ignore("FIXME Flaky, seems like Realm.compactRealm(config) sometimes returns false")
+//    fun compactRealm_populatedRealm() {
+//        val config = configFactory.createSyncConfigurationBuilder(createNewUser()).build()
+//        Realm.getInstance(config).use { realm ->
+//            realm.executeTransaction { r: Realm ->
+//                for (i in 0..9) {
+//                    r.insert(AllJavaTypes(i.toLong()))
+//                }
+//            }
+//        }
+//        assertTrue(Realm.compactRealm(config))
+//
+//        Realm.getInstance(config).use { realm ->
+//            assertEquals(10, realm.where(AllJavaTypes::class.java).count())
+//        }
+//    }
+//
+//    @Test
+//    fun compactOnLaunch_shouldCompact() {
+//        val user = createTestUser(app)
+//
+//        // Fill Realm with data and record size
+//        val config1 = configFactory.createSyncConfigurationBuilder(user)
+//            .testSchema(SyncByteArray::class.java)
+//            .build()
+//
+//        var originalSize: Long? = null
+//        Realm.getInstance(config1).use { realm ->
+//            val oneMBData = ByteArray(1024 * 1024)
+//            realm.executeTransaction {
+//                for (i in 0..9) {
+//                    realm.createObject(SyncByteArray::class.java, ObjectId()).columnBinary =
+//                        oneMBData
+//                }
+//            }
+//            originalSize = File(realm.path).length()
+//        }
+//
+//        // Open Realm with CompactOnLaunch
+//        val config2 = configFactory.createSyncConfigurationBuilder(user)
+//            .compactOnLaunch { totalBytes, usedBytes -> true }
+//            .testSchema(SyncByteArray::class.java)
+//            .build()
+//        Realm.getInstance(config2).use { realm ->
+//            val compactedSize = File(realm.path).length()
+//            assertTrue(originalSize!! > compactedSize)
+//        }
+//    }
+//
+//    @Test
+//    fun embeddedObject_roundTrip() {
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//        val primaryKeyValue = UUID.randomUUID().toString()
+//        Realm.getInstance(config1).use { realm ->
+//            assertTrue(realm.isEmpty)
+//
+//            realm.executeTransaction {
+//                realm.createObject<EmbeddedSimpleParent>(primaryKeyValue).let { parent ->
+//                    realm.createEmbeddedObject<EmbeddedSimpleChild>(parent, "child")
+//                }
+//            }
+//            realm.syncSession.uploadAllLocalChanges()
+//
+//            assertEquals(1, realm.where<EmbeddedSimpleParent>().count())
+//            assertEquals(1, realm.where<EmbeddedSimpleChild>().count())
+//        }
+//
+//        val user2: User = createNewUser()
+//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
+//        Realm.getInstance(config2).use { realm ->
+//            realm.syncSession.downloadAllServerChanges(5, TimeUnit.SECONDS).let {
+//                if (!it) fail()
+//            }
+//            realm.refresh()
+//
+//            val childResults = realm.where<EmbeddedSimpleChild>()
+//            assertEquals(1, childResults.count())
+//            val parentResults = realm.where<EmbeddedSimpleParent>()
+//            assertEquals(1, parentResults.count())
+//            val parent = parentResults.findFirst()!!
+//            assertEquals(primaryKeyValue, parent._id)
+//            assertEquals(parent._id, parent.child!!.parent._id)
+//        }
+//    }
+//
+//    // FIXME: remove ignore when sync issue fixed
+//    @Test
+//    @Ignore("ignored until https://jira.mongodb.org/browse/REALMC-6541 is fixed")
+//    fun embeddedObject_copyUnmanaged_roundTrip() {
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//        val primaryKeyValue = UUID.randomUUID().toString()
+//
+//        Realm.getInstance(config1).use { realm ->
+//            assertTrue(realm.isEmpty)
+//
+//            realm.executeTransaction {
+//                val parent = EmbeddedSimpleParent(primaryKeyValue)
+//
+////                parent.child = EmbeddedSimpleChild()
+//                val managedParent = it.copyToRealmOrUpdate(parent)
+//                // FIXME: instantiating the child in managedParent yields this from sync:
+//                //  "MongoDB error: Updating the path 'child.childID' would create a conflict at 'child'"
+//                managedParent.child = EmbeddedSimpleChild() // Will copy the object to Realm
+//            }
+//            realm.syncSession.uploadAllLocalChanges()
+//
+//            assertEquals(1, realm.where<EmbeddedSimpleParent>().count())
+//            assertEquals(1, realm.where<EmbeddedSimpleChild>().count())
+//        }
+//
+//        val user2: User = createNewUser()
+//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
+//        Realm.getInstance(config2).use { realm ->
+//            realm.syncSession.downloadAllServerChanges(5, TimeUnit.SECONDS).let {
+//                if (!it) fail()
+//            }
+//            realm.refresh()
+//
+//            val childResults = realm.where<EmbeddedSimpleChild>()
+//            assertEquals(1, childResults.count())
+//            val parentResults = realm.where<EmbeddedSimpleParent>()
+//            assertEquals(1, parentResults.count())
+//            val parent = parentResults.findFirst()!!
+//            assertEquals(primaryKeyValue, parent._id)
+//            assertEquals(parent._id, parent.child!!.parent._id)
+//        }
+//    }
+//
+//    @Test
+//    fun embeddedObject_realmList_roundTrip() {
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//        val primaryKeyValue = UUID.randomUUID().toString()
+//        Realm.getInstance(config1).use { realm ->
+//            realm.executeTransaction {
+//                realm.createObject(EmbeddedSimpleListParent::class.java, primaryKeyValue)
+//                    .let { parent ->
+//                        realm.createEmbeddedObject(
+//                            EmbeddedSimpleChild::class.java,
+//                            parent,
+//                            "children"
+//                        )
+//                        realm.createEmbeddedObject(
+//                            EmbeddedSimpleChild::class.java,
+//                            parent,
+//                            "children"
+//                        )
+//                    }
+//            }
+//            realm.syncSession.uploadAllLocalChanges()
+//
+//            assertEquals(1, realm.where<EmbeddedSimpleListParent>().count())
+//            assertEquals(2, realm.where<EmbeddedSimpleChild>().count())
+//        }
+//
+//        val user2: User = createNewUser()
+//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
+//        Realm.getInstance(config2).use { realm ->
+//            assertEquals(0, realm.where<EmbeddedSimpleListParent>().count())
+//            assertEquals(0, realm.where<EmbeddedSimpleChild>().count())
+//
+//            realm.syncSession.downloadAllServerChanges(5, TimeUnit.SECONDS).let {
+//                if (!it) fail()
+//            }
+//            realm.refresh()
+//
+//            val childResults = realm.where<EmbeddedSimpleChild>()
+//            assertEquals(2, childResults.count())
+//            val parentResults = realm.where<EmbeddedSimpleListParent>()
+//            assertEquals(1, parentResults.count())
+//            val parentFromResults = parentResults.findFirst()!!
+//            assertEquals(primaryKeyValue, parentFromResults._id)
+//
+//            parentFromResults.children.also { childrenInParent ->
+//                val childrenFromResults = childResults.findAll()
+//                childrenInParent.forEach { childInParent ->
+//                    assertTrue(childrenFromResults.contains(childInParent))
+//                }
+//            }
+//        }
+//    }
+//
+//    @Test
+//    fun embeddedObject_realmList_copyUnmanaged_roundTrip() {
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//        val primaryKeyValue = UUID.randomUUID().toString()
+//        Realm.getInstance(config1).use { realm ->
+//            realm.executeTransaction {
+//                val parent = EmbeddedSimpleListParent(primaryKeyValue)
+//                parent.children =
+//                    RealmList(EmbeddedSimpleChild("child1"), EmbeddedSimpleChild("child2"))
+//                realm.insert(parent)
+//            }
+//            realm.syncSession.uploadAllLocalChanges()
+//
+//            assertEquals(1, realm.where<EmbeddedSimpleListParent>().count())
+//            assertEquals(2, realm.where<EmbeddedSimpleChild>().count())
+//        }
+//
+//        val user2: User = createNewUser()
+//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
+//        Realm.getInstance(config2).use { realm ->
+//            assertEquals(0, realm.where<EmbeddedSimpleListParent>().count())
+//            assertEquals(0, realm.where<EmbeddedSimpleChild>().count())
+//
+//            realm.syncSession.downloadAllServerChanges(1, TimeUnit.SECONDS).let {
+//                if (!it) fail()
+//            }
+//            realm.refresh()
+//
+//            val childResults = realm.where<EmbeddedSimpleChild>()
+//            assertEquals(2, childResults.count())
+//            val parentResults = realm.where<EmbeddedSimpleListParent>()
+//            assertEquals(1, parentResults.count())
+//            val parentFromResults = parentResults.findFirst()!!
+//            assertEquals(primaryKeyValue, parentFromResults._id)
+//            assertEquals("child1", childResults.findAll()[0]!!.childId)
+//            assertEquals("child2", childResults.findAll()[1]!!.childId)
+//        }
+//    }
+//
+//    // FIXME: remember to add tree structure classes to DefaultSyncSchema.kt
+//    @Test
+//    @Ignore("Enable when https://jira.mongodb.org/projects/HELP/queues/issue/HELP-17759 is fixed")
+//    fun copyToRealm_treeSchema() {
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//        val primaryKeyValue = UUID.randomUUID().toString()
+//
+//        Realm.getInstance(config1).use { realm ->
+//            realm.executeTransaction {
+//                val parent = EmbeddedTreeParent("parent1")
+//
+//                val node1 = EmbeddedTreeNode("node1")
+//                node1.leafNode = EmbeddedTreeLeaf("leaf1")
+//                parent.middleNode = node1
+//                val node2 = EmbeddedTreeNode("node2")
+//                node2.leafNodeList.add(EmbeddedTreeLeaf("leaf2"))
+//                node2.leafNodeList.add(EmbeddedTreeLeaf("leaf3"))
+//                parent.middleNodeList.add(node2)
+//
+//                it.copyToRealm(parent)
+//            }
+//            realm.syncSession.uploadAllLocalChanges()
+//        }
+//
+//        val user2: User = createNewUser()
+//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
+//        Realm.getInstance(config2).use { realm ->
+//            assertEquals(0, realm.where<EmbeddedSimpleListParent>().count())
+//            assertEquals(0, realm.where<EmbeddedSimpleChild>().count())
+//
+//            realm.syncSession.downloadAllServerChanges(1, TimeUnit.SECONDS).let {
+//                if (!it) fail()
+//            }
+//            realm.refresh()
+//
+//            Assert.assertEquals(1, realm.where<EmbeddedTreeParent>().count())
+//            Assert.assertEquals("parent1", realm.where<EmbeddedTreeParent>().findFirst()!!._id)
+//
+//            Assert.assertEquals(2, realm.where<EmbeddedTreeNode>().count())
+//            val nodeResults = realm.where<EmbeddedTreeNode>().findAll()
+//            Assert.assertTrue(nodeResults.any { it.treeNodeId == "node1" })
+//            Assert.assertTrue(nodeResults.any { it.treeNodeId == "node2" })
+//
+//            Assert.assertEquals(3, realm.where<EmbeddedTreeLeaf>().count())
+//            val leafResults = realm.where<EmbeddedTreeLeaf>().findAll()
+//            Assert.assertTrue(leafResults.any { it.treeLeafId == "leaf1" })
+//            Assert.assertTrue(leafResults.any { it.treeLeafId == "leaf2" })
+//            Assert.assertTrue(leafResults.any { it.treeLeafId == "leaf3" })
+//        }
+//    }
+//
+//    // Check that we can create multiple apps that synchronize with each other
+//    @Test
+//    fun multipleAppsCanSync() {
+//        val app2 = TestApp(appName = TEST_APP_2)
+//        var realm1: Realm? = null
+//        var realm2: Realm? = null
+//        try {
+//            // Login users on both Realms
+//            val app1User = app.login(Credentials.anonymous())
+//            val app2User = app2.login(Credentials.anonymous())
+//            Assert.assertNotEquals(app1User, app2User)
+//
+//            // Create one Realm against each app
+//            val config1 = configFactory.createSyncConfigurationBuilder(app1User, BsonString("foo"))
+//                .modules(DefaultSyncSchema())
+//                .build()
+//            val config2 = configFactory.createSyncConfigurationBuilder(app2User, BsonString("foo"))
+//                .modules(DefaultSyncSchema())
+//                .build()
+//
+//            // Make sure we can synchronize changes
+//            realm1 = Realm.getInstance(config1)
+//            realm2 = Realm.getInstance(config2)
+//            realm1.syncSession.downloadAllServerChanges()
+//            realm2.syncSession.downloadAllServerChanges()
+//            Assert.assertTrue(realm1.isEmpty)
+//            Assert.assertTrue(realm2.isEmpty)
+//        } finally {
+//            realm1?.close()
+//            realm2?.close()
+//            app2.close()
+//        }
+//    }
+//
+//    @Test
+//    fun allTypes_roundTrip() {
+//        val expectedRealmAnyValues = arrayListOf(
+//            RealmAny.valueOf(1.toLong()),
+//            RealmAny.valueOf(false),
+//            RealmAny.valueOf(10.5.toFloat()),
+//            RealmAny.valueOf(10.5.toDouble()),
+//            RealmAny.valueOf("hello world 2"),
+//            RealmAny.valueOf(Date(105)),
+//            RealmAny.valueOf(Decimal128(102)),
+//            RealmAny.valueOf(ObjectId()),
+//            RealmAny.valueOf(UUID.randomUUID())
+//        )
+//
+//        val primaryKeyValue = ObjectId()
+//        val expectedRealmInteger = 100.toLong()
+//        val expectedString = "hello world"
+//        val expectedLong = 10.toLong()
+//        val expectedDouble = 10.0
+//        val expectedFloat = 10.0.toFloat()
+//        val expectedBoolean = true
+//        val expectedDate = Date()
+//        val expectedBinary = byteArrayOf(0, 1, 0)
+//        val expectedDecimal128 = Decimal128(10)
+//        val expectedObjectId = ObjectId()
+//        val expectedUUID = UUID.randomUUID()
+//        var expectedRealmObject = SyncDog().apply {
+//            id = expectedObjectId
+//        }
+//        val expectedRealmList = RealmList<SyncDog>()
+//        val expectedStringList = RealmList<String>("hello world 1", "hello world 2")
+//        val expectedBinaryList = RealmList<ByteArray>(expectedBinary)
+//        val expectedBooleanList = RealmList<Boolean>(true, false, false, true)
+//        val expectedLongList = RealmList<Long>(0, 1, 2, 5, 7)
+//        val expectedDoubleList = RealmList<Double>(0.0, 2.toDouble(), 10.5)
+//        val expectedFloatList = RealmList<Float>(0.0.toFloat(), 2.toFloat(), 10.5.toFloat())
+//        val expectedDateList = RealmList<Date>(Date(100), Date(10), Date(200))
+//        val expectedDecimal128List =
+//            RealmList<Decimal128>(Decimal128(10), Decimal128(100), Decimal128(20))
+//        val expectedObjectIdList = RealmList<ObjectId>(
+//            ObjectId(Date(1000)), ObjectId(Date(100)), ObjectId(
+//                Date(2000)
+//            )
+//        )
+//        val expectedUUIDList = RealmList<UUID>(UUID.randomUUID())
+//        val expectedRealmAnyList = RealmList<RealmAny>()
+//        expectedRealmAnyList.addAll(expectedRealmAnyValues)
+//
+//        val expectedRealmDict = RealmDictionary<SyncDog>()
+//        val expectedStringDict = RealmDictionary<String>().init(listOf("key" to expectedString))
+//        val expectedBinaryDict = RealmDictionary<ByteArray>().init(listOf("key" to expectedBinary))
+//        val expectedBooleanDict = RealmDictionary<Boolean>().init(listOf("key" to expectedBoolean))
+//        val expectedLongDict = RealmDictionary<Long>().init(listOf("key" to expectedLong))
+//        val expectedDoubleDict = RealmDictionary<Double>().init(listOf("key" to expectedDouble))
+//        val expectedFloatDict = RealmDictionary<Float>().init(listOf("key" to expectedFloat))
+//        val expectedDateDict = RealmDictionary<Date>().init(listOf("key" to expectedDate))
+//        val expectedDecimal128Dict =
+//            RealmDictionary<Decimal128>().init(listOf("key" to expectedDecimal128))
+//        val expectedObjectIdDict =
+//            RealmDictionary<ObjectId>().init(listOf("key" to expectedObjectId))
+//        val expectedUUIDDict = RealmDictionary<UUID>().init(listOf("key" to expectedUUID))
+//        val expectedRealmAnyDict = RealmDictionary<RealmAny>()
+//
+//        val expectedRealmSet = RealmSet<SyncDog>()
+//        val expectedStringSet = RealmSet<String>().init(listOf(expectedString))
+//        val expectedBinarySet = RealmSet<ByteArray>().init(listOf(expectedBinary))
+//        val expectedBooleanSet = RealmSet<Boolean>().init(listOf(expectedBoolean))
+//        val expectedLongSet = RealmSet<Long>().init(listOf(expectedLong))
+//        val expectedDoubleSet = RealmSet<Double>().init(listOf(expectedDouble))
+//        val expectedFloatSet = RealmSet<Float>().init(listOf(expectedFloat))
+//        val expectedDateSet = RealmSet<Date>().init(listOf(expectedDate))
+//        val expectedDecimal128Set = RealmSet<Decimal128>().init(listOf(expectedDecimal128))
+//        val expectedObjectIdSet = RealmSet<ObjectId>().init(listOf(expectedObjectId))
+//        val expectedUUIDSet = RealmSet<UUID>().init(listOf(expectedUUID))
+//        val expectedRealmAnySet = RealmSet<RealmAny>()
+//
+//        val user1: User = createNewUser()
+//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//
+//        val user2: User = createNewUser()
+//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
+//
+//        Realm.getInstance(config1).use { realm1 ->
+//            Realm.getInstance(config2).use { realm2 ->
+//                for (expectedRealmAny in expectedRealmAnyValues) {
+//                    realm1.executeTransaction {
+//                        expectedRealmObject = realm1.copyToRealmOrUpdate(expectedRealmObject)
+//                        expectedRealmList.add(expectedRealmObject)
+//                        expectedRealmDict["key"] = expectedRealmObject
+//
+//                        // Populate object to round-trip
+//                        val syncObject = SyncAllTypes().apply {
+//                            id = primaryKeyValue
+//
+//                            RealmFieldType.values().map { realmFieldType ->
+//                                when (realmFieldType) {
+//                                    RealmFieldType.INTEGER -> {
+//                                        columnLong = expectedLong
+//                                        // MutableRealmInteger
+//                                        columnRealmInteger.set(expectedRealmInteger)
+//                                    }
+//                                    RealmFieldType.BOOLEAN -> isColumnBoolean = expectedBoolean
+//                                    RealmFieldType.STRING -> columnString = expectedString
+//                                    RealmFieldType.BINARY -> columnBinary = expectedBinary
+//                                    RealmFieldType.DATE -> columnDate = expectedDate
+//                                    RealmFieldType.DOUBLE -> columnDouble = expectedDouble
+//                                    RealmFieldType.FLOAT -> columnFloat = expectedFloat
+//                                    RealmFieldType.OBJECT -> columnRealmObject = expectedRealmObject
+//                                    RealmFieldType.DECIMAL128 -> columnDecimal128 =
+//                                        expectedDecimal128
+//                                    RealmFieldType.OBJECT_ID -> columnObjectId = expectedObjectId
+//                                    RealmFieldType.UUID -> columnUUID = expectedUUID
+//                                    RealmFieldType.MIXED -> columnRealmAny = expectedRealmAny
+//                                    RealmFieldType.LIST -> columnRealmList = expectedRealmList
+//                                    RealmFieldType.INTEGER_LIST -> columnLongList = expectedLongList
+//                                    RealmFieldType.BOOLEAN_LIST -> columnBooleanList =
+//                                        expectedBooleanList
+//                                    RealmFieldType.STRING_LIST -> columnStringList =
+//                                        expectedStringList
+//                                    RealmFieldType.BINARY_LIST -> columnBinaryList =
+//                                        expectedBinaryList
+//                                    RealmFieldType.DATE_LIST -> columnDateList = expectedDateList
+//                                    RealmFieldType.DOUBLE_LIST -> columnDoubleList =
+//                                        expectedDoubleList
+//                                    RealmFieldType.FLOAT_LIST -> columnFloatList = expectedFloatList
+//                                    RealmFieldType.DECIMAL128_LIST -> columnDecimal128List =
+//                                        expectedDecimal128List
+//                                    RealmFieldType.OBJECT_ID_LIST -> columnObjectIdList =
+//                                        expectedObjectIdList
+//                                    RealmFieldType.UUID_LIST -> columnUUIDList = expectedUUIDList
+//                                    RealmFieldType.MIXED_LIST -> columnRealmAnyList =
+//                                        expectedRealmAnyList
+//                                    RealmFieldType.STRING_TO_INTEGER_MAP -> columnLongDictionary =
+//                                        expectedLongDict
+//                                    RealmFieldType.STRING_TO_BOOLEAN_MAP -> columnBooleanDictionary =
+//                                        expectedBooleanDict
+//                                    RealmFieldType.STRING_TO_STRING_MAP -> columnStringDictionary =
+//                                        expectedStringDict
+//                                    RealmFieldType.STRING_TO_BINARY_MAP -> columnBinaryDictionary =
+//                                        expectedBinaryDict
+//                                    RealmFieldType.STRING_TO_DATE_MAP -> columnDateDictionary =
+//                                        expectedDateDict
+//                                    RealmFieldType.STRING_TO_DOUBLE_MAP -> columnDoubleDictionary =
+//                                        expectedDoubleDict
+//                                    RealmFieldType.STRING_TO_FLOAT_MAP -> columnFloatDictionary =
+//                                        expectedFloatDict
+//                                    RealmFieldType.STRING_TO_DECIMAL128_MAP -> columnDecimal128Dictionary =
+//                                        expectedDecimal128Dict
+//                                    RealmFieldType.STRING_TO_OBJECT_ID_MAP -> columnObjectIdDictionary =
+//                                        expectedObjectIdDict
+//                                    RealmFieldType.STRING_TO_UUID_MAP -> columnUUIDDictionary =
+//                                        expectedUUIDDict
+//                                    RealmFieldType.STRING_TO_MIXED_MAP -> {
+//                                        expectedRealmAnyDict["key"] = expectedRealmAny
+//                                        columnRealmAnyDictionary = expectedRealmAnyDict
+//                                    }
+//                                    RealmFieldType.STRING_TO_LINK_MAP -> columnRealmDictionary =
+//                                        expectedRealmDict
+//                                    RealmFieldType.LINK_SET -> columnRealmSet = expectedRealmSet
+//                                    RealmFieldType.INTEGER_SET -> columnLongSet = expectedLongSet
+//                                    RealmFieldType.BOOLEAN_SET -> columnBooleanSet =
+//                                        expectedBooleanSet
+//                                    RealmFieldType.STRING_SET -> columnStringSet = expectedStringSet
+//                                    RealmFieldType.BINARY_SET -> columnBinarySet = expectedBinarySet
+//                                    RealmFieldType.DATE_SET -> columnDateSet = expectedDateSet
+//                                    RealmFieldType.DOUBLE_SET -> columnDoubleSet = expectedDoubleSet
+//                                    RealmFieldType.FLOAT_SET -> columnFloatSet = expectedFloatSet
+//                                    RealmFieldType.DECIMAL128_SET -> columnDecimal128Set =
+//                                        expectedDecimal128Set
+//                                    RealmFieldType.OBJECT_ID_SET -> columnObjectIdSet =
+//                                        expectedObjectIdSet
+//                                    RealmFieldType.UUID_SET -> columnUUIDSet = expectedUUIDSet
+//                                    RealmFieldType.MIXED_SET -> columnRealmAnySet =
+//                                        expectedRealmAnySet
+//                                    RealmFieldType.LINKING_OBJECTS,     // Nothing to set
+//                                    RealmFieldType.TYPED_LINK          // Not an actual exposed type, it is used internally by RealmAny
+//                                    -> {
+//                                    }
+//                                }
+//                            }
+//                        }
+//
+//                        realm1.copyToRealmOrUpdate(syncObject)
+//                    }
+//                    realm1.syncSession.uploadAllLocalChanges()
+//
+//                    assertEquals(1, realm1.where<SyncAllTypes>().count())
+//
+//                    realm2.syncSession.downloadAllServerChanges(
+//                        TestHelper.STANDARD_WAIT_SECS.toLong(),
+//                        TimeUnit.SECONDS
+//                    ).let {
+//                        if (!it) fail()
+//                    }
+//                    realm2.refresh()
+//
+//                    assertEquals(1, realm2.where<SyncAllTypes>().count())
+//
+//                    // Validate that after a round-trip the values are the initial ones, the expected values
+//                    realm2.where<SyncAllTypes>().findFirst()!!.let { syncAllTypes ->
+//                        assertEquals(primaryKeyValue, syncAllTypes.id)
+//
+//                        RealmFieldType.values().map { realmFieldType ->
+//                            when (realmFieldType) {
+//                                RealmFieldType.INTEGER -> {
+//                                    assertEquals(expectedLong, syncAllTypes.columnLong)
+//                                    // MutableRealmInteger
+//                                    assertEquals(
+//                                        expectedRealmInteger,
+//                                        syncAllTypes.columnRealmInteger.get()
+//                                    )
+//                                }
+//                                RealmFieldType.BOOLEAN -> assertEquals(
+//                                    expectedBoolean,
+//                                    syncAllTypes.isColumnBoolean
+//                                )
+//                                RealmFieldType.STRING -> assertEquals(
+//                                    expectedString,
+//                                    syncAllTypes.columnString
+//                                )
+//                                RealmFieldType.BINARY -> assertTrue(
+//                                    expectedBinary.contentEquals(
+//                                        syncAllTypes.columnBinary
+//                                    )
+//                                )
+//                                RealmFieldType.DATE -> assertEquals(
+//                                    expectedDate,
+//                                    syncAllTypes.columnDate
+//                                )
+//                                RealmFieldType.DOUBLE -> assertEquals(
+//                                    expectedDouble,
+//                                    syncAllTypes.columnDouble
+//                                )
+//                                RealmFieldType.OBJECT -> assertEquals(
+//                                    expectedObjectId,
+//                                    syncAllTypes.columnRealmObject!!.id
+//                                )
+//                                RealmFieldType.DECIMAL128 -> assertEquals(
+//                                    expectedDecimal128,
+//                                    syncAllTypes.columnDecimal128
+//                                )
+//                                RealmFieldType.OBJECT_ID -> assertEquals(
+//                                    expectedObjectId,
+//                                    syncAllTypes.columnObjectId
+//                                )
+//                                RealmFieldType.UUID -> assertEquals(
+//                                    expectedUUID,
+//                                    syncAllTypes.columnUUID
+//                                )
+//                                RealmFieldType.MIXED -> assertEquals(
+//                                    expectedRealmAny,
+//                                    syncAllTypes.columnRealmAny
+//                                )
+//                                RealmFieldType.LIST -> assertEquals(
+//                                    expectedObjectId,
+//                                    syncAllTypes.columnRealmList.first()!!.id
+//                                )
+//                                RealmFieldType.INTEGER_LIST -> assertEquals(
+//                                    expectedLongList,
+//                                    syncAllTypes.columnLongList
+//                                )
+//                                RealmFieldType.BOOLEAN_LIST -> assertEquals(
+//                                    expectedBooleanList,
+//                                    syncAllTypes.columnBooleanList
+//                                )
+//                                RealmFieldType.STRING_LIST -> assertEquals(
+//                                    expectedStringList,
+//                                    syncAllTypes.columnStringList
+//                                )
+//                                RealmFieldType.BINARY_LIST -> {
+//                                    expectedBinaryList.forEachIndexed { index, bytes ->
+//                                        Arrays.equals(bytes, syncAllTypes.columnBinaryList[index])
+//                                    }
+//                                }
+//                                RealmFieldType.DATE_LIST -> assertEquals(
+//                                    expectedDateList,
+//                                    syncAllTypes.columnDateList
+//                                )
+//                                RealmFieldType.DOUBLE_LIST -> assertEquals(
+//                                    expectedDoubleList,
+//                                    syncAllTypes.columnDoubleList
+//                                )
+//                                RealmFieldType.DECIMAL128_LIST -> assertEquals(
+//                                    expectedDecimal128List,
+//                                    syncAllTypes.columnDecimal128List
+//                                )
+//                                RealmFieldType.OBJECT_ID_LIST -> assertEquals(
+//                                    expectedObjectIdList,
+//                                    syncAllTypes.columnObjectIdList
+//                                )
+//                                RealmFieldType.UUID_LIST -> assertEquals(
+//                                    expectedUUIDList,
+//                                    syncAllTypes.columnUUIDList
+//                                )
+//                                RealmFieldType.MIXED_LIST -> assertEquals(
+//                                    expectedRealmAnyList,
+//                                    syncAllTypes.columnRealmAnyList
+//                                )
+//                                RealmFieldType.STRING_TO_INTEGER_MAP -> assertEquals(
+//                                    expectedLong,
+//                                    syncAllTypes.columnLongDictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_BOOLEAN_MAP -> assertEquals(
+//                                    expectedBoolean,
+//                                    syncAllTypes.columnBooleanDictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_STRING_MAP -> assertEquals(
+//                                    expectedString,
+//                                    syncAllTypes.columnStringDictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_BINARY_MAP -> assertTrue(
+//                                    Arrays.equals(
+//                                        expectedBinary,
+//                                        syncAllTypes.columnBinaryDictionary["key"]
+//                                    )
+//                                )
+//                                RealmFieldType.STRING_TO_DATE_MAP -> assertEquals(
+//                                    expectedDate,
+//                                    syncAllTypes.columnDateDictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_DOUBLE_MAP -> assertEquals(
+//                                    expectedDouble,
+//                                    syncAllTypes.columnDoubleDictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_DECIMAL128_MAP -> assertEquals(
+//                                    expectedDecimal128,
+//                                    syncAllTypes.columnDecimal128Dictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_OBJECT_ID_MAP -> assertEquals(
+//                                    expectedObjectId,
+//                                    syncAllTypes.columnObjectIdDictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_UUID_MAP -> assertEquals(
+//                                    expectedUUID,
+//                                    syncAllTypes.columnUUIDDictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_MIXED_MAP -> assertEquals(
+//                                    expectedRealmAny,
+//                                    syncAllTypes.columnRealmAnyDictionary["key"]
+//                                )
+//                                RealmFieldType.STRING_TO_LINK_MAP -> assertEquals(
+//                                    expectedObjectId,
+//                                    syncAllTypes.columnRealmDictionary["key"]!!.id
+//                                )
+//                                RealmFieldType.INTEGER_SET -> {
+//                                    assertEquals(
+//                                        expectedLongSet.size,
+//                                        syncAllTypes.columnLongSet.size
+//                                    )
+//                                    expectedLongSet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnLongSet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.BOOLEAN_SET -> {
+//                                    assertEquals(
+//                                        expectedBooleanSet.size,
+//                                        syncAllTypes.columnBooleanSet.size
+//                                    )
+//                                    expectedBooleanSet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnBooleanSet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.STRING_SET -> {
+//                                    assertEquals(
+//                                        expectedStringSet.size,
+//                                        syncAllTypes.columnStringSet.size
+//                                    )
+//                                    expectedStringSet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnStringSet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.BINARY_SET -> {
+//                                    assertEquals(
+//                                        expectedBinarySet.size,
+//                                        syncAllTypes.columnBinarySet.size
+//                                    )
+//                                    expectedBinarySet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnBinarySet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.DATE_SET -> {
+//                                    assertEquals(
+//                                        expectedDateSet.size,
+//                                        syncAllTypes.columnDateSet.size
+//                                    )
+//                                    expectedDateSet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnDateSet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.DOUBLE_SET -> {
+//                                    assertEquals(
+//                                        expectedDoubleSet.size,
+//                                        syncAllTypes.columnDoubleSet.size
+//                                    )
+//                                    expectedDoubleSet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnDoubleSet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.DECIMAL128_SET -> {
+//                                    assertEquals(
+//                                        expectedDecimal128Set.size,
+//                                        syncAllTypes.columnDecimal128Set.size
+//                                    )
+//                                    expectedDecimal128Set.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnDecimal128Set.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.OBJECT_ID_SET -> {
+//                                    assertEquals(
+//                                        expectedObjectIdSet.size,
+//                                        syncAllTypes.columnObjectIdSet.size
+//                                    )
+//                                    expectedObjectIdSet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnObjectIdSet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.UUID_SET -> {
+//                                    assertEquals(
+//                                        expectedUUIDSet.size,
+//                                        syncAllTypes.columnUUIDSet.size
+//                                    )
+//                                    expectedUUIDSet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnUUIDSet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.MIXED_SET -> {
+//                                    assertEquals(
+//                                        expectedRealmAnySet.size,
+//                                        syncAllTypes.columnRealmAnySet.size
+//                                    )
+//                                    expectedRealmAnySet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnRealmAnySet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.LINK_SET -> {
+//                                    assertEquals(
+//                                        expectedRealmSet.size,
+//                                        syncAllTypes.columnRealmSet.size
+//                                    )
+//                                    expectedRealmSet.forEach { value ->
+//                                        assertTrue(syncAllTypes.columnRealmSet.contains(value))
+//                                    }
+//                                }
+//                                RealmFieldType.LINKING_OBJECTS -> assertEquals(
+//                                    primaryKeyValue,
+//                                    syncAllTypes.columnRealmObject!!.syncAllTypes!!.first()!!.id
+//                                )
+//                                RealmFieldType.TYPED_LINK,          // Not an actual exposed type, it is used internally by RealmAny
+//                                RealmFieldType.FLOAT,               // Float is not cloud compatible yet
+//                                RealmFieldType.FLOAT_LIST,          // Float is not cloud compatible yet
+//                                RealmFieldType.STRING_TO_FLOAT_MAP  // Float is not cloud compatible yet
+//                                -> {
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
+}

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.collect
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 const val DEFAULT_PARTITION_VALUE = "default"
@@ -106,11 +107,10 @@ class SyncConfigTests {
             }
 
             val childResult = channel.receive()
-            println("------ child received: ${childResult._id}, ${childResult.name}")
+            assertEquals("CHILD_A", childResult._id)
             observer.cancel()
             channel.close()
         }
-        println("------ done")
     }
 
 //    @Test

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
@@ -27,13 +27,14 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertNotNull
+import kotlin.test.assertEquals
 
 const val DEFAULT_PARTITION_VALUE = "default"
+const val DEFAULT_NAME = "test.realm"
 
 class SyncConfigTests {
 
-    lateinit var app: App
+    private lateinit var app: App
 
     @BeforeTest
     fun setup() {
@@ -47,7 +48,7 @@ class SyncConfigTests {
         }
     }
 
-    private fun createNewUser(): User {
+    private fun createTestUser(): User {
         app.asTestApp.createUser("asdf@asdf.com", "asdfasdf")
         return runBlocking {
             app.login(Credentials.anonymous()).getOrThrow()
@@ -56,930 +57,582 @@ class SyncConfigTests {
 
     private fun createSyncConfig(
         user: User,
-        partitionValue: String = DEFAULT_PARTITION_VALUE
+        partitionValue: String = DEFAULT_PARTITION_VALUE,
+        path: String? = null,
+        name: String = DEFAULT_NAME
     ): SyncConfiguration = SyncConfiguration.Builder(
+        path = path,
+        name = name,
         schema = setOf(Sample::class),
         user = user,
         partitionValue = partitionValue
     ).build()
 
-    @Test
-    fun syncConfig() {
-        val user = createNewUser()
-        val config = SyncConfiguration.Builder(
-            schema = setOf(Sample::class),
-            partitionValue = "ASDF",
-            user = user
-        ).build()
+//    @Test
+//    fun errorHandler() {
+//        val builder: SyncConfiguration.Builder = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//        val errorHandler: SyncSession.ErrorHandler = object : SyncSession.ErrorHandler {
+//            override fun onError(session: SyncSession, error: AppException) {}
+//        }
+//        val config = builder.errorHandler(errorHandler).build()
+//        assertEquals(errorHandler, config.errorHandler)
+//    }
+//
+//    @Test
+//    fun errorHandler_fromAppConfiguration() {
+//        val user: User = createTestUser(app)
+//        val config: SyncConfiguration = SyncConfiguration.defaultConfig(user, DEFAULT_PARTITION)
+//        assertEquals(app.configuration.defaultErrorHandler, config.errorHandler)
+//    }
+//
+//    @Test
+//    fun errorHandler_nullThrows() {
+//        val user: User = createTestUser(app)
+//        val builder = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+//        assertFailsWith<IllegalArgumentException> { builder.errorHandler(TestHelper.getNull()) }
+//    }
+//
+//    @Test
+//    fun clientResetHandler() {
+//        val builder: SyncConfiguration.Builder = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//        val handler = object : SyncSession.ClientResetHandler {
+//            override fun onClientReset(session: SyncSession, error: ClientResetRequiredError) {}
+//        }
+//        val config = builder.clientResetHandler(handler).build()
+//        assertEquals(handler, config.clientResetHandler)
+//    }
+//
+//    @Test
+//    fun clientResetHandler_fromAppConfiguration() {
+//        val user: User = createTestUser(app)
+//        val config: SyncConfiguration = SyncConfiguration.defaultConfig(user, DEFAULT_PARTITION)
+//        assertEquals(app.configuration.defaultClientResetHandler, config.clientResetHandler)
+//    }
+//
+//    @Test
+//    fun clientResetHandler_nullThrows() {
+//        val user: User = createTestUser(app)
+//        val builder = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+//        assertFailsWith<IllegalArgumentException> { builder.clientResetHandler(TestHelper.getNull()) }
+//    }
+//
+//    @Test
+//    fun equals() {
+//        val user = createTestUser()
+//        val config = SyncConfiguration.Builder(user = user, partitionValue = DEFAULT_PARTITION_VALUE)
+//            .build()
+//        assertEquals(config, config)
+//    }
+//
+//    @Test
+//    fun equals_same() {
+//        val user = createTestUser()
+//        val config1 = SyncConfiguration.Builder(user = user, partitionValue = DEFAULT_PARTITION_VALUE)
+//            .build()
+//        val config2 = SyncConfiguration.Builder(user = user, partitionValue = DEFAULT_PARTITION_VALUE)
+//            .build()
+//        assertEquals(config1, config2)
+//    }
+//
+//    @Test
+//    // FIXME Tests are not exhaustive
+//    fun equals_not() {
+//        val user1: User = createTestUser(app)
+//        val user2: User = createTestUser(app)
+//        val config1: SyncConfiguration = SyncConfiguration.Builder(user1, DEFAULT_PARTITION).build()
+//        val config2: SyncConfiguration = SyncConfiguration.Builder(user2, DEFAULT_PARTITION).build()
+//        assertFalse(config1 == config2)
+//    }
+//
+//    @Test
+//    fun hashCode_equal() {
+//        val user: User = createTestUser(app)
+//        val config: SyncConfiguration = SyncConfiguration.defaultConfig(user, DEFAULT_PARTITION)
+//        assertEquals(config.hashCode(), config.hashCode())
+//    }
+//
+//    @Test
+//    fun hashCode_notEquals() {
+//        val user1: User = createTestUser(app)
+//        val user2: User = createTestUser(app)
+//        val config1: SyncConfiguration = SyncConfiguration.defaultConfig(user1, DEFAULT_PARTITION)
+//        val config2: SyncConfiguration = SyncConfiguration.defaultConfig(user2, DEFAULT_PARTITION)
+//        assertNotEquals(config1.hashCode(), config2.hashCode())
+//    }
+//
 
-        assertNotNull(config)
+    @Test
+    fun equals_syncSpecificFields() {
+        val user = createTestUser()
+        val config = createSyncConfig(user = user, name = DEFAULT_NAME)
+        assertEquals(config.name, DEFAULT_NAME)
+        assertEquals(config.partitionValue.asString(), DEFAULT_PARTITION_VALUE)
     }
 
-//    // Smoke test for Sync. Waiting for working Sync support.
 //    @Test
-//    fun connectWithInitialSchema() {
-//        val user: User = createNewUser()
-//        val config = createSyncConfig(user)
-//        val realm: Realm = Realm.open(config)
-//        realm.writeBlocking {
-//            with(realm.syncSession) {
-//                uploadAllLocalChanges()
-//                downloadAllServerChanges()
-//            }
-//            assertTrue(isEmpty)
-//        }
-//    }
-//
-//    // Smoke test for Sync
-//    @Test
-//    fun roundTripObjectsNotInServerSchemaObject() {
-//        // User 1 creates an object an uploads it to MongoDB Realm
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createCustomConfig(user1, partitionValue)
-//        Realm.getInstance(config1).use { realm ->
-//            realm.executeTransaction {
-//                for (i in 1..10) {
-//                    it.insert(SyncColor())
-//                }
-//            }
-//            realm.syncSession.uploadAllLocalChanges()
-//            assertEquals(10, realm.where<SyncColor>().count())
-//        }
-//
-//        // User 2 logs and using the same partition key should see the object
-//        val user2: User = createNewUser()
-//        val config2 = createCustomConfig(user2, partitionValue)
-//        Realm.getInstance(config2).use { realm ->
-//            realm.syncSession.downloadAllServerChanges()
-//            realm.refresh()
-//            assertEquals(10, realm.where<SyncColor>().count())
-//        }
-//    }
-//
-//    // Smoke test for sync
-//    // Insert different types with no links between them
-//    @Test
-//    fun roundTripSimpleObjectsInServerSchema() {
-//        // User 1 creates an object an uploads it to MongoDB Realm
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
-//        Realm.getInstance(config1).use { realm ->
-//            realm.executeTransaction {
-//                val person = SyncPerson()
-//                person.firstName = "Jane"
-//                person.lastName = "Doe"
-//                person.age = 42
-//                realm.insert(person);
-//                for (i in 0..9) {
-//                    val dog = SyncDog()
-//                    dog.name = "Fido $i"
-//                    it.insert(dog)
-//                }
-//            }
-//            realm.syncSession.uploadAllLocalChanges()
-//            assertEquals(10, realm.where<SyncDog>().count())
-//            assertEquals(1, realm.where<SyncPerson>().count())
-//        }
-//
-//        // User 2 logs and using the same partition key should see the object
-//        val user2: User = createNewUser()
-//        val config2 = createSyncConfig(user2, partitionValue)
-//        Realm.getInstance(config2).use { realm ->
-//            realm.syncSession.downloadAllServerChanges()
-//            realm.refresh()
-//            assertEquals(10, realm.where<SyncDog>().count())
-//            assertEquals(1, realm.where<SyncPerson>().count())
-//        }
-//    }
-//
-//    // Smoke test for sync
-//    // Insert objects with links between them
-//    @Test
-//    fun roundTripObjectsWithLists() {
-//        // User 1 creates an object an uploads it to MongoDB Realm
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
-//        Realm.deleteRealm(config1)
-//        Realm.getInstance(config1).use { realm ->
-//            realm.executeTransaction {
-//                val person = SyncPerson()
-//                person.firstName = "Jane"
-//                person.lastName = "Doe"
-//                person.age = 42
-//                for (i in 0..9) {
-//                    val dog = SyncDog()
-//                    dog.name = "Fido $i"
-//                    person.dogs.add(dog)
-//                }
-//                realm.insert(person)
-//            }
-//            realm.syncSession.uploadAllLocalChanges()
-//            assertEquals(10, realm.where<SyncDog>().count())
-//            assertEquals(1, realm.where<SyncPerson>().count())
-//        }
-//
-//        // User 2 logs and using the same partition key should see the object
-//        val user2: User = createNewUser()
-//        val config2 = createSyncConfig(user2, partitionValue)
-//        Realm.deleteRealm(config2)
-//        Realm.getInstance(config2).use { realm ->
-//            realm.syncSession.downloadAllServerChanges()
-//            realm.refresh()
-//            assertEquals(10, realm.where<SyncDog>().count())
-//            assertEquals(1, realm.where<SyncPerson>().count())
-//        }
-//    }
-//
-//    @Test
-//    fun session() {
-//        val user: User = app.login(Credentials.anonymous())
-//        Realm.getInstance(createSyncConfig(user)).use { realm ->
-//            assertNotNull(realm.syncSession)
-//            assertEquals(SyncSession.State.ACTIVE, realm.syncSession.state)
-//            assertEquals(user, realm.syncSession.user)
-//        }
-//    }
-//
-//    @Test
-//    fun nullPartition() {
-//        val config = configFactory.createSyncConfigurationBuilder(createNewUser(), BsonNull())
-//            .modules(DefaultSyncSchema())
+//    fun name() {
+//        val user: User = createTestUser(app)
+//        val filename = "my-file-name.realm"
+//        val config: SyncConfiguration = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+//            .name(filename)
 //            .build()
-//        assertTrue(config.path.endsWith("null.realm"))
-//        Realm.getInstance(config).use { realm ->
-//            realm.syncSession.uploadAllLocalChanges() // Ensures that we can actually connect
-//        }
+//        val suffix = "/mongodb-realm/${user.app.configuration.appId}/${user.id}/$filename"
+//        assertTrue(config.path.endsWith(suffix))
 //    }
 //
 //    @Test
-//    @Ignore("FIXME Flaky, seems like Realm.compactRealm(config) sometimes returns false")
-//    fun compactRealm_populatedRealm() {
-//        val config = configFactory.createSyncConfigurationBuilder(createNewUser()).build()
-//        Realm.getInstance(config).use { realm ->
-//            realm.executeTransaction { r: Realm ->
-//                for (i in 0..9) {
-//                    r.insert(AllJavaTypes(i.toLong()))
+//    fun name_illegalValuesThrows() {
+//        val user: User = createTestUser(app)
+//        val builder = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+//
+//        assertFailsWith<IllegalArgumentException> { builder.name(TestHelper.getNull()) }
+//        assertFailsWith<IllegalArgumentException> { builder.name(".realm") }
+//    }
+//
+//    @Test
+//    fun encryption() {
+//        val user: User = createTestUser(app)
+//        val config: SyncConfiguration = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+//            .encryptionKey(TestHelper.getRandomKey())
+//            .build()
+//        assertNotNull(config.encryptionKey)
+//    }
+//
+//    @Test
+//    fun encryption_invalid_null() {
+//        val user: User = createTestUser(app)
+//        val builder = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+//        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(TestHelper.getNull()) }
+//    }
+//
+//    @Test
+//    fun encryption_invalid_wrong_length() {
+//        val user: User = createTestUser(app)
+//        val builder = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+//        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(byteArrayOf(1, 2, 3)) }
+//    }
+//
+//    @Test
+//    fun initialData() {
+//        val user: User = createTestUser(app)
+//        val config = configFactory.createSyncConfigurationBuilder(user)
+//            .schema(SyncStringOnly::class.java)
+//            .initialData(object : Realm.Transaction {
+//                override fun execute(realm: Realm) {
+//                    val stringOnly: SyncStringOnly = realm.createObject(ObjectId())
+//                    stringOnly.chars = "TEST 42"
 //                }
-//            }
-//        }
-//        assertTrue(Realm.compactRealm(config))
+//            })
+//            .build()
+//        assertNotNull(config.initialDataTransaction)
 //
+//        // open the first time - initialData must be triggered
 //        Realm.getInstance(config).use { realm ->
-//            assertEquals(10, realm.where(AllJavaTypes::class.java).count())
+//            val results: RealmResults<SyncStringOnly> = realm.where<SyncStringOnly>().findAll()
+//            assertEquals(1, results.size)
+//            assertEquals("TEST 42", results.first()!!.chars)
+//        }
+//
+//        // open the second time - initialData must not be triggered
+//        Realm.getInstance(config).use { realm ->
+//            assertEquals(1, realm.where<SyncStringOnly>().count())
 //        }
 //    }
 //
 //    @Test
-//    fun compactOnLaunch_shouldCompact() {
-//        val user = createTestUser(app)
+//    fun defaultRxFactory() {
+//        val user: User = createTestUser(app)
+//        val config: SyncConfiguration = SyncConfiguration.defaultConfig(user, DEFAULT_PARTITION)
+//        assertNotNull(config.rxFactory)
+//    }
 //
-//        // Fill Realm with data and record size
-//        val config1 = configFactory.createSyncConfigurationBuilder(user)
-//            .testSchema(SyncByteArray::class.java)
+//    @Test
+//    fun toString_nonEmpty() {
+//        val user: User = createTestUser(app)
+//        val config: SyncConfiguration = SyncConfiguration.defaultConfig(user, DEFAULT_PARTITION)
+//        val configStr = config.toString()
+//        assertTrue(configStr.isNotEmpty())
+//    }
+//
+//    // Check that it is possible for multiple users to reference the same Realm URL while each user still use their
+//    // own copy on the filesystem. This is e.g. what happens if a Realm is shared using a PermissionOffer.
+//    @Test
+//    fun multipleUsersReferenceSameRealm() {
+//        val user1: User = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
+//        val user2: User = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
+//
+//        val config1: SyncConfiguration = SyncConfiguration.Builder(user1, DEFAULT_PARTITION)
+//            .modules(SyncStringOnlyModule())
+//            .build()
+//        val config2: SyncConfiguration = SyncConfiguration.Builder(user2, DEFAULT_PARTITION)
+//            .modules(SyncStringOnlyModule())
 //            .build()
 //
-//        var originalSize: Long? = null
-//        Realm.getInstance(config1).use { realm ->
-//            val oneMBData = ByteArray(1024 * 1024)
-//            realm.executeTransaction {
-//                for (i in 0..9) {
-//                    realm.createObject(SyncByteArray::class.java, ObjectId()).columnBinary =
-//                        oneMBData
-//                }
-//            }
-//            originalSize = File(realm.path).length()
-//        }
+//        // Verify that two different configurations can be used for the same URL
+//        val realm1: Realm = Realm.getInstance(config1)
+//        val realm2: Realm = Realm.getInstance(config2)
+//        assertNotEquals(realm1, realm2)
 //
-//        // Open Realm with CompactOnLaunch
-//        val config2 = configFactory.createSyncConfigurationBuilder(user)
-//            .compactOnLaunch { totalBytes, usedBytes -> true }
-//            .testSchema(SyncByteArray::class.java)
+//        realm1.close()
+//        realm2.close()
+//
+//        // Verify that we actually save two different files
+//        assertNotEquals(config1.path, config2.path)
+//    }
+//
+//    @Test
+//    fun defaultConfiguration_throwsIfNotLoggedIn() {
+//        // TODO Maybe we could avoid registering a real user
+//        val user = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
+//        user.logOut()
+//        assertFailsWith<IllegalArgumentException> { SyncConfiguration.defaultConfig(user, DEFAULT_PARTITION) }
+//    }
+//
+//    @Test
+//    @Ignore("Not implemented yet")
+//    fun shouldWaitForInitialRemoteData() {
+//    }
+//
+//    @Test
+//    @Ignore("Not implemented yet")
+//    fun getInitialRemoteDataTimeout() {
+//    }
+//
+//    @Test
+//    @Ignore("Not implemented yet")
+//    fun getSessionStopPolicy() {
+//    }
+//
+//    @Test
+//    @Ignore("Not implemented yet")
+//    fun getUrlPrefix() {
+//    }
+//
+//    @Test
+//    fun getPartitionValue() {
+//        val user: User = createTestUser(app)
+//        val config: SyncConfiguration = SyncConfiguration.defaultConfig(user, DEFAULT_PARTITION)
+//        assertEquals(BsonString(DEFAULT_PARTITION), config.partitionValue)
+//    }
+//
+//    @Test
+//    fun clientResyncMode() {
+//        val user: User = createTestUser(app)
+//
+//        // Default mode for full Realms
+//        var config: SyncConfiguration = SyncConfiguration.defaultConfig(user, DEFAULT_PARTITION)
+//        assertEquals(ClientResyncMode.MANUAL, config.clientResyncMode)
+//
+//        // Manually set the mode
+//        config = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+//            .clientResyncMode(ClientResyncMode.DISCARD_LOCAL_REALM)
 //            .build()
-//        Realm.getInstance(config2).use { realm ->
-//            val compactedSize = File(realm.path).length()
-//            assertTrue(originalSize!! > compactedSize)
-//        }
+//        assertEquals(ClientResyncMode.DISCARD_LOCAL_REALM, config.clientResyncMode)
 //    }
 //
 //    @Test
-//    fun embeddedObject_roundTrip() {
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
-//        val primaryKeyValue = UUID.randomUUID().toString()
-//        Realm.getInstance(config1).use { realm ->
-//            assertTrue(realm.isEmpty)
-//
-//            realm.executeTransaction {
-//                realm.createObject<EmbeddedSimpleParent>(primaryKeyValue).let { parent ->
-//                    realm.createEmbeddedObject<EmbeddedSimpleChild>(parent, "child")
-//                }
-//            }
-//            realm.syncSession.uploadAllLocalChanges()
-//
-//            assertEquals(1, realm.where<EmbeddedSimpleParent>().count())
-//            assertEquals(1, realm.where<EmbeddedSimpleChild>().count())
-//        }
-//
-//        val user2: User = createNewUser()
-//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
-//        Realm.getInstance(config2).use { realm ->
-//            realm.syncSession.downloadAllServerChanges(5, TimeUnit.SECONDS).let {
-//                if (!it) fail()
-//            }
-//            realm.refresh()
-//
-//            val childResults = realm.where<EmbeddedSimpleChild>()
-//            assertEquals(1, childResults.count())
-//            val parentResults = realm.where<EmbeddedSimpleParent>()
-//            assertEquals(1, parentResults.count())
-//            val parent = parentResults.findFirst()!!
-//            assertEquals(primaryKeyValue, parent._id)
-//            assertEquals(parent._id, parent.child!!.parent._id)
-//        }
-//    }
-//
-//    // FIXME: remove ignore when sync issue fixed
-//    @Test
-//    @Ignore("ignored until https://jira.mongodb.org/browse/REALMC-6541 is fixed")
-//    fun embeddedObject_copyUnmanaged_roundTrip() {
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
-//        val primaryKeyValue = UUID.randomUUID().toString()
-//
-//        Realm.getInstance(config1).use { realm ->
-//            assertTrue(realm.isEmpty)
-//
-//            realm.executeTransaction {
-//                val parent = EmbeddedSimpleParent(primaryKeyValue)
-//
-////                parent.child = EmbeddedSimpleChild()
-//                val managedParent = it.copyToRealmOrUpdate(parent)
-//                // FIXME: instantiating the child in managedParent yields this from sync:
-//                //  "MongoDB error: Updating the path 'child.childID' would create a conflict at 'child'"
-//                managedParent.child = EmbeddedSimpleChild() // Will copy the object to Realm
-//            }
-//            realm.syncSession.uploadAllLocalChanges()
-//
-//            assertEquals(1, realm.where<EmbeddedSimpleParent>().count())
-//            assertEquals(1, realm.where<EmbeddedSimpleChild>().count())
-//        }
-//
-//        val user2: User = createNewUser()
-//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
-//        Realm.getInstance(config2).use { realm ->
-//            realm.syncSession.downloadAllServerChanges(5, TimeUnit.SECONDS).let {
-//                if (!it) fail()
-//            }
-//            realm.refresh()
-//
-//            val childResults = realm.where<EmbeddedSimpleChild>()
-//            assertEquals(1, childResults.count())
-//            val parentResults = realm.where<EmbeddedSimpleParent>()
-//            assertEquals(1, parentResults.count())
-//            val parent = parentResults.findFirst()!!
-//            assertEquals(primaryKeyValue, parent._id)
-//            assertEquals(parent._id, parent.child!!.parent._id)
-//        }
-//    }
-//
-//    @Test
-//    fun embeddedObject_realmList_roundTrip() {
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
-//        val primaryKeyValue = UUID.randomUUID().toString()
-//        Realm.getInstance(config1).use { realm ->
-//            realm.executeTransaction {
-//                realm.createObject(EmbeddedSimpleListParent::class.java, primaryKeyValue)
-//                    .let { parent ->
-//                        realm.createEmbeddedObject(
-//                            EmbeddedSimpleChild::class.java,
-//                            parent,
-//                            "children"
-//                        )
-//                        realm.createEmbeddedObject(
-//                            EmbeddedSimpleChild::class.java,
-//                            parent,
-//                            "children"
-//                        )
-//                    }
-//            }
-//            realm.syncSession.uploadAllLocalChanges()
-//
-//            assertEquals(1, realm.where<EmbeddedSimpleListParent>().count())
-//            assertEquals(2, realm.where<EmbeddedSimpleChild>().count())
-//        }
-//
-//        val user2: User = createNewUser()
-//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
-//        Realm.getInstance(config2).use { realm ->
-//            assertEquals(0, realm.where<EmbeddedSimpleListParent>().count())
-//            assertEquals(0, realm.where<EmbeddedSimpleChild>().count())
-//
-//            realm.syncSession.downloadAllServerChanges(5, TimeUnit.SECONDS).let {
-//                if (!it) fail()
-//            }
-//            realm.refresh()
-//
-//            val childResults = realm.where<EmbeddedSimpleChild>()
-//            assertEquals(2, childResults.count())
-//            val parentResults = realm.where<EmbeddedSimpleListParent>()
-//            assertEquals(1, parentResults.count())
-//            val parentFromResults = parentResults.findFirst()!!
-//            assertEquals(primaryKeyValue, parentFromResults._id)
-//
-//            parentFromResults.children.also { childrenInParent ->
-//                val childrenFromResults = childResults.findAll()
-//                childrenInParent.forEach { childInParent ->
-//                    assertTrue(childrenFromResults.contains(childInParent))
-//                }
-//            }
-//        }
-//    }
-//
-//    @Test
-//    fun embeddedObject_realmList_copyUnmanaged_roundTrip() {
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
-//        val primaryKeyValue = UUID.randomUUID().toString()
-//        Realm.getInstance(config1).use { realm ->
-//            realm.executeTransaction {
-//                val parent = EmbeddedSimpleListParent(primaryKeyValue)
-//                parent.children =
-//                    RealmList(EmbeddedSimpleChild("child1"), EmbeddedSimpleChild("child2"))
-//                realm.insert(parent)
-//            }
-//            realm.syncSession.uploadAllLocalChanges()
-//
-//            assertEquals(1, realm.where<EmbeddedSimpleListParent>().count())
-//            assertEquals(2, realm.where<EmbeddedSimpleChild>().count())
-//        }
-//
-//        val user2: User = createNewUser()
-//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
-//        Realm.getInstance(config2).use { realm ->
-//            assertEquals(0, realm.where<EmbeddedSimpleListParent>().count())
-//            assertEquals(0, realm.where<EmbeddedSimpleChild>().count())
-//
-//            realm.syncSession.downloadAllServerChanges(1, TimeUnit.SECONDS).let {
-//                if (!it) fail()
-//            }
-//            realm.refresh()
-//
-//            val childResults = realm.where<EmbeddedSimpleChild>()
-//            assertEquals(2, childResults.count())
-//            val parentResults = realm.where<EmbeddedSimpleListParent>()
-//            assertEquals(1, parentResults.count())
-//            val parentFromResults = parentResults.findFirst()!!
-//            assertEquals(primaryKeyValue, parentFromResults._id)
-//            assertEquals("child1", childResults.findAll()[0]!!.childId)
-//            assertEquals("child2", childResults.findAll()[1]!!.childId)
-//        }
-//    }
-//
-//    // FIXME: remember to add tree structure classes to DefaultSyncSchema.kt
-//    @Test
-//    @Ignore("Enable when https://jira.mongodb.org/projects/HELP/queues/issue/HELP-17759 is fixed")
-//    fun copyToRealm_treeSchema() {
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
-//        val primaryKeyValue = UUID.randomUUID().toString()
-//
-//        Realm.getInstance(config1).use { realm ->
-//            realm.executeTransaction {
-//                val parent = EmbeddedTreeParent("parent1")
-//
-//                val node1 = EmbeddedTreeNode("node1")
-//                node1.leafNode = EmbeddedTreeLeaf("leaf1")
-//                parent.middleNode = node1
-//                val node2 = EmbeddedTreeNode("node2")
-//                node2.leafNodeList.add(EmbeddedTreeLeaf("leaf2"))
-//                node2.leafNodeList.add(EmbeddedTreeLeaf("leaf3"))
-//                parent.middleNodeList.add(node2)
-//
-//                it.copyToRealm(parent)
-//            }
-//            realm.syncSession.uploadAllLocalChanges()
-//        }
-//
-//        val user2: User = createNewUser()
-//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
-//        Realm.getInstance(config2).use { realm ->
-//            assertEquals(0, realm.where<EmbeddedSimpleListParent>().count())
-//            assertEquals(0, realm.where<EmbeddedSimpleChild>().count())
-//
-//            realm.syncSession.downloadAllServerChanges(1, TimeUnit.SECONDS).let {
-//                if (!it) fail()
-//            }
-//            realm.refresh()
-//
-//            Assert.assertEquals(1, realm.where<EmbeddedTreeParent>().count())
-//            Assert.assertEquals("parent1", realm.where<EmbeddedTreeParent>().findFirst()!!._id)
-//
-//            Assert.assertEquals(2, realm.where<EmbeddedTreeNode>().count())
-//            val nodeResults = realm.where<EmbeddedTreeNode>().findAll()
-//            Assert.assertTrue(nodeResults.any { it.treeNodeId == "node1" })
-//            Assert.assertTrue(nodeResults.any { it.treeNodeId == "node2" })
-//
-//            Assert.assertEquals(3, realm.where<EmbeddedTreeLeaf>().count())
-//            val leafResults = realm.where<EmbeddedTreeLeaf>().findAll()
-//            Assert.assertTrue(leafResults.any { it.treeLeafId == "leaf1" })
-//            Assert.assertTrue(leafResults.any { it.treeLeafId == "leaf2" })
-//            Assert.assertTrue(leafResults.any { it.treeLeafId == "leaf3" })
-//        }
-//    }
-//
-//    // Check that we can create multiple apps that synchronize with each other
-//    @Test
-//    fun multipleAppsCanSync() {
-//        val app2 = TestApp(appName = TEST_APP_2)
-//        var realm1: Realm? = null
-//        var realm2: Realm? = null
+//    fun clientResyncMode_throwsOnNull() {
+//        val user: User = createTestUser(app)
+//        val config: SyncConfiguration.Builder = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
 //        try {
-//            // Login users on both Realms
-//            val app1User = app.login(Credentials.anonymous())
-//            val app2User = app2.login(Credentials.anonymous())
-//            Assert.assertNotEquals(app1User, app2User)
+//            config.clientResyncMode(TestHelper.getNull())
+//            fail()
+//        } catch (ignore: IllegalArgumentException) {
+//        }
+//    }
 //
-//            // Create one Realm against each app
-//            val config1 = configFactory.createSyncConfigurationBuilder(app1User, BsonString("foo"))
-//                .modules(DefaultSyncSchema())
-//                .build()
-//            val config2 = configFactory.createSyncConfigurationBuilder(app2User, BsonString("foo"))
-//                .modules(DefaultSyncSchema())
-//                .build()
+//    // If the same user create two configurations with different partition values they must
+//    // resolve to different paths on disk.
+//    @Test
+//    fun differentPartitionValuesAreDifferentRealms() {
+//        val user: User = createTestUser(app)
+//        val config1 = SyncConfiguration.Builder(user, "realm1").modules(SyncStringOnlyModule()).build()
+//        val config2 = SyncConfiguration.Builder(user, "realm2").modules(SyncStringOnlyModule()).build()
+//        assertNotEquals(config1.path, config2.path)
 //
-//            // Make sure we can synchronize changes
-//            realm1 = Realm.getInstance(config1)
-//            realm2 = Realm.getInstance(config2)
-//            realm1.syncSession.downloadAllServerChanges()
-//            realm2.syncSession.downloadAllServerChanges()
-//            Assert.assertTrue(realm1.isEmpty)
-//            Assert.assertTrue(realm2.isEmpty)
+//        assertTrue(config1.path.endsWith("${app.configuration.appId}/${user.id}/s_realm1.realm"))
+//        assertTrue(config2.path.endsWith("${app.configuration.appId}/${user.id}/s_realm2.realm"))
+//
+//        // Check for https://github.com/realm/realm-java/issues/6882
+//        val realm1 = Realm.getInstance(config1)
+//        try {
+//            val realm2 = Realm.getInstance(config2)
+//            realm2.close()
 //        } finally {
-//            realm1?.close()
-//            realm2?.close()
-//            app2.close()
+//            realm1.close()
 //        }
 //    }
 //
 //    @Test
-//    fun allTypes_roundTrip() {
-//        val expectedRealmAnyValues = arrayListOf(
-//            RealmAny.valueOf(1.toLong()),
-//            RealmAny.valueOf(false),
-//            RealmAny.valueOf(10.5.toFloat()),
-//            RealmAny.valueOf(10.5.toDouble()),
-//            RealmAny.valueOf("hello world 2"),
-//            RealmAny.valueOf(Date(105)),
-//            RealmAny.valueOf(Decimal128(102)),
-//            RealmAny.valueOf(ObjectId()),
-//            RealmAny.valueOf(UUID.randomUUID())
+//    fun nullPartitionValue() {
+//        val user: User = createTestUser(app)
+//
+//        val configs = listOf<SyncConfiguration>(
+//            SyncConfiguration.defaultConfig(user, null as String?),
+//            SyncConfiguration.defaultConfig(user, null as Int?),
+//            SyncConfiguration.defaultConfig(user, null as Long?),
+//            SyncConfiguration.defaultConfig(user, null as ObjectId?),
+//            SyncConfiguration.Builder(user, null as String?).build(),
+//            SyncConfiguration.Builder(user, null as Int?).build(),
+//            SyncConfiguration.Builder(user, null as Long?).build(),
+//            SyncConfiguration.Builder(user, null as ObjectId?).build()
 //        )
 //
-//        val primaryKeyValue = ObjectId()
-//        val expectedRealmInteger = 100.toLong()
-//        val expectedString = "hello world"
-//        val expectedLong = 10.toLong()
-//        val expectedDouble = 10.0
-//        val expectedFloat = 10.0.toFloat()
-//        val expectedBoolean = true
-//        val expectedDate = Date()
-//        val expectedBinary = byteArrayOf(0, 1, 0)
-//        val expectedDecimal128 = Decimal128(10)
-//        val expectedObjectId = ObjectId()
-//        val expectedUUID = UUID.randomUUID()
-//        var expectedRealmObject = SyncDog().apply {
-//            id = expectedObjectId
+//        configs.forEach { config ->
+//            assertTrue(config.path.endsWith("/null.realm"))
 //        }
-//        val expectedRealmList = RealmList<SyncDog>()
-//        val expectedStringList = RealmList<String>("hello world 1", "hello world 2")
-//        val expectedBinaryList = RealmList<ByteArray>(expectedBinary)
-//        val expectedBooleanList = RealmList<Boolean>(true, false, false, true)
-//        val expectedLongList = RealmList<Long>(0, 1, 2, 5, 7)
-//        val expectedDoubleList = RealmList<Double>(0.0, 2.toDouble(), 10.5)
-//        val expectedFloatList = RealmList<Float>(0.0.toFloat(), 2.toFloat(), 10.5.toFloat())
-//        val expectedDateList = RealmList<Date>(Date(100), Date(10), Date(200))
-//        val expectedDecimal128List =
-//            RealmList<Decimal128>(Decimal128(10), Decimal128(100), Decimal128(20))
-//        val expectedObjectIdList = RealmList<ObjectId>(
-//            ObjectId(Date(1000)), ObjectId(Date(100)), ObjectId(
-//                Date(2000)
-//            )
-//        )
-//        val expectedUUIDList = RealmList<UUID>(UUID.randomUUID())
-//        val expectedRealmAnyList = RealmList<RealmAny>()
-//        expectedRealmAnyList.addAll(expectedRealmAnyValues)
+//    }
 //
-//        val expectedRealmDict = RealmDictionary<SyncDog>()
-//        val expectedStringDict = RealmDictionary<String>().init(listOf("key" to expectedString))
-//        val expectedBinaryDict = RealmDictionary<ByteArray>().init(listOf("key" to expectedBinary))
-//        val expectedBooleanDict = RealmDictionary<Boolean>().init(listOf("key" to expectedBoolean))
-//        val expectedLongDict = RealmDictionary<Long>().init(listOf("key" to expectedLong))
-//        val expectedDoubleDict = RealmDictionary<Double>().init(listOf("key" to expectedDouble))
-//        val expectedFloatDict = RealmDictionary<Float>().init(listOf("key" to expectedFloat))
-//        val expectedDateDict = RealmDictionary<Date>().init(listOf("key" to expectedDate))
-//        val expectedDecimal128Dict =
-//            RealmDictionary<Decimal128>().init(listOf("key" to expectedDecimal128))
-//        val expectedObjectIdDict =
-//            RealmDictionary<ObjectId>().init(listOf("key" to expectedObjectId))
-//        val expectedUUIDDict = RealmDictionary<UUID>().init(listOf("key" to expectedUUID))
-//        val expectedRealmAnyDict = RealmDictionary<RealmAny>()
+//    @Test
+//    fun loggedOutUsersThrows() {
+//        val user: User = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
+//        user.logOut()
+//        assertFailsWith<java.lang.IllegalArgumentException> {
+//            SyncConfiguration.defaultConfig(user, ObjectId())
+//        }
+//        assertFailsWith<java.lang.IllegalArgumentException> {
+//            SyncConfiguration.defaultConfig(app.currentUser(), ObjectId())
+//        }
+//    }
 //
-//        val expectedRealmSet = RealmSet<SyncDog>()
-//        val expectedStringSet = RealmSet<String>().init(listOf(expectedString))
-//        val expectedBinarySet = RealmSet<ByteArray>().init(listOf(expectedBinary))
-//        val expectedBooleanSet = RealmSet<Boolean>().init(listOf(expectedBoolean))
-//        val expectedLongSet = RealmSet<Long>().init(listOf(expectedLong))
-//        val expectedDoubleSet = RealmSet<Double>().init(listOf(expectedDouble))
-//        val expectedFloatSet = RealmSet<Float>().init(listOf(expectedFloat))
-//        val expectedDateSet = RealmSet<Date>().init(listOf(expectedDate))
-//        val expectedDecimal128Set = RealmSet<Decimal128>().init(listOf(expectedDecimal128))
-//        val expectedObjectIdSet = RealmSet<ObjectId>().init(listOf(expectedObjectId))
-//        val expectedUUIDSet = RealmSet<UUID>().init(listOf(expectedUUID))
-//        val expectedRealmAnySet = RealmSet<RealmAny>()
+//    @Test
+//    fun allowQueriesOnUiThread_defaultsToTrue() {
+//        val builder: SyncConfiguration.Builder = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//        val configuration = builder.build()
+//        assertTrue(configuration.isAllowQueriesOnUiThread)
+//    }
 //
-//        val user1: User = createNewUser()
-//        val config1: SyncConfiguration = createSyncConfig(user1, partitionValue)
+//    @Test
+//    fun allowQueriesOnUiThread_explicitFalse() {
+//        val builder: SyncConfiguration.Builder = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//        val configuration = builder.allowQueriesOnUiThread(false)
+//            .build()
+//        assertFalse(configuration.isAllowQueriesOnUiThread)
+//    }
 //
-//        val user2: User = createNewUser()
-//        val config2: SyncConfiguration = createSyncConfig(user2, partitionValue)
+//    @Test
+//    fun allowQueriesOnUiThread_explicitTrue() {
+//        val builder: SyncConfiguration.Builder = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//        val configuration = builder.allowQueriesOnUiThread(true)
+//            .build()
+//        assertTrue(configuration.isAllowQueriesOnUiThread)
+//    }
 //
-//        Realm.getInstance(config1).use { realm1 ->
-//            Realm.getInstance(config2).use { realm2 ->
-//                for (expectedRealmAny in expectedRealmAnyValues) {
-//                    realm1.executeTransaction {
-//                        expectedRealmObject = realm1.copyToRealmOrUpdate(expectedRealmObject)
-//                        expectedRealmList.add(expectedRealmObject)
-//                        expectedRealmDict["key"] = expectedRealmObject
+//    @Test
+//    fun allowWritesOnUiThread_defaultsToFalse() {
+//        val builder: SyncConfiguration.Builder = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//        val configuration = builder.build()
+//        assertFalse(configuration.isAllowWritesOnUiThread)
+//    }
 //
-//                        // Populate object to round-trip
-//                        val syncObject = SyncAllTypes().apply {
-//                            id = primaryKeyValue
+//    @Test
+//    fun allowWritesOnUiThread_explicitFalse() {
+//        val builder: SyncConfiguration.Builder = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//        val configuration = builder.allowWritesOnUiThread(false)
+//            .build()
+//        assertFalse(configuration.isAllowWritesOnUiThread)
+//    }
 //
-//                            RealmFieldType.values().map { realmFieldType ->
-//                                when (realmFieldType) {
-//                                    RealmFieldType.INTEGER -> {
-//                                        columnLong = expectedLong
-//                                        // MutableRealmInteger
-//                                        columnRealmInteger.set(expectedRealmInteger)
-//                                    }
-//                                    RealmFieldType.BOOLEAN -> isColumnBoolean = expectedBoolean
-//                                    RealmFieldType.STRING -> columnString = expectedString
-//                                    RealmFieldType.BINARY -> columnBinary = expectedBinary
-//                                    RealmFieldType.DATE -> columnDate = expectedDate
-//                                    RealmFieldType.DOUBLE -> columnDouble = expectedDouble
-//                                    RealmFieldType.FLOAT -> columnFloat = expectedFloat
-//                                    RealmFieldType.OBJECT -> columnRealmObject = expectedRealmObject
-//                                    RealmFieldType.DECIMAL128 -> columnDecimal128 =
-//                                        expectedDecimal128
-//                                    RealmFieldType.OBJECT_ID -> columnObjectId = expectedObjectId
-//                                    RealmFieldType.UUID -> columnUUID = expectedUUID
-//                                    RealmFieldType.MIXED -> columnRealmAny = expectedRealmAny
-//                                    RealmFieldType.LIST -> columnRealmList = expectedRealmList
-//                                    RealmFieldType.INTEGER_LIST -> columnLongList = expectedLongList
-//                                    RealmFieldType.BOOLEAN_LIST -> columnBooleanList =
-//                                        expectedBooleanList
-//                                    RealmFieldType.STRING_LIST -> columnStringList =
-//                                        expectedStringList
-//                                    RealmFieldType.BINARY_LIST -> columnBinaryList =
-//                                        expectedBinaryList
-//                                    RealmFieldType.DATE_LIST -> columnDateList = expectedDateList
-//                                    RealmFieldType.DOUBLE_LIST -> columnDoubleList =
-//                                        expectedDoubleList
-//                                    RealmFieldType.FLOAT_LIST -> columnFloatList = expectedFloatList
-//                                    RealmFieldType.DECIMAL128_LIST -> columnDecimal128List =
-//                                        expectedDecimal128List
-//                                    RealmFieldType.OBJECT_ID_LIST -> columnObjectIdList =
-//                                        expectedObjectIdList
-//                                    RealmFieldType.UUID_LIST -> columnUUIDList = expectedUUIDList
-//                                    RealmFieldType.MIXED_LIST -> columnRealmAnyList =
-//                                        expectedRealmAnyList
-//                                    RealmFieldType.STRING_TO_INTEGER_MAP -> columnLongDictionary =
-//                                        expectedLongDict
-//                                    RealmFieldType.STRING_TO_BOOLEAN_MAP -> columnBooleanDictionary =
-//                                        expectedBooleanDict
-//                                    RealmFieldType.STRING_TO_STRING_MAP -> columnStringDictionary =
-//                                        expectedStringDict
-//                                    RealmFieldType.STRING_TO_BINARY_MAP -> columnBinaryDictionary =
-//                                        expectedBinaryDict
-//                                    RealmFieldType.STRING_TO_DATE_MAP -> columnDateDictionary =
-//                                        expectedDateDict
-//                                    RealmFieldType.STRING_TO_DOUBLE_MAP -> columnDoubleDictionary =
-//                                        expectedDoubleDict
-//                                    RealmFieldType.STRING_TO_FLOAT_MAP -> columnFloatDictionary =
-//                                        expectedFloatDict
-//                                    RealmFieldType.STRING_TO_DECIMAL128_MAP -> columnDecimal128Dictionary =
-//                                        expectedDecimal128Dict
-//                                    RealmFieldType.STRING_TO_OBJECT_ID_MAP -> columnObjectIdDictionary =
-//                                        expectedObjectIdDict
-//                                    RealmFieldType.STRING_TO_UUID_MAP -> columnUUIDDictionary =
-//                                        expectedUUIDDict
-//                                    RealmFieldType.STRING_TO_MIXED_MAP -> {
-//                                        expectedRealmAnyDict["key"] = expectedRealmAny
-//                                        columnRealmAnyDictionary = expectedRealmAnyDict
-//                                    }
-//                                    RealmFieldType.STRING_TO_LINK_MAP -> columnRealmDictionary =
-//                                        expectedRealmDict
-//                                    RealmFieldType.LINK_SET -> columnRealmSet = expectedRealmSet
-//                                    RealmFieldType.INTEGER_SET -> columnLongSet = expectedLongSet
-//                                    RealmFieldType.BOOLEAN_SET -> columnBooleanSet =
-//                                        expectedBooleanSet
-//                                    RealmFieldType.STRING_SET -> columnStringSet = expectedStringSet
-//                                    RealmFieldType.BINARY_SET -> columnBinarySet = expectedBinarySet
-//                                    RealmFieldType.DATE_SET -> columnDateSet = expectedDateSet
-//                                    RealmFieldType.DOUBLE_SET -> columnDoubleSet = expectedDoubleSet
-//                                    RealmFieldType.FLOAT_SET -> columnFloatSet = expectedFloatSet
-//                                    RealmFieldType.DECIMAL128_SET -> columnDecimal128Set =
-//                                        expectedDecimal128Set
-//                                    RealmFieldType.OBJECT_ID_SET -> columnObjectIdSet =
-//                                        expectedObjectIdSet
-//                                    RealmFieldType.UUID_SET -> columnUUIDSet = expectedUUIDSet
-//                                    RealmFieldType.MIXED_SET -> columnRealmAnySet =
-//                                        expectedRealmAnySet
-//                                    RealmFieldType.LINKING_OBJECTS,     // Nothing to set
-//                                    RealmFieldType.TYPED_LINK          // Not an actual exposed type, it is used internally by RealmAny
-//                                    -> {
-//                                    }
-//                                }
-//                            }
-//                        }
+//    @Test
+//    fun allowWritesOnUiThread_explicitTrue() {
+//        val builder: SyncConfiguration.Builder = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//        val configuration = builder.allowWritesOnUiThread(true)
+//            .build()
+//        assertTrue(configuration.isAllowWritesOnUiThread)
+//    }
 //
-//                        realm1.copyToRealmOrUpdate(syncObject)
-//                    }
-//                    realm1.syncSession.uploadAllLocalChanges()
+//    @Test
+//    fun rxFactory_defaultNonNull() {
+//        val configuration = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//            .build()
+//        assertNotNull(configuration.rxFactory)
+//    }
 //
-//                    assertEquals(1, realm1.where<SyncAllTypes>().count())
+//    @Test
+//    fun rxFactory_nullThrows() {
+//        assertFailsWith<IllegalArgumentException> {
+//            SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//                .rxFactory(TestHelper.getNull())
+//        }.let {
+//            assertTrue(it.message!!.contains("null"))
+//        }
+//    }
 //
-//                    realm2.syncSession.downloadAllServerChanges(
-//                        TestHelper.STANDARD_WAIT_SECS.toLong(),
-//                        TimeUnit.SECONDS
-//                    ).let {
-//                        if (!it) fail()
-//                    }
-//                    realm2.refresh()
+//    @Test
+//    fun rxFactory() {
+//        val factory = object: RxObservableFactory {
+//            override fun from(realm: Realm): Flowable<Realm> {
+//                return Flowable.just(null)
+//            }
 //
-//                    assertEquals(1, realm2.where<SyncAllTypes>().count())
+//            override fun from(realm: DynamicRealm): Flowable<DynamicRealm> {
+//                return Flowable.just(null)
+//            }
 //
-//                    // Validate that after a round-trip the values are the initial ones, the expected values
-//                    realm2.where<SyncAllTypes>().findFirst()!!.let { syncAllTypes ->
-//                        assertEquals(primaryKeyValue, syncAllTypes.id)
+//            override fun <E : Any?> from(realm: Realm, results: RealmResults<E>): Flowable<RealmResults<E>> {
+//                return Flowable.just(null)
+//            }
 //
-//                        RealmFieldType.values().map { realmFieldType ->
-//                            when (realmFieldType) {
-//                                RealmFieldType.INTEGER -> {
-//                                    assertEquals(expectedLong, syncAllTypes.columnLong)
-//                                    // MutableRealmInteger
-//                                    assertEquals(
-//                                        expectedRealmInteger,
-//                                        syncAllTypes.columnRealmInteger.get()
-//                                    )
-//                                }
-//                                RealmFieldType.BOOLEAN -> assertEquals(
-//                                    expectedBoolean,
-//                                    syncAllTypes.isColumnBoolean
-//                                )
-//                                RealmFieldType.STRING -> assertEquals(
-//                                    expectedString,
-//                                    syncAllTypes.columnString
-//                                )
-//                                RealmFieldType.BINARY -> assertTrue(
-//                                    expectedBinary.contentEquals(
-//                                        syncAllTypes.columnBinary
-//                                    )
-//                                )
-//                                RealmFieldType.DATE -> assertEquals(
-//                                    expectedDate,
-//                                    syncAllTypes.columnDate
-//                                )
-//                                RealmFieldType.DOUBLE -> assertEquals(
-//                                    expectedDouble,
-//                                    syncAllTypes.columnDouble
-//                                )
-//                                RealmFieldType.OBJECT -> assertEquals(
-//                                    expectedObjectId,
-//                                    syncAllTypes.columnRealmObject!!.id
-//                                )
-//                                RealmFieldType.DECIMAL128 -> assertEquals(
-//                                    expectedDecimal128,
-//                                    syncAllTypes.columnDecimal128
-//                                )
-//                                RealmFieldType.OBJECT_ID -> assertEquals(
-//                                    expectedObjectId,
-//                                    syncAllTypes.columnObjectId
-//                                )
-//                                RealmFieldType.UUID -> assertEquals(
-//                                    expectedUUID,
-//                                    syncAllTypes.columnUUID
-//                                )
-//                                RealmFieldType.MIXED -> assertEquals(
-//                                    expectedRealmAny,
-//                                    syncAllTypes.columnRealmAny
-//                                )
-//                                RealmFieldType.LIST -> assertEquals(
-//                                    expectedObjectId,
-//                                    syncAllTypes.columnRealmList.first()!!.id
-//                                )
-//                                RealmFieldType.INTEGER_LIST -> assertEquals(
-//                                    expectedLongList,
-//                                    syncAllTypes.columnLongList
-//                                )
-//                                RealmFieldType.BOOLEAN_LIST -> assertEquals(
-//                                    expectedBooleanList,
-//                                    syncAllTypes.columnBooleanList
-//                                )
-//                                RealmFieldType.STRING_LIST -> assertEquals(
-//                                    expectedStringList,
-//                                    syncAllTypes.columnStringList
-//                                )
-//                                RealmFieldType.BINARY_LIST -> {
-//                                    expectedBinaryList.forEachIndexed { index, bytes ->
-//                                        Arrays.equals(bytes, syncAllTypes.columnBinaryList[index])
-//                                    }
-//                                }
-//                                RealmFieldType.DATE_LIST -> assertEquals(
-//                                    expectedDateList,
-//                                    syncAllTypes.columnDateList
-//                                )
-//                                RealmFieldType.DOUBLE_LIST -> assertEquals(
-//                                    expectedDoubleList,
-//                                    syncAllTypes.columnDoubleList
-//                                )
-//                                RealmFieldType.DECIMAL128_LIST -> assertEquals(
-//                                    expectedDecimal128List,
-//                                    syncAllTypes.columnDecimal128List
-//                                )
-//                                RealmFieldType.OBJECT_ID_LIST -> assertEquals(
-//                                    expectedObjectIdList,
-//                                    syncAllTypes.columnObjectIdList
-//                                )
-//                                RealmFieldType.UUID_LIST -> assertEquals(
-//                                    expectedUUIDList,
-//                                    syncAllTypes.columnUUIDList
-//                                )
-//                                RealmFieldType.MIXED_LIST -> assertEquals(
-//                                    expectedRealmAnyList,
-//                                    syncAllTypes.columnRealmAnyList
-//                                )
-//                                RealmFieldType.STRING_TO_INTEGER_MAP -> assertEquals(
-//                                    expectedLong,
-//                                    syncAllTypes.columnLongDictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_BOOLEAN_MAP -> assertEquals(
-//                                    expectedBoolean,
-//                                    syncAllTypes.columnBooleanDictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_STRING_MAP -> assertEquals(
-//                                    expectedString,
-//                                    syncAllTypes.columnStringDictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_BINARY_MAP -> assertTrue(
-//                                    Arrays.equals(
-//                                        expectedBinary,
-//                                        syncAllTypes.columnBinaryDictionary["key"]
-//                                    )
-//                                )
-//                                RealmFieldType.STRING_TO_DATE_MAP -> assertEquals(
-//                                    expectedDate,
-//                                    syncAllTypes.columnDateDictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_DOUBLE_MAP -> assertEquals(
-//                                    expectedDouble,
-//                                    syncAllTypes.columnDoubleDictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_DECIMAL128_MAP -> assertEquals(
-//                                    expectedDecimal128,
-//                                    syncAllTypes.columnDecimal128Dictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_OBJECT_ID_MAP -> assertEquals(
-//                                    expectedObjectId,
-//                                    syncAllTypes.columnObjectIdDictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_UUID_MAP -> assertEquals(
-//                                    expectedUUID,
-//                                    syncAllTypes.columnUUIDDictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_MIXED_MAP -> assertEquals(
-//                                    expectedRealmAny,
-//                                    syncAllTypes.columnRealmAnyDictionary["key"]
-//                                )
-//                                RealmFieldType.STRING_TO_LINK_MAP -> assertEquals(
-//                                    expectedObjectId,
-//                                    syncAllTypes.columnRealmDictionary["key"]!!.id
-//                                )
-//                                RealmFieldType.INTEGER_SET -> {
-//                                    assertEquals(
-//                                        expectedLongSet.size,
-//                                        syncAllTypes.columnLongSet.size
-//                                    )
-//                                    expectedLongSet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnLongSet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.BOOLEAN_SET -> {
-//                                    assertEquals(
-//                                        expectedBooleanSet.size,
-//                                        syncAllTypes.columnBooleanSet.size
-//                                    )
-//                                    expectedBooleanSet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnBooleanSet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.STRING_SET -> {
-//                                    assertEquals(
-//                                        expectedStringSet.size,
-//                                        syncAllTypes.columnStringSet.size
-//                                    )
-//                                    expectedStringSet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnStringSet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.BINARY_SET -> {
-//                                    assertEquals(
-//                                        expectedBinarySet.size,
-//                                        syncAllTypes.columnBinarySet.size
-//                                    )
-//                                    expectedBinarySet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnBinarySet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.DATE_SET -> {
-//                                    assertEquals(
-//                                        expectedDateSet.size,
-//                                        syncAllTypes.columnDateSet.size
-//                                    )
-//                                    expectedDateSet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnDateSet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.DOUBLE_SET -> {
-//                                    assertEquals(
-//                                        expectedDoubleSet.size,
-//                                        syncAllTypes.columnDoubleSet.size
-//                                    )
-//                                    expectedDoubleSet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnDoubleSet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.DECIMAL128_SET -> {
-//                                    assertEquals(
-//                                        expectedDecimal128Set.size,
-//                                        syncAllTypes.columnDecimal128Set.size
-//                                    )
-//                                    expectedDecimal128Set.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnDecimal128Set.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.OBJECT_ID_SET -> {
-//                                    assertEquals(
-//                                        expectedObjectIdSet.size,
-//                                        syncAllTypes.columnObjectIdSet.size
-//                                    )
-//                                    expectedObjectIdSet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnObjectIdSet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.UUID_SET -> {
-//                                    assertEquals(
-//                                        expectedUUIDSet.size,
-//                                        syncAllTypes.columnUUIDSet.size
-//                                    )
-//                                    expectedUUIDSet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnUUIDSet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.MIXED_SET -> {
-//                                    assertEquals(
-//                                        expectedRealmAnySet.size,
-//                                        syncAllTypes.columnRealmAnySet.size
-//                                    )
-//                                    expectedRealmAnySet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnRealmAnySet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.LINK_SET -> {
-//                                    assertEquals(
-//                                        expectedRealmSet.size,
-//                                        syncAllTypes.columnRealmSet.size
-//                                    )
-//                                    expectedRealmSet.forEach { value ->
-//                                        assertTrue(syncAllTypes.columnRealmSet.contains(value))
-//                                    }
-//                                }
-//                                RealmFieldType.LINKING_OBJECTS -> assertEquals(
-//                                    primaryKeyValue,
-//                                    syncAllTypes.columnRealmObject!!.syncAllTypes!!.first()!!.id
-//                                )
-//                                RealmFieldType.TYPED_LINK,          // Not an actual exposed type, it is used internally by RealmAny
-//                                RealmFieldType.FLOAT,               // Float is not cloud compatible yet
-//                                RealmFieldType.FLOAT_LIST,          // Float is not cloud compatible yet
-//                                RealmFieldType.STRING_TO_FLOAT_MAP  // Float is not cloud compatible yet
-//                                -> {
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
+//            override fun <E : Any?> from(realm: DynamicRealm, results: RealmResults<E>): Flowable<RealmResults<E>> {
+//                return Flowable.just(null)
+//            }
+//
+//            override fun <E : Any?> from(realm: Realm, list: RealmList<E>): Flowable<RealmList<E>> {
+//                return Flowable.just(null)
+//            }
+//
+//            override fun <E : Any?> from(realm: DynamicRealm, list: RealmList<E>): Flowable<RealmList<E>> {
+//                return Flowable.just(null)
+//            }
+//
+//            override fun <E : RealmModel?> from(realm: Realm, `object`: E): Flowable<E> {
+//                return Flowable.just(null)
+//            }
+//
+//            override fun from(realm: DynamicRealm, `object`: DynamicRealmObject): Flowable<DynamicRealmObject> {
+//                return Flowable.just(null)
+//            }
+//
+//            override fun <E : Any?> from(realm: Realm, query: RealmQuery<E>): Single<RealmQuery<E>> {
+//                return Single.just(null)
+//            }
+//
+//            override fun <E : Any?> from(realm: DynamicRealm, query: RealmQuery<E>): Single<RealmQuery<E>> {
+//                return Single.just(null)
+//            }
+//
+//            override fun <E : Any?> changesetsFrom(realm: Realm, results: RealmResults<E>): Observable<CollectionChange<RealmResults<E>>> {
+//                return Observable.just(null)
+//            }
+//
+//            override fun <E : Any?> changesetsFrom(realm: DynamicRealm, results: RealmResults<E>): Observable<CollectionChange<RealmResults<E>>> {
+//                return Observable.just(null)
+//            }
+//
+//            override fun <E : Any?> changesetsFrom(realm: Realm, list: RealmList<E>): Observable<CollectionChange<RealmList<E>>> {
+//                return Observable.just(null)
+//            }
+//
+//            override fun <E : Any?> changesetsFrom(realm: DynamicRealm, list: RealmList<E>): Observable<CollectionChange<RealmList<E>>> {
+//                return Observable.just(null)
+//            }
+//
+//            override fun <E : RealmModel?> changesetsFrom(realm: Realm, `object`: E): Observable<ObjectChange<E>> {
+//                return Observable.just(null)
+//            }
+//
+//            override fun changesetsFrom(realm: DynamicRealm, `object`: DynamicRealmObject): Observable<ObjectChange<DynamicRealmObject>> {
+//                return Observable.just(null)
+//            }
+//
+//        }
+//
+//        val configuration1 = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//            .rxFactory(factory)
+//            .build()
+//        assertEquals(factory, configuration1.rxFactory)
+//
+//        val configuration2 = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//            .build()
+//        assertNotEquals(factory, configuration2.rxFactory)
+//    }
+//
+//    @Test
+//    fun flowFactory_defaultNonNull() {
+//        val configuration = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//            .build()
+//        assertNotNull(configuration.flowFactory)
+//    }
+//
+//    @Test
+//    fun flowFactory_nullThrows() {
+//        assertFailsWith<IllegalArgumentException> {
+//            SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//                .flowFactory(TestHelper.getNull())
+//        }.let {
+//            assertTrue(it.message!!.contains("null"))
+//        }
+//    }
+//
+//    @Test
+//    fun flowFactory() {
+//        val factory = object : FlowFactory {
+//            override fun from(realm: Realm): Flow<Realm> {
+//                return flowOf()
+//            }
+//
+//            override fun from(dynamicRealm: DynamicRealm): Flow<DynamicRealm> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : Any?> from(realm: Realm, results: RealmResults<T>): Flow<RealmResults<T>> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : Any?> from(dynamicRealm: DynamicRealm, results: RealmResults<T>): Flow<RealmResults<T>> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : Any?> from(realm: Realm, realmList: RealmList<T>): Flow<RealmList<T>> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : Any?> from(dynamicRealm: DynamicRealm, realmList: RealmList<T>): Flow<RealmList<T>> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : RealmModel?> from(realm: Realm, realmObject: T): Flow<T> {
+//                return flowOf()
+//            }
+//
+//            override fun from(dynamicRealm: DynamicRealm, dynamicRealmObject: DynamicRealmObject): Flow<DynamicRealmObject> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : Any?> changesetFrom(realm: Realm, results: RealmResults<T>): Flow<CollectionChange<RealmResults<T>>> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : Any?> changesetFrom(dynamicRealm: DynamicRealm, results: RealmResults<T>): Flow<CollectionChange<RealmResults<T>>> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : Any?> changesetFrom(realm: Realm, list: RealmList<T>): Flow<CollectionChange<RealmList<T>>> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : Any?> changesetFrom(dynamicRealm: DynamicRealm, list: RealmList<T>): Flow<CollectionChange<RealmList<T>>> {
+//                return flowOf()
+//            }
+//
+//            override fun <T : RealmModel?> changesetFrom(realm: Realm, realmObject: T): Flow<ObjectChange<T>> {
+//                return flowOf()
+//            }
+//
+//            override fun changesetFrom(dynamicRealm: DynamicRealm, dynamicRealmObject: DynamicRealmObject): Flow<ObjectChange<DynamicRealmObject>> {
+//                return flowOf()
 //            }
 //        }
+//
+//        val configuration1 = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//            .flowFactory(factory)
+//            .build()
+//        assertEquals(factory, configuration1.flowFactory)
+//
+//        val configuration2 = SyncConfiguration.Builder(createTestUser(app), DEFAULT_PARTITION)
+//            .build()
+//        assertNotEquals(factory, configuration2.flowFactory)
+//    }
+
+//    @Test
+//    fun syncConfig() {
+//        val user = createNewUser()
+//        val config = createSyncConfig(user)
+//        assertNotNull(config)
+//    }
+//
+//    @Test
+//    fun canOpen() {
+//        realm = Realm.open(syncConfiguration)
 //    }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
@@ -19,14 +19,15 @@ import io.realm.Realm
 import io.realm.VersionId
 import io.realm.entities.link.Child
 import io.realm.entities.link.Parent
+import io.realm.internal.platform.runBlocking
 import io.realm.mongodb.App
 import io.realm.mongodb.Credentials
 import io.realm.mongodb.SyncConfiguration
 import io.realm.test.mongodb.TestApp
 import io.realm.test.mongodb.asTestApp
 import io.realm.test.platform.PlatformUtils
+import io.realm.test.util.TestHelper.randomEmail
 import io.realm.test.util.Utils.createRandomString
-import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -51,9 +52,10 @@ class SyncedRealmTests {
         app = TestApp()
 
         // Create test user through REST admin api until we have EmailPasswordAuth.registerUser in place
-        app.asTestApp.createUser("asdf@asdf.com", "asdfasdf")
+        val (email, password) = randomEmail() to "asdfasdf"
+        app.asTestApp.createUser(email, password)
         val user = runBlocking {
-            app.login(Credentials.emailPassword("asdf@asdf.com", "asdfasdf"))
+            app.login(Credentials.emailPassword(email, password))
         }
 
         tmpDir = PlatformUtils.createTempDir()
@@ -67,7 +69,7 @@ class SyncedRealmTests {
 
     @AfterTest
     fun tearDown() {
-         if (this::app.isInitialized) {
+        if (this::app.isInitialized) {
             app.asTestApp.close()
         }
         if (!realm.isClosed()) {

--- a/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
@@ -78,7 +79,7 @@ class SyncedRealmTests {
     @Test
     fun canOpen() {
         realm = Realm.open(syncConfiguration)
-        val khasd = 0
+        assertNotNull(realm)
     }
 
 //    @Test

--- a/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.test.shared
+
+import io.realm.Realm
+import io.realm.VersionId
+import io.realm.entities.link.Child
+import io.realm.entities.link.Parent
+import io.realm.mongodb.App
+import io.realm.mongodb.Credentials
+import io.realm.mongodb.SyncConfiguration
+import io.realm.test.mongodb.TestApp
+import io.realm.test.mongodb.asTestApp
+import io.realm.test.platform.PlatformUtils
+import io.realm.test.util.Utils.createRandomString
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+class SyncedRealmTests {
+
+    companion object {
+        // Initial version of any new typed Realm (due to schema being written)
+        private val INITIAL_VERSION = VersionId(2)
+    }
+
+    private lateinit var tmpDir: String
+    private lateinit var realm: Realm
+    private lateinit var syncConfiguration: SyncConfiguration
+    private lateinit var app: App
+
+    @BeforeTest
+    fun setup() {
+        app = TestApp()
+
+        // Create test user through REST admin api until we have EmailPasswordAuth.registerUser in place
+        app.asTestApp.createUser("asdf@asdf.com", "asdfasdf")
+        val user = runBlocking {
+            app.login(Credentials.emailPassword("asdf@asdf.com", "asdfasdf")).getOrThrow()
+        }
+
+        tmpDir = PlatformUtils.createTempDir()
+        syncConfiguration = SyncConfiguration.Builder(
+            path = "$tmpDir/${createRandomString(16)}.realm",
+            schema = setOf(Parent::class, Child::class),
+            partitionValue = "default",
+            user = user
+        ).build()
+    }
+
+    @AfterTest
+    fun tearDown() {
+         if (this::app.isInitialized) {
+            app.asTestApp.close()
+        }
+        if (!realm.isClosed()) {
+            realm.close()
+        }
+        PlatformUtils.deleteTempDir(tmpDir)
+    }
+
+    @Test
+    fun canOpen() {
+        realm = Realm.open(syncConfiguration)
+        val khasd = 0
+    }
+
+//    @Test
+//    fun initialVersion() {
+//        assertEquals(INITIAL_VERSION, realm.version())
+//    }
+//
+//    @Test
+//    fun versionIncreaseOnWrite() {
+//        assertEquals(INITIAL_VERSION, realm.version())
+//        realm.writeBlocking { /* Do Nothing */ }
+//        assertEquals(VersionId(3), realm.version())
+//    }
+//
+//    @Test
+//    fun versionDoesNotChangeWhenCancellingWrite() {
+//        assertEquals(INITIAL_VERSION, realm.version())
+//        realm.writeBlocking { cancelWrite() }
+//        assertEquals(INITIAL_VERSION, realm.version())
+//    }
+//
+//    @Test
+//    fun versionThrowsIfRealmIsClosed() {
+//        realm.close()
+//        assertFailsWith<IllegalStateException> { realm.version() }
+//    }
+//
+//    @Test
+//    fun versionInsideWriteIsLatest() {
+//        assertEquals(INITIAL_VERSION, realm.version())
+//        realm.writeBlocking {
+//            assertEquals(INITIAL_VERSION, version())
+//            cancelWrite()
+//        }
+//        assertEquals(INITIAL_VERSION, realm.version())
+//    }
+//
+//    @Test
+//    fun numberOfActiveVersions() {
+//        assertEquals(2, realm.getNumberOfActiveVersions())
+//        realm.writeBlocking {
+//            assertEquals(2, getNumberOfActiveVersions())
+//        }
+//        assertEquals(2, realm.getNumberOfActiveVersions())
+//    }
+//
+//    @Test
+//    @Ignore // FIXME This fails on MacOS only. Are versions cleaned up more aggressively there?
+//    fun throwsIfMaxNumberOfActiveVersionsAreExceeded() {
+//        realm.close()
+//        val config = RealmConfiguration.Builder(
+//            path = "$tmpDir/exceed-versions.realm",
+//            schema = setOf(Parent::class, Child::class)
+//        ).maxNumberOfActiveVersions(1).build()
+//        realm = Realm.open(config)
+//        // Pin the version, so when starting a new transaction on the first Realm,
+//        // we don't release older versions.
+//        val otherRealm = Realm.open(config)
+//
+//        try {
+//            assertFailsWith<IllegalStateException> { realm.writeBlocking { } }
+//        } finally {
+//            otherRealm.close()
+//        }
+//    }
+//
+//    @Suppress("invisible_member")
+//    @Test
+//    fun write() = runBlocking {
+//        val name = "Realm"
+//        val child: Child = realm.write {
+//            this.copyToRealm(Child()).apply { this.name = name }
+//        }
+//        assertEquals(name, child.name)
+//        val objects = realm.objects<Child>()
+//        val childFromResult = objects[0]
+//        assertEquals(name, childFromResult.name)
+//    }
+//
+//    @Suppress("invisible_member")
+//    @Test
+//    fun exceptionInWriteWillRollback() = runBlocking {
+//        class CustomException : Exception()
+//
+//        assertFailsWith<CustomException> {
+//            realm.write {
+//                val name = "Realm"
+//                this.copyToRealm(Child()).apply { this.name = name }
+//                throw CustomException()
+//            }
+//        }
+//        assertEquals(0, realm.objects<Child>().size)
+//    }
+//
+//    @Test
+//    fun writeBlocking() {
+//        val managedChild = realm.writeBlocking { copyToRealm(Child().apply { name = "John" }) }
+//        assertTrue(managedChild.isManaged())
+//        assertEquals("John", managedChild.name)
+//    }
+//
+//    @Suppress("invisible_member")
+//    @Test
+//    fun writeBlockingAfterWrite() = runBlocking {
+//        val name = "Realm"
+//        val child: Child = realm.write {
+//            this.copyToRealm(Child()).apply { this.name = name }
+//        }
+//        assertEquals(name, child.name)
+//        assertEquals(1, realm.objects<Child>().size)
+//
+//        realm.writeBlocking {
+//            this.copyToRealm(Child()).apply { this.name = name }
+//        }
+//        Unit
+//    }
+//
+//    @Suppress("invisible_member")
+//    @Test
+//    fun exceptionInWriteBlockingWillRollback() {
+//        class CustomException : Exception()
+//        assertFailsWith<CustomException> {
+//            realm.writeBlocking {
+//                val name = "Realm"
+//                this.copyToRealm(Child()).apply { this.name = name }
+//                throw CustomException()
+//            }
+//        }
+//        assertEquals(0, realm.objects<Child>().size)
+//    }
+//
+//    @Test
+//    @Suppress("invisible_member")
+//    fun simultaneousWritesAreAllExecuted() = runBlocking {
+//        val jobs: List<Job> = IntRange(0, 9).map {
+//            launch {
+//                realm.write {
+//                    copyToRealm(Parent())
+//                }
+//            }
+//        }
+//        jobs.map { it.join() }
+//
+//        // Ensure that all writes are actually committed
+//        realm.close()
+//        assertTrue(realm.isClosed())
+//        realm = Realm.open(configuration)
+//        assertEquals(10, realm.objects(Parent::class).size)
+//    }
+//
+//    @Test
+//    @Suppress("invisible_member")
+//    fun writeBlockingWhileWritingIsSerialized() = runBlocking {
+//        val writeStarted = Mutex(true)
+//        val writeEnding = Mutex(true)
+//        val writeBlockingQueued = Mutex(true)
+//        async {
+//            realm.write {
+//                writeStarted.unlock()
+//                while (writeBlockingQueued.isLocked) {
+//                    PlatformUtils.sleep(1.milliseconds)
+//                }
+//                writeEnding.unlock()
+//            }
+//        }
+//        writeStarted.lock()
+//        runBlocking {
+//            val async = async {
+//                realm.writeBlocking {
+//                    assertFalse { writeEnding.isLocked }
+//                }
+//            }
+//            writeBlockingQueued.unlock()
+//            async.await()
+//        }
+//    }
+//
+//    @Test
+//    @Suppress("invisible_member")
+//    fun close() = runBlocking {
+//        realm.write {
+//            copyToRealm(Parent())
+//        }
+//        realm.close()
+//        assertTrue(realm.isClosed())
+//
+//        realm = Realm.open(configuration)
+//        assertEquals(1, realm.objects(Parent::class).size)
+//    }
+//
+//    @Test
+//    @Suppress("invisible_member")
+//    fun closeCausesOngoingWriteToThrow() = runBlocking {
+//        val writeStarted = Mutex(true)
+//        val write = async {
+//            assertFailsWith<IllegalStateException> {
+//                realm.write {
+//                    writeStarted.unlock()
+//                    copyToRealm(Parent())
+//                    // realm.close is blocking until write block is done, so we cannot wait on
+//                    // specific external events, so just sleep a bit :/
+//                    PlatformUtils.sleep(Duration.Companion.milliseconds(100))
+//                }
+//            }
+//        }
+//        writeStarted.lock()
+//        realm.close()
+//        assert(write.await() is RuntimeException)
+//        realm = Realm.open(configuration)
+//        assertEquals(0, realm.objects<Parent>().size)
+//    }
+//
+//    @Test
+//    @Suppress("invisible_member")
+//    fun writeAfterCloseThrows() = runBlocking {
+//        realm.close()
+//        assertTrue(realm.isClosed())
+//        assertFailsWith<IllegalStateException> {
+//            realm.write {
+//                copyToRealm(Child())
+//            }
+//        }
+//        Unit
+//    }
+//
+//    @Test
+//    @Suppress("invisible_member")
+//    fun coroutineCancelCausesRollback() = runBlocking {
+//        val mutex = Mutex(true)
+//        val job = async {
+//            realm.write {
+//                copyToRealm(Parent())
+//                mutex.unlock()
+//                // Ensure that we keep on going until actually cancelled
+//                while (isActive) {
+//                    PlatformUtils.sleep(1.milliseconds)
+//                }
+//            }
+//        }
+//        mutex.lock()
+//        job.cancelAndJoin()
+//
+//        // Ensure that write is not committed
+//        realm.close()
+//        assertTrue(realm.isClosed())
+//        realm = Realm.open(configuration)
+//        // This assertion doesn't hold on MacOS as all code executes on the same thread as the
+//        // dispatcher is a run loop on the local thread, thus, the main flow is not picked up when
+//        // the mutex is unlocked. Doing so would require the write block to be able to suspend in
+//        // some way (or the writer to be backed by another thread).
+//        assertEquals(0, realm.objects(Parent::class).size)
+//    }
+//
+//    @Test
+//    @Suppress("invisible_member")
+//    fun writeAfterCoroutineCancel() = runBlocking {
+//        val mutex = Mutex(true)
+//        val job = async {
+//            realm.write {
+//                copyToRealm(Parent())
+//                mutex.unlock()
+//                // Ensure that we keep on going until actually cancelled
+//                while (isActive) {
+//                    PlatformUtils.sleep(1.milliseconds)
+//                }
+//            }
+//        }
+//
+//        mutex.lock()
+//        job.cancelAndJoin()
+//
+//        // Verify that we can do other writes after cancel
+//        realm.write {
+//            copyToRealm(Parent())
+//        }
+//
+//        // Ensure that only one write is actually committed
+//        realm.close()
+//        assertTrue(realm.isClosed())
+//        realm = Realm.open(configuration)
+//        // This assertion doesn't hold on MacOS as all code executes on the same thread as the
+//        // dispatcher is a run loop on the local thread, thus, the main flow is not picked up when
+//        // the mutex is unlocked. Doing so would require the write block to be able to suspend in
+//        // some way (or the writer to be backed by another thread).
+//        assertEquals(1, realm.objects(Parent::class).size)
+//    }
+//
+//    @Test
+//    @Suppress("invisible_member")
+//    fun writesOnFrozenRealm() {
+//        val dispatcher = newSingleThreadContext("background")
+//        runBlocking {
+//            realm.write {
+//                copyToRealm(Parent())
+//            }
+//        }
+//        runBlocking(dispatcher) {
+//            realm.write {
+//                copyToRealm(Parent())
+//            }
+//        }
+//        assertEquals(2, realm.objects<Parent>().size)
+//    }
+//
+//    @Test
+//    fun closeClosesAllVersions() {
+//        runBlocking {
+//            realm.write { copyToRealm(Parent()) }
+//        }
+//        val parent: Parent = realm.objects<Parent>().first()
+//        runBlocking {
+//            realm.write { copyToRealm(Parent()) }
+//        }
+//        realm.close()
+//        assertFailsWith<IllegalStateException> {
+//            parent.version()
+//        }
+//    }
+//
+//    @Test
+//    fun closingIntermediateVersionsWhenNoLongerReferenced() {
+//        assertEquals(0, intermediateReferences.value.size)
+//        var parent: Parent? = realm.writeBlocking { copyToRealm(Parent()) }
+//        assertEquals(1, intermediateReferences.value.size)
+//        realm.writeBlocking { }
+//        assertEquals(2, intermediateReferences.value.size)
+//
+//        // Clear reference
+//        parent = null
+//        // Trigger GC
+//        triggerGC()
+//        // Close of intermediate version is currently only done when updating the realm after a write
+//        realm.writeBlocking { }
+//        assertEquals(1, intermediateReferences.value.size)
+//    }
+//
+//    @Suppress("invisible_reference")
+//    private val intermediateReferences: AtomicRef<Set<Pair<NativePointer, WeakReference<io.realm.internal.RealmReference>>>>
+//        get() {
+//            @Suppress("invisible_member")
+//            return (realm as io.realm.internal.RealmImpl).intermediateReferences
+//        }
+}

--- a/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
@@ -52,7 +52,7 @@ class SyncedRealmTests {
         // Create test user through REST admin api until we have EmailPasswordAuth.registerUser in place
         app.asTestApp.createUser("asdf@asdf.com", "asdfasdf")
         val user = runBlocking {
-            app.login(Credentials.emailPassword("asdf@asdf.com", "asdfasdf")).getOrThrow()
+            app.login(Credentials.emailPassword("asdf@asdf.com", "asdfasdf"))
         }
 
         tmpDir = PlatformUtils.createTempDir()

--- a/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
@@ -18,7 +18,7 @@
 
 package io.realm.test.mongodb
 
-import io.ktor.client.request.*
+import io.ktor.client.request.get
 import io.realm.internal.platform.runBlocking
 import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.mongodb.App

--- a/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
@@ -18,7 +18,7 @@
 
 package io.realm.test.mongodb
 
-import io.ktor.client.request.get
+import io.ktor.client.request.*
 import io.realm.internal.platform.runBlocking
 import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.mongodb.App

--- a/test/sync/src/macosTest/kotlin/io/realm/test/shared
+++ b/test/sync/src/macosTest/kotlin/io/realm/test/shared
@@ -1,0 +1,1 @@
+/Users/eduardo.lopez/git/realm-kotlin/test/sync/src/androidTest/kotlin/io/realm/test/shared


### PR DESCRIPTION
Added `SyncConfiguration` and builder.
Abstracted `RealmConfiguration` so that "sync configs" are also "local configs".
Added `PartitionValue` container to mimic BsonValue until we have a viable multiplatform library for that.
Added `InternalRealmConfiguration` to avoid exposing certain properties to the public API.
A number of classes (e.g. `Mediator`) are not internal anymore due to `library-base` and `library-sync` being two different modules.

TODO:
- [ ] add jvm test support