### PR TITLE
Separating generated swig code from manual code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,7 +284,7 @@ def genAndStashSwigJNI() {
         ../gradlew assemble
         """
     }
-    stash includes: 'packages/jni-swig-stub/src/main/jni/realmc.cpp,packages/jni-swig-stub/src/main/jni/realmc.h', name: 'swig_jni'
+    stash includes: 'packages/jni-swig-stub/build/generated/sources/jni/realmc.cpp,packages/jni-swig-stub/build/generated/sources/jni/realmc.h', name: 'swig_jni'
 }
 def runBuild() {
     def buildJvmAbiFlag = "-PcopyJvmABIs=false"

--- a/packages/cinterop/src/jvm/CMakeLists.txt
+++ b/packages/cinterop/src/jvm/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory("realm-core" EXCLUDE_FROM_ALL)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
-include_directories(${CAPI_BUILD}/src jni)
+include_directories(${CAPI_BUILD}/src jni ${SWIG_JNI_GENERATED} ${SWIG_JNI_HELPERS})
 
 file(GLOB jni_SRC
         "jni/env_utils.cpp"

--- a/packages/cinterop/src/jvm/CMakeLists.txt
+++ b/packages/cinterop/src/jvm/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.4.1)
 project(RealmKotlin)
 set(CAPI "${CMAKE_SOURCE_DIR}/../../../external/core")
 set(CAPI_BUILD "${CAPI}/build-android-${ANDROID_ABI}-${CMAKE_BUILD_TYPE}")
-set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/sources/jni")
+set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/generated/sources/jni")
 set(SWIG_JNI_HELPERS "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 
 # Build Realm Core

--- a/packages/cinterop/src/jvm/CMakeLists.txt
+++ b/packages/cinterop/src/jvm/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.4.1)
 project(RealmKotlin)
 set(CAPI "${CMAKE_SOURCE_DIR}/../../../external/core")
 set(CAPI_BUILD "${CAPI}/build-android-${ANDROID_ABI}-${CMAKE_BUILD_TYPE}")
-set(SWIG_JNI "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
+set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/sources/jni")
+set(SWIG_JNI_HELPERS "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 
 # Build Realm Core
 # Set option flags for Core.
@@ -25,8 +26,8 @@ file(GLOB jni_SRC
         )
 
 file(GLOB swig_SRC
-        ${SWIG_JNI}/realmc.cpp
-        ${SWIG_JNI}/realm_api_helpers.cpp
+        ${SWIG_JNI_GENERATED}/realmc.cpp
+        ${SWIG_JNI_HELPERS}/realm_api_helpers.cpp
         )
 
 # Create shared FFI library that is consumed by the C-Interop layer.

--- a/packages/cinterop/src/jvmMain/CMakeLists.txt
+++ b/packages/cinterop/src/jvmMain/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(RealmKotlin)
 find_package(JNI)
-set(SWIG_JNI "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
+set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/sources/jni")
+set(SWIG_JNI_HELPERS "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 set(CINTEROP_JNI "${CMAKE_SOURCE_DIR}/../jvm/jni")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
@@ -25,8 +26,8 @@ file(GLOB jni_SRC
         )
 
 file(GLOB swig_SRC
-        ${SWIG_JNI}/realm_api_helpers.cpp
-        ${SWIG_JNI}/realmc.cpp
+        ${SWIG_JNI_GENERATED}/realmc.cpp
+        ${SWIG_JNI_HELPERS}/realm_api_helpers.cpp
         )
 
 

--- a/packages/cinterop/src/jvmMain/CMakeLists.txt
+++ b/packages/cinterop/src/jvmMain/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(RealmKotlin)
 find_package(JNI)
-set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/sources/jni")
+set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/generated/sources/jni")
 set(SWIG_JNI_HELPERS "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 set(CINTEROP_JNI "${CMAKE_SOURCE_DIR}/../jvm/jni")
 
@@ -14,7 +14,7 @@ set(REALM_ENABLE_SYNC ON)
 set(REALM_BUILD_LIB_ONLY ON)
 add_subdirectory("${CMAKE_SOURCE_DIR}/../../../external/core" core EXCLUDE_FROM_ALL)
 
-include_directories("${CMAKE_BINARY_DIR}/src" "${JAVA_INCLUDE_PATH}" "${JAVA_INCLUDE_PATH}/darwin" "${CINTEROP_JNI}" "${SWIG_JNI}")
+include_directories("${CMAKE_BINARY_DIR}/src" "${JAVA_INCLUDE_PATH}" "${JAVA_INCLUDE_PATH}/darwin" "${CINTEROP_JNI}" "${SWIG_JNI_GENERATED}" "${SWIG_JNI_HELPERS}")
 
 file(GLOB jni_SRC
         "${CINTEROP_JNI}/env_utils.cpp"

--- a/packages/cinterop/src/jvmMain/linux/CMakeLists.txt
+++ b/packages/cinterop/src/jvmMain/linux/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(RealmKotlin)
 find_package(JNI)
-set(SWIG_JNI "${CMAKE_SOURCE_DIR}/../../../../jni-swig-stub/src/main/jni")
+set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/sources/jni")
+set(SWIG_JNI_HELPERS "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 set(CINTEROP_JNI "${CMAKE_SOURCE_DIR}/../../jvm/jni")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
@@ -26,8 +27,8 @@ file(GLOB jni_SRC
         )
 
 file(GLOB swig_SRC
-        ${SWIG_JNI}/realm_api_helpers.cpp
-        ${SWIG_JNI}/realmc.cpp
+        ${SWIG_JNI_GENERATED}/realmc.cpp
+        ${SWIG_JNI_HELPERS}/realm_api_helpers.cpp
         )
 
 

--- a/packages/cinterop/src/jvmMain/linux/CMakeLists.txt
+++ b/packages/cinterop/src/jvmMain/linux/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(RealmKotlin)
 find_package(JNI)
-set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/sources/jni")
+set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/generated/sources/jni")
 set(SWIG_JNI_HELPERS "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 set(CINTEROP_JNI "${CMAKE_SOURCE_DIR}/../../jvm/jni")
 
@@ -15,7 +15,7 @@ set(REALM_ENABLE_SYNC ON)
 set(REALM_BUILD_LIB_ONLY ON)
 add_subdirectory("${CMAKE_SOURCE_DIR}/../../../../external/core" core EXCLUDE_FROM_ALL)
 
-include_directories("${CMAKE_BINARY_DIR}/src" "${JAVA_INCLUDE_PATH}" "${JAVA_INCLUDE_PATH}/linux" "${CINTEROP_JNI}" "${SWIG_JNI}")
+include_directories("${CMAKE_BINARY_DIR}/src" "${JAVA_INCLUDE_PATH}" "${JAVA_INCLUDE_PATH}/linux" "${CINTEROP_JNI}" "${SWIG_JNI_GENERATED}" "${SWIG_JNI_HELPERS}")
 
 file(GLOB jni_SRC
         "${CINTEROP_JNI}/env_utils.cpp"

--- a/packages/cinterop/src/jvmMain/windows/CMakeLists.txt
+++ b/packages/cinterop/src/jvmMain/windows/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(RealmKotlin)
 find_package(JNI)
-set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/sources/jni")
+set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/generated/sources/jni")
 set(SWIG_JNI_HELPERS "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 set(CINTEROP_JNI "${CMAKE_SOURCE_DIR}/../../jvm/jni")
 
@@ -16,7 +16,7 @@ set(REALM_ENABLE_SYNC ON)
 set(REALM_BUILD_LIB_ONLY ON)
 add_subdirectory("${CMAKE_SOURCE_DIR}/../../../../external/core" core EXCLUDE_FROM_ALL)
 
-include_directories("${CMAKE_BINARY_DIR}/src" "${JAVA_INCLUDE_PATH}" "${JAVA_INCLUDE_PATH}/win32" "${CINTEROP_JNI}" "${SWIG_JNI}")
+include_directories("${CMAKE_BINARY_DIR}/src" "${JAVA_INCLUDE_PATH}" "${JAVA_INCLUDE_PATH}/win32" "${CINTEROP_JNI}" "${SWIG_JNI_GENERATED}" "${SWIG_JNI_HELPERS}")
 
 file(GLOB jni_SRC
         "${CINTEROP_JNI}/env_utils.cpp"

--- a/packages/cinterop/src/jvmMain/windows/CMakeLists.txt
+++ b/packages/cinterop/src/jvmMain/windows/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(RealmKotlin)
 find_package(JNI)
-set(SWIG_JNI "${CMAKE_SOURCE_DIR}/../../../../jni-swig-stub/src/main/jni")
+set(SWIG_JNI_GENERATED "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/build/sources/jni")
+set(SWIG_JNI_HELPERS "${CMAKE_SOURCE_DIR}/../../../jni-swig-stub/src/main/jni")
 set(CINTEROP_JNI "${CMAKE_SOURCE_DIR}/../../jvm/jni")
 
 set(CMAKE_CXX_STANDARD 17)
@@ -27,8 +28,8 @@ file(GLOB jni_SRC
         )
 
 file(GLOB swig_SRC
-        ${SWIG_JNI}/realm_api_helpers.cpp
-        ${SWIG_JNI}/realmc.cpp
+        ${SWIG_JNI_GENERATED}/realmc.cpp
+        ${SWIG_JNI_HELPERS}/realm_api_helpers.cpp
         )
 
 

--- a/packages/jni-swig-stub/.gitignore
+++ b/packages/jni-swig-stub/.gitignore
@@ -1,4 +1,0 @@
-java
-!**/LongPointerWrapper.java
-src/main/jni/realmc.cpp
-src/main/jni/realmc.h

--- a/packages/jni-swig-stub/build.gradle.kts
+++ b/packages/jni-swig-stub/build.gradle.kts
@@ -43,7 +43,7 @@ tasks.create("realmWrapperJvm") {
         delete(fileTree(generatedSourceRoot))
         exec {
             workingDir(".")
-            commandLine("swig", "-java", "-c++", "-package", "io.realm.internal.interop", "-I$projectDir/../external/core/src", "-o", "${generatedSourceRoot}/jni/realmc.cpp", "-outdir", "${generatedSourceRoot}/java/io/realm/internal/interop", "realm.i")
+            commandLine("swig", "-java", "-c++", "-package", "io.realm.internal.interop", "-I$projectDir/../external/core/src", "-o", "$generatedSourceRoot/jni/realmc.cpp", "-outdir", "$generatedSourceRoot/java/io/realm/internal/interop", "realm.i")
         }
     }
     inputs.file("$projectDir/../external/core/src/realm.h")

--- a/packages/jni-swig-stub/build.gradle.kts
+++ b/packages/jni-swig-stub/build.gradle.kts
@@ -21,8 +21,15 @@ plugins {
 
 val mavenPublicationName = "jniSwigStubs"
 
+val generatedSourceRoot = "$buildDir/generated/sources"
+
 java {
     withSourcesJar()
+    sourceSets {
+        main {
+            this.java.srcDir("$generatedSourceRoot/java")
+        }
+    }
 }
 
 configure<JavaPluginConvention> {
@@ -33,16 +40,18 @@ configure<JavaPluginConvention> {
 tasks.create("realmWrapperJvm") {
     doLast {
         // If task is actually triggered (not up to date) then we should clean up the old stuff
-        deleteGeneratedFiles()
+        delete(fileTree(generatedSourceRoot))
         exec {
             workingDir(".")
-            commandLine("swig", "-java", "-c++", "-package", "io.realm.internal.interop", "-I$projectDir/../external/core/src", "-o", "$projectDir/src/main/jni/realmc.cpp", "-outdir", "$projectDir/src/main/java/io/realm/internal/interop", "realm.i")
+            commandLine("swig", "-java", "-c++", "-package", "io.realm.internal.interop", "-I$projectDir/../external/core/src", "-o", "${generatedSourceRoot}/jni/realmc.cpp", "-outdir", "${generatedSourceRoot}/java/io/realm/internal/interop", "realm.i")
         }
     }
     inputs.file("$projectDir/../external/core/src/realm.h")
     inputs.file("realm.i")
-    outputs.dir("$projectDir/src/main/java/io/realm/internal/interop")
-    outputs.dir("$projectDir/src/main/jni")
+    inputs.dir("$projectDir/src/main/jni")
+    // Specifying full paths triggers creation of dirs, which would otherwise cause swig to fail
+    outputs.dir("$generatedSourceRoot/java/io/realm/internal/interop")
+    outputs.dir("$generatedSourceRoot/jni")
 }
 
 tasks.named("compileJava") {
@@ -69,22 +78,5 @@ publishing {
             artifactId = Realm.jniSwigStubsId
             from(components["java"])
         }
-    }
-}
-
-fun deleteGeneratedFiles() {
-    delete(
-        fileTree("$projectDir/src/main/java/io/realm/internal/interop/").matching {
-            include("*.java")
-            exclude("LongPointerWrapper.java") // not generated
-        }
-    )
-    delete(file("$projectDir/src/main/jni/realmc.cpp"))
-    delete(file("$projectDir/src/main/jni/realmc.h"))
-}
-
-tasks.named("clean") {
-    doLast {
-        deleteGeneratedFiles()
     }
 }


### PR DESCRIPTION
This just puts all swig-generated content into `jni-swig-stub/build/generated/sources/{jni,java}` and adds appropriate incremental build dependencies to input files.