### PR TITLE
RealmQuery POC

### DIFF
--- a/packages/library-base/build.gradle.kts
+++ b/packages/library-base/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.1")
                 implementation(kotlin("stdlib-common"))
                 implementation(kotlin("reflect"))
                 // If runtimeapi is merged with cinterop then we will be exposing both to the users

--- a/packages/library-base/src/commonMain/kotlin/io/realm/prototype/RealmQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/prototype/RealmQuery.kt
@@ -1,0 +1,248 @@
+package io.realm.prototype
+
+import io.realm.MutableRealm
+import io.realm.RealmObject
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.reflect.KClass
+
+//<editor-fold desc="Public Query API">
+
+/**
+ * Open Questions:
+ *  - We should strive for the same method across classes to enter "query-mode". `filter` is the
+ *    standard in other SDK's and used by Kotlin stdlib. Is it a problem if we overload it or
+ *    should we find another name? "query", "where", "something else"?
+ */
+
+interface Realm {
+    // QUESTION Similar to Cocoa, JS and Kotlin stdlib. Not a problem on Realm, but on Collections
+    // people might accidentally hit the wrong override. Is that a problem?
+    fun <T : RealmObject>filter(clazz: KClass<T>, query: String = "TRUEPREDICATE"): RealmQuery<T>
+
+    suspend fun <R> write(block: MutableRealm.() -> R): R
+}
+inline fun <reified T: RealmObject> Realm.filter(query: String = "TRUEPREDICATE"): RealmQuery<T> { TODO() }
+
+interface MutableRealm {
+    // QUESTION Similar to Cocoa, JS and Kotlin stdlib. Not a problem on Realm, but on Collections
+    // people might accidentally hit the wrong override. Is that a problem?
+    fun <T : RealmObject> filter(clazz: KClass<T>, query: String = "TRUEPREDICATE"): RealmQuery<T>
+}
+inline fun <reified T: RealmObject> MutableRealm.filter(query: String = "TRUEPREDICATE"): RealmQuery<T> { TODO() }
+
+
+
+interface RealmResults<E>: List<E> {
+    // QUESTION Similar to Cocoa, JS and Kotlin stdlib, but people might hit accidental override.
+    // Is that a problem?
+    fun filter(query: String = "TRUEPREDICATE"): RealmQuery<E>
+
+    // QUESTION Do we want to expose aggregate methods on Results. They are slower than doing it
+    // as a query, but also a lot faster than using the stdlib `List.maxOf { }`?
+    // If we expose them here. Lists of primitiveds might be annoying as they need a special
+    // syntax ("$") instead of a property name.
+    fun <E: Any> min(property: String, type: KClass<E>): E
+    fun <E: Any> max(property: String, type: KClass<E>): E
+    fun <E: Any> sum(property: String, type: KClass<E>): E
+    fun <E: Any> average(property: String, type: KClass<E>): E
+}
+
+interface RealmList<E>: MutableList<E> {
+    // QUESTION Similar to Cocoa, JS and Kotlin stdlib, but people might hit accidental override.
+    // Is that a problem?
+    fun filter(query: String = "TRUEPREDICATE"): RealmQuery<E>
+}
+
+enum class Sort {
+    ASCENDING,
+    DESCENDING
+}
+
+// QUESTION: Should fieldNames be KProperty or Strings? If KProperty, we need a different class for queries
+// on DynamicRealm
+// TODO We also need to support queries on primitive types, e.g. `RealmList<String>`
+interface RealmQuery<E>: RealmElementQuery<E> {
+    fun filter(filter: String, vararg arguments: Any?): RealmQuery<E>
+
+    fun sort(field: String, sortOrder: Sort = Sort.ASCENDING): RealmQuery<E>
+    fun sort(fieldName1: String?, sortOrder1: Sort, fieldName2: String, sortOrder2: Sort): RealmQuery<E>
+    fun sort(fieldNames: Array<String>, sortOrders: Array<Sort>): RealmQuery<E>
+    fun distinct(field: String): RealmQuery<E>
+
+    // QUESTION In stdlib these are called `minOf`, `maxOf`. Do we want to adopt same naming?
+    // Probably the answer will depend on what we think of `filter` vs. something else.
+    // Instead of adding `minDate/maxDate` etc. I'm adding the output class to these. This is particular
+    // helpful for dates where we don't have a single date type like in Java with `minDate`
+    fun <E: Any> min(property: String, type: KClass<E>): RealmScalarQuery<E>
+    fun <E: Any> max(property: String, type: KClass<E>): RealmScalarQuery<E>
+    fun <E: Any> sum(property: String, type: KClass<E>): RealmScalarQuery<E>
+    fun <E: Any> average(property: String, type: KClass<E>): RealmScalarQuery<E>
+    fun count(): RealmScalarQuery<Long>
+}
+
+inline fun <reified T> RealmQuery<out Any>.min(property: String): RealmScalarQuery<T> = TODO()
+inline fun <reified T> RealmQuery<out Any>.max(property: String): RealmScalarQuery<T> = TODO()
+inline fun <reified T> RealmQuery<out Any>.average(property: String): RealmScalarQuery<T> = TODO()
+
+/**
+ * Queries that return elements in the collection being queried. This needs to support both
+ * RealmObjects and primitive types.
+ */
+interface RealmElementQuery<E> {
+    fun findAll(): RealmResults<E>
+    fun asFlow(): Flow<RealmResults<E>>
+}
+
+/**
+ * Queries that return scalar values. We cannot express in the type-system which scalar values
+ * we support, so this checks must be done by the compiler plugin or at runtime.
+ */
+interface RealmScalarQuery<E> {
+    fun find(): E
+    // These will require a few hacks as Core changelisteners do not support these currently.
+    // Easy work-around is just calling `Results.<aggregateFunction>()` inside the NotifierThread
+    fun asFlow(): Flow<E>
+}
+
+//</editor-fold>
+
+//<editor-fold desc="Examples">
+fun updateUI(vararg args: Any?) { TODO() }
+class Person: RealmObject {
+    var name: String = ""
+    var age: Int = 0
+    var birthday: Instant = Clock.System.now()
+}
+
+fun getRealm(): Realm { TODO() }
+fun viewModelExamples() {
+    val realm: Realm = getRealm()
+    val viewModelScope = CoroutineScope(CoroutineName("CustomScope") + Dispatchers.Main)
+
+    // Use case 1: Observe objects using a simple query for the UI
+    viewModelScope.launch {
+        realm.filter<Person>("age > 42").asFlow()
+            .collect { it: RealmResults<Person> ->
+                updateUI(it)
+            }
+    }
+
+    // Use case 2: Observe objects using an advanced query for the UI
+    viewModelScope.launch {
+        realm.filter<Person>("age > 42")
+            .filter("name BEGINSWITH 'John'")
+            .distinct("age")
+            .sort("name")
+            .asFlow()
+            .collect { it: RealmResults<Person> ->
+                updateUI(it)
+            }
+    }
+
+    // Use case 3a: Observe scalar values for the UI. Fast version (part of the query)
+    viewModelScope.launch {
+        realm.filter<Person>("name BEGINSWITH 'John'")
+            .max<Int>("age")
+            .asFlow()
+            .collect { it: Int ->
+                updateUI(it)
+            }
+    }
+
+    // Use case 3b: Observe scalar values for the UI. Slower version (Realm code, but part of the mapping)
+    viewModelScope.launch {
+        realm.filter<Person>("name BEGINSWITH 'John'")
+            .asFlow()
+            .map { it: RealmResults<Person> ->
+                withContext(Dispatchers.Default) {
+                    it.max("age", Int::class)
+                }
+            }
+            .collect { it: Int ->
+                updateUI(it)
+            }
+    }
+
+    // Use case 3c: Observe scalar values for the UI. Slowest version using Kotlin stdlib
+    viewModelScope.launch {
+        realm.filter<Person>("name BEGINSWITH 'John'")
+            .asFlow()
+            .map { it: RealmResults<Person> ->
+                it.maxOf { person -> person.age }
+            }
+            .collect { it: Int ->
+                updateUI(it)
+            }
+    }
+
+    // Use case 4: Combine Flows of Objects and Scalars
+    viewModelScope.launch {
+        val flow1: Flow<RealmResults<Person>> = realm.filter<Person>("name BEGINSWITH 'Jane'").asFlow()
+        val flow2: Flow<Float> = realm.filter<Person>().average("age", Float::class).asFlow()
+
+        // Combing the results into a different output where listOf("Name - Age (Average Age)")
+        flow1.combine(flow2) { f1: RealmResults<Person>, f2: Float ->
+            f1.map {
+              "${it.name} - ${it.age} ($f2)"
+            }
+        }.collect { it: List<String> ->
+            updateUI(it)
+        }
+    }
+
+    // Use case 5: Running queries by accident on the UI thread.
+    // There is no guard against this unless we introduce `RealmConfiguration.allowQueriesOnMainThread()`
+    // We should probably do that.
+    viewModelScope.launch {
+        val results: RealmResults<Person> = realm.filter<Person>().filter("age > 42").findAll()
+        val count: Long = realm.filter<Person>().count().find()
+        updateUI(results, count)
+    }
+}
+
+fun writeExamples() {
+    val realm: Realm = getRealm()
+    val scope = CoroutineScope(CoroutineName("CustomScope"))
+
+    scope.launch {
+        // Queries in MutableRealm use the same API as reads. Only difference is that any method
+        // that isn't a blocking method will throw an exception. There doesn't seem to be an easy
+        // way to avoid this using the type system.
+        realm.write {
+            // Use case 1: Standard simple object queries
+            val results1: RealmResults<Person> = filter<Person>("age > 42").findAll()
+
+            // Use case 2: More advanced object queries
+            val results2: RealmResults<Person> = filter<Person>("age > 42")
+                .filter("name BEGINSWITH 'John'")
+                .sort("name")
+                .findAll()
+
+            // Use case 3: Selecting first match
+            val person: Person? = filter<Person>("age > 42")
+                .filter("name BEGINSWITH 'John'")
+                .sort("name")
+                .findAll()
+                .firstOrNull()
+
+            // Use case 4: Scalar queries
+            val maxAge: Long = filter<Person>().max("age", Long::class).find()
+
+            // Use case 5: Scalar queries with type conversion. By asking users to provide the type
+            // we should also do conversions for standard types, e.g. casting numbers, string/int
+            // conversion, Date conversion
+            val youngestBirthday: Long = filter<Person>().max<Long>("birthday").find()
+            val maxAgeAsDouble: Double = filter<Person>().max<Double>("age").find()
+
+            // Use case 6: Observing queries are not supported in writes.
+            filter<Person>().asFlow() // Will throw exception
+            filter<Person>().max<Long>("age").asFlow() // Will throw exception
+        }
+    }
+}
+//</editor-fold>
+
+

--- a/packages/library-base/src/commonMain/kotlin/io/realm/prototype/RealmQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/prototype/RealmQuery.kt
@@ -91,7 +91,7 @@ interface RealmElementQuery<E> {
  * NOTE: The interaction with primitive queries might be a bit akward
  */
 interface RealmSingleQuery<E: RealmObject> {
-    fun find(): E
+    fun find(): E?
     fun asFlow(): Flow<E>
     // When fine-grained notifications are merged
     // fun asFlow(): Flow<ObjectChange<E>>

--- a/packages/library-base/src/commonMain/kotlin/io/realm/prototype/RealmQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/prototype/RealmQuery.kt
@@ -1,6 +1,5 @@
 package io.realm.prototype
 
-import io.realm.MutableRealm
 import io.realm.RealmObject
 import io.realm.realmListOf
 import kotlinx.coroutines.*
@@ -30,7 +29,7 @@ inline fun <reified T: RealmObject> Realm.query(query: String = "TRUEPREDICATE")
 interface MutableRealm {
     fun <T : RealmObject> query(clazz: KClass<T>, query: String = "TRUEPREDICATE"): RealmQuery<T>
 }
-inline fun <reified T: RealmObject> MutableRealm.filter(query: String = "TRUEPREDICATE"): RealmQuery<T> { TODO() }
+inline fun <reified T: RealmObject> MutableRealm.query(query: String = "TRUEPREDICATE"): RealmQuery<T> { TODO() }
 
 /**
  * Add `query` method to RealmResults
@@ -227,33 +226,33 @@ fun writeExamples() {
         // way to avoid this using the type system.
         realm.write {
             // Use case 1: Standard simple object queries
-            val results1: RealmResults<Person> = filter<Person>("age > 42").find()
+            val results1: RealmResults<Person> = query<Person>("age > 42").find()
 
             // Use case 2: More advanced object queries
-            val results2: RealmResults<Person> = filter<Person>("age > 42")
+            val results2: RealmResults<Person> = query<Person>("age > 42")
                 .query("name BEGINSWITH 'John'")
                 .sort("name")
                 .find()
 
             // Use case 3: Selecting first match
-            val person: Person? = filter<Person>("age > 42")
+            val person: Person? = query<Person>("age > 42")
                 .query("name BEGINSWITH 'John'")
                 .sort("name")
                 .find()
                 .firstOrNull()
 
             // Use case 4: Scalar queries
-            val maxAge: Long = filter<Person>().max("age", Long::class).find()
+            val maxAge: Long = query<Person>().max("age", Long::class).find()
 
             // Use case 5: Scalar queries with type conversion. By asking users to provide the type
             // we should also do conversions for standard types, e.g. casting numbers, string/int
             // conversion, Date conversion
-            val youngestBirthday: Long = filter<Person>().max<Long>("birthday").find()
-            val maxAgeAsDouble: Double = filter<Person>().max<Double>("age").find()
+            val youngestBirthday: Long = query<Person>().max<Long>("birthday").find()
+            val maxAgeAsDouble: Double = query<Person>().max<Double>("age").find()
 
             // Use case 6: Observing queries are not supported in writes.
-            filter<Person>().asFlow() // Will throw exception
-            filter<Person>().max<Long>("age").asFlow() // Will throw exception
+            query<Person>().asFlow() // Will throw exception
+            query<Person>().max<Long>("age").asFlow() // Will throw exception
         }
     }
 }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmQueryExampleTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmQueryExampleTests.kt
@@ -1,0 +1,4 @@
+package io.realm.test.shared
+
+class RealmQueryExampleTests {
+}


### PR DESCRIPTION
POC of a possible Query API based on our discussions. This PR is just intended to facilitate discussion and should not be merged.

This API makes it possible to run both object and scalar queries in blocking and non-blocking variants. 

The main idea is to have 3 classes: `RealmQuery`, `RealmElementQuery` and `RealmScalarQuery` which then offer different "execute" methods.

Some design considerations:

1) What should we call the `query/filter` method? We should strive to make it the same across all classes. Other SDK's use `filter`. Which is also offered by the Kotlin stdlib. Overriding it offers easier discoverability. Downside is that people might use the wrong method by accident.

2) Should we expose `min/max/cont/average` directly on RealmResults. They are slower than queries, but faster than the similar Kotlin stdlib methods?

3) Should we support helper methods like `findFirst()` or let people use `findAll().firstOrNull`?

4) I renamed `observe` to `asFlow`. This was a discussion I had with @edualonso a few weeks ago. `observe` feels like `collect` and `asFlow` are used by other frameworks.

5) The biggest tradeoff is that we cannot prevent people from calling `asFlow()` inside a write transaction. Runtime exceptions are needed here. This seems acceptable.

6) This API did try to take into consideration that we also need to support queries on Lists of primitives, but without a specific `PrimitiveRealmList` it is always going to be a bit ugly, e.g. people need to put a placeholder in where properties are required.

 

