### PR TITLE
Ignore nondeterministic native GC test

### DIFF
--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmTests.kt
@@ -398,6 +398,9 @@ class RealmTests {
     }
 
     @Test
+    // TODO Non deterministic.
+    //  https://github.com/realm/realm-kotlin/issues/486
+    @Ignore
     fun intermediateVersionsReleaseWhenProgressingRealm() {
         assertEquals(0, intermediateReferences.value.size)
         realm.writeBlocking { }


### PR DESCRIPTION
Failing test in https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-kotlin/detail/master/186/pipeline/ is actually a valid actual outcome as intermediate references could be cleared if the GC kicks in before doing the write, thus ignoring until we have a deterministic way of verifying clean up of versions. 