### PR TITLE
Rework AppConfiguration initialization

### DIFF
--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
@@ -20,15 +20,15 @@ import io.ktor.client.features.logging.Logger
 import io.realm.LogConfiguration
 import io.realm.Realm
 import io.realm.RealmConfiguration
-import io.realm.internal.interop.sync.MetadataMode
-import io.realm.internal.platform.freeze
-import io.realm.internal.platform.createDefaultSystemLogger
-import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.internal.RealmLog
+import io.realm.internal.interop.sync.MetadataMode
+import io.realm.internal.interop.sync.NetworkTransport
+import io.realm.internal.platform.createDefaultSystemLogger
+import io.realm.internal.platform.freeze
+import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.log.LogLevel
 import io.realm.log.RealmLogger
 import io.realm.mongodb.internal.AppConfigurationImpl
-import io.realm.internal.interop.sync.NetworkTransport
 import io.realm.mongodb.internal.KtorNetworkTransport
 import kotlinx.coroutines.CoroutineDispatcher
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
@@ -16,15 +16,20 @@
 
 package io.realm.mongodb
 
+import io.ktor.client.features.logging.Logger
 import io.realm.LogConfiguration
 import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.internal.interop.sync.MetadataMode
+import io.realm.internal.platform.freeze
 import io.realm.internal.platform.createDefaultSystemLogger
 import io.realm.internal.platform.singleThreadDispatcher
+import io.realm.internal.RealmLog
 import io.realm.log.LogLevel
 import io.realm.log.RealmLogger
 import io.realm.mongodb.internal.AppConfigurationImpl
+import io.realm.internal.interop.sync.NetworkTransport
+import io.realm.mongodb.internal.KtorNetworkTransport
 import kotlinx.coroutines.CoroutineDispatcher
 
 /**
@@ -39,7 +44,7 @@ interface AppConfiguration {
     // TODO Consider replacing with URL type, but didn't want to include io.ktor.http.Url as it
     //  requires ktor as api dependency
     val baseUrl: String
-    val networkTransportDispatcher: CoroutineDispatcher
+    val networkTransport: NetworkTransport
     val metadataMode: MetadataMode
 
     companion object {
@@ -121,11 +126,26 @@ interface AppConfiguration {
                 allLoggers.add(createDefaultSystemLogger(Realm.DEFAULT_LOG_TAG))
             }
             allLoggers.addAll(userLoggers)
+            val appLogger: RealmLog = RealmLog(configuration = LogConfiguration(this.logLevel, allLoggers))
+
+            val networkTransport: NetworkTransport = KtorNetworkTransport(
+                // FIXME Add AppConfiguration.Builder option to set timeout as a Duration with default \
+                //  constant in AppConfiguration.Companion
+                //  https://github.com/realm/realm-kotlin/issues/408
+                timeoutMs = 5000,
+                dispatcher = dispatcher,
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        appLogger.debug(message)
+                    }
+                }
+            ).freeze() // Kotlin network client needs to be frozen before passed to the C-API
+
             return AppConfigurationImpl(
                 appId = appId,
                 baseUrl = baseUrl,
-                networkTransportDispatcher = dispatcher,
-                logConfig = LogConfiguration(this.logLevel, allLoggers)
+                networkTransport = networkTransport,
+                log = appLogger
             )
         }
     }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
@@ -16,8 +16,6 @@
 
 package io.realm.mongodb.internal
 
-import io.ktor.client.features.logging.Logger
-import io.realm.LogConfiguration
 import io.realm.internal.RealmLog
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
@@ -29,35 +27,14 @@ import io.realm.internal.platform.RUNTIME
 import io.realm.internal.platform.freeze
 import io.realm.mongodb.AppConfiguration
 import io.realm.mongodb.AppConfiguration.Companion.DEFAULT_BASE_URL
-import kotlinx.coroutines.CoroutineDispatcher
 
 internal class AppConfigurationImpl(
     override val appId: String,
     override val baseUrl: String = DEFAULT_BASE_URL,
-    override val networkTransportDispatcher: CoroutineDispatcher,
+    override val networkTransport: NetworkTransport,
     override val metadataMode: MetadataMode = MetadataMode.RLM_SYNC_CLIENT_METADATA_MODE_PLAINTEXT,
-    logConfig: LogConfiguration,
+    val log: RealmLog
 ) : AppConfiguration {
-
-    val log: RealmLog = RealmLog(configuration = logConfig)
-
-    private val networkTransport: NetworkTransport = KtorNetworkTransport(
-        // FIXME Add AppConfiguration.Builder option to set timeout as a Duration with default \
-        //  constant in AppConfiguration.Companion
-        //  https://github.com/realm/realm-kotlin/issues/408
-        timeoutMs = 5000,
-        dispatcher = networkTransportDispatcher,
-        logger = object : Logger {
-            // This should ideally be the AppConfigurationImpl.log but iOS ktor client seems to
-            // pass all configuration to another thread which freezes it. Having two logs with the
-            // same configuration is not ideal but would yield the same result when the
-            // configuration and loggers itself are frozen.
-            val log: RealmLog = RealmLog(configuration = logConfig)
-            override fun log(message: String) {
-                this.log.debug(message)
-            }
-        }
-    ).freeze() // Kotlin network client needs to be frozen before passed to the C-API
 
     // Only freeze anything after all properties are setup as this triggers freezing the actual
     // AppConfigurationImpl instance itself


### PR DESCRIPTION
This just injecst the `NetworkTransport` instead of constructing it internally in `AppConfigurationImpl`. 

This allows us to mock the `NetworkTransport` of `AppConfigurationImpl` and also allows us to use the same logger for `AppConfiguration` and `KtorNetworkTransport`.