### PR TITLE
Trigger sdk version generation for native targets too

### DIFF
--- a/packages/library-base/build.gradle.kts
+++ b/packages/library-base/build.gradle.kts
@@ -264,6 +264,6 @@ tasks.create("pluginVersion") {
         )
     }
 }
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {
     dependsOn("pluginVersion")
 }

--- a/packages/library-base/build.gradle.kts
+++ b/packages/library-base/build.gradle.kts
@@ -246,7 +246,7 @@ publishing {
 }
 
 // Generate code with version constant
-tasks.create("pluginVersion") {
+tasks.create("generateSdkVersionConstant") {
     val outputDir = file(versionDirectory)
 
     inputs.property("version", project.version)
@@ -265,5 +265,5 @@ tasks.create("pluginVersion") {
     }
 }
 tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {
-    dependsOn("pluginVersion")
+    dependsOn("generateSdkVersionConstant")
 }


### PR DESCRIPTION
The task generating `SDK_VERSION`-constant wasn't triggered for Kotlin native compilation sets. 

Apparently the `org.jetbrains.kotlin.gradle.tasks.KotlinCompile` is only the JVM tasks, whereas `org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>` also covers native ones.