### PR TITLE
Clean up old swig generated files if we need to rerun swig

### DIFF
--- a/packages/jni-swig-stub/build.gradle.kts
+++ b/packages/jni-swig-stub/build.gradle.kts
@@ -32,6 +32,8 @@ configure<JavaPluginConvention> {
 
 tasks.create("realmWrapperJvm") {
     doLast {
+        // If task is actually triggered (not up to date) then we should clean up the old stuff
+        deleteGeneratedFiles()
         exec {
             workingDir(".")
             commandLine("swig", "-java", "-c++", "-package", "io.realm.internal.interop", "-I$projectDir/../external/core/src", "-o", "$projectDir/src/main/jni/realmc.cpp", "-outdir", "$projectDir/src/main/java/io/realm/internal/interop", "realm.i")
@@ -69,19 +71,19 @@ publishing {
     }
 }
 
-tasks.create("cleanJvmWrapper") {
-    doLast {
-        delete(
-            fileTree("$projectDir/src/main/java/io/realm/internal/interop/").matching {
-                include("*.java")
-                exclude("LongPointerWrapper.java") // not generated
-            }
-        )
-        delete(file("$projectDir/src/main/jni/realmc.cpp"))
-        delete(file("$projectDir/src/main/jni/realmc.h"))
-    }
+fun deleteGeneratedFiles() {
+    delete(
+        fileTree("$projectDir/src/main/java/io/realm/internal/interop/").matching {
+            include("*.java")
+            exclude("LongPointerWrapper.java") // not generated
+        }
+    )
+    delete(file("$projectDir/src/main/jni/realmc.cpp"))
+    delete(file("$projectDir/src/main/jni/realmc.h"))
 }
 
 tasks.named("clean") {
-    dependsOn("cleanJvmWrapper")
+    doLast {
+        deleteGeneratedFiles()
+    }
 }


### PR DESCRIPTION
This fixes an issue of incremental compilation when headers/swig configuration has changed in a way that previously generated files are left around and pollutes new builds. 