### PR TITLE
Collect logcat output from Android tests on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -483,7 +483,7 @@ def stopLogCatCollector(String backgroundPid, name) {
     // Zip file generation will fail if the file is already there 
     // Pipeline Utility Steps Plugin 2.6.1 introduces 'overwrite' property
     // https://issues.jenkins.io/browse/JENKINS-42591
-    sh "rm logcat-${name}.zip"
+    sh "rm -f logcat-${name}.zip"
     zip([
       'zipFile': "logcat-${name}.zip",
       'archive': true,


### PR DESCRIPTION
This adds collection of Android logcat output. 

Unittests and integrationtests are collected in separate files. Integration tests are currently not split into _base_ and _sync_ files, but infrastructure if we want to do that.

Closes #455 