### PR TITLE
update cmake files for Linux and Windows to include missing symbols

### DIFF
--- a/packages/cinterop/src/jvmMain/linux/CMakeLists.txt
+++ b/packages/cinterop/src/jvmMain/linux/CMakeLists.txt
@@ -19,6 +19,10 @@ include_directories("${CMAKE_BINARY_DIR}/src" "${JAVA_INCLUDE_PATH}" "${JAVA_INC
 file(GLOB jni_SRC
         "${CINTEROP_JNI}/env_utils.cpp"
         "${CINTEROP_JNI}/utils.cpp"
+        "${CINTEROP_JNI}/java_global_ref_by_move.cpp"
+        "${CINTEROP_JNI}/java_class_global_def.cpp"
+        "${CINTEROP_JNI}/java_class.cpp"
+        "${CINTEROP_JNI}/java_method.cpp"
         )
 
 file(GLOB swig_SRC

--- a/packages/cinterop/src/jvmMain/windows/CMakeLists.txt
+++ b/packages/cinterop/src/jvmMain/windows/CMakeLists.txt
@@ -20,6 +20,10 @@ include_directories("${CMAKE_BINARY_DIR}/src" "${JAVA_INCLUDE_PATH}" "${JAVA_INC
 file(GLOB jni_SRC
         "${CINTEROP_JNI}/env_utils.cpp"
         "${CINTEROP_JNI}/utils.cpp"
+        "${CINTEROP_JNI}/java_global_ref_by_move.cpp"
+        "${CINTEROP_JNI}/java_class_global_def.cpp"
+        "${CINTEROP_JNI}/java_class.cpp"
+        "${CINTEROP_JNI}/java_method.cpp"
         )
 
 file(GLOB swig_SRC


### PR DESCRIPTION
We should prioritise merging all 4 cmake files to avoid similar issue 