### PR TITLE
Tmp Fix for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,8 @@ pipeline {
                           when { expression { shouldBuildJvmABIs() } }
                           agent {
                               node {
-                                  label 'windows'
+                                   // FIXME aws-windows-02 has issue with checking out the repo with symlinks
+                                  label 'aws-windows-01'
                               }
                           }
                           steps {


### PR DESCRIPTION
While investigating a work-around  for `aws-windows-02` and why symlink are fails the SCM checkout we should be able to build on `aws-windows-01`