### PR TITLE
Use correct ktor client on macos. 

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -82,7 +82,7 @@ object Versions {
     const val kotlinCompileTesting = "1.4.2" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlintPlugin = "10.1.0" // https://github.com/jlleitschuh/ktlint-gradle
     const val ktlintVersion = "0.41.0" // https://github.com/pinterest/ktlint
-    const val ktor = "1.6.0" // https://kotlinlang.org/docs/releases.html#release-details
+    const val ktor = "1.6.3" // https://kotlinlang.org/docs/releases.html#release-details
     const val nexusPublishPlugin = "1.1.0" // https://github.com/gradle-nexus/publish-plugin
     const val serialization = "1.2.1" // https://kotlinlang.org/docs/releases.html#release-details
     const val shadowJar =  "6.1.0" // https://mvnrepository.com/artifact/com.github.johnrengelman.shadow/com.github.johnrengelman.shadow.gradle.plugin?repo=gradle-plugins

--- a/packages/library-sync/build.gradle.kts
+++ b/packages/library-sync/build.gradle.kts
@@ -120,12 +120,7 @@ kotlin {
 
             // Observe this ktor dependency cannot be abstracted away with the ios ones
             dependencies {
-                // TODO According to https://ktor.io/docs/http-client-engines.html#desktop we should
-                //  use ktor-client-curl for desktop, but the KtorNetworkTransportTest fails with
-                //  a trace that looks like some operations are interleaved. Test works with CIO
-                //  even though it is only listed as an option for JVM/Android!?
-                // implementation("io.ktor:ktor-client-curl:${Versions.ktor}")
-                implementation("io.ktor:ktor-client-cio:${Versions.ktor}")
+                implementation("io.ktor:ktor-client-curl:${Versions.ktor}")
             }
         }
         getByName("iosArm64Main") {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/KtorNetworkTransport.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/KtorNetworkTransport.kt
@@ -55,7 +55,8 @@ class KtorNetworkTransport(
     private val dispatcher: CoroutineDispatcher,
 ) : NetworkTransport {
 
-    private val client: HttpClient = getClient()
+    // FIXME Figure out how to reuse the HttpClient across all network requests.
+    // private val client: HttpClient = getClient()
 
     @Suppress("ComplexMethod", "TooGenericExceptionCaught")
     override fun sendRequest(
@@ -66,6 +67,14 @@ class KtorNetworkTransport(
         usesRefreshToken: Boolean
     ): Response {
         try {
+            // FIXME When using a shared HttpClient we are seeing sporadic
+            //  network failures on macOS. They manifest as ClientRequestException
+            //  even though the request appear to be valid. This could indicate
+            //  that some state isn't cleaned up correctly between requests, but
+            //  it is unclear what. As a temporary work-around, we now create a
+            //  HttpClient pr. request.
+            val client = getClient()
+
             // FIXME Ensure background jobs does not block user/main thread
             //  https://github.com/realm/realm-kotlin/issues/450
             return runBlocking(dispatcher) {


### PR DESCRIPTION
As part of enabling the Sync demo, I discovered several problems. This PR fixes one of them: namely that using `cio` as network client doesn't work inside macOS apps. It did work inside our macOS tests for some reason, but when installing a shared module in a real macOS app, it resulted in `Duplicate symbols for architecture x86_64 under Xcode` during build time.

Moving to Curl however also has issues as there seems to be some problem with cleanup or a bug in Ktor. I have not yet found the root cause, but creating a new HttpClient for every request fixes the issues (but it adds significant overhead).

The latest Ktor is 1.6.4, but that doesn't work right now due to https://youtrack.jetbrains.com/issue/KTOR-3216, so I just bumped to latest working version.