### PR TITLE
Fix InvalidMutabilityException for sync on iOS

### DIFF
--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
@@ -54,7 +54,7 @@ internal class AppConfigurationImpl(
                 this.log.debug(message)
             }
         }
-    )
+    ).freeze() // Kotlin network client needs to be frozen before passed to the C-API
 
     // Only freeze anything after all properties are setup as this triggers freezing the actual
     // AppConfigurationImpl instance itself


### PR DESCRIPTION
App configuration itself is frozen on iOS when referenced from anything that is passed to the ktor configuration builder. This creates a separate logger with identical configuration to overcome freezing the app configuration before it is fully build.