### PR TITLE
Update to latest BAAS server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -433,44 +433,43 @@ def testWithServer(tasks) {
             [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'realm-kotlin-baas-aws-credentials', accessKeyVariable: 'BAAS_AWS_ACCESS_KEY_ID', secretKeyVariable: 'BAAS_AWS_SECRET_ACCESS_KEY']
     ]) {
         sh "security -v unlock-keychain -p $PASSWORD"
-    }
-
-    try {
-        // Prepare Docker containers with MongoDB Realm Test Server infrastructure for
-        // integration tests.
-        // TODO: How much of this logic can be moved to start_server.sh for shared logic with local testing.
-        def props = readProperties file: 'dependencies.list'
-        echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
-        def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")
-        docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {
-          mdbRealmImage.pull()
-        }
-        def commandServerEnv = docker.build 'mongodb-realm-command-server', "tools/sync_test_server"
-        def tempDir = runCommand('mktemp -d -t app_config.XXXXXXXXXX')
-        sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template testapp1 testapp2"
-
-        sh "docker network create ${dockerNetworkId}"
-        mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000 -e AWS_ACCESS_KEY_ID='$BAAS_AWS_ACCESS_KEY_ID' -e AWS_SECRET_ACCESS_KEY='$BAAS_AWS_SECRET_ACCESS_KEY'")
-        mongoDbRealmCommandServerContainer = commandServerEnv.run("--rm -i -t -d --network container:${mongoDbRealmContainer.id} -v$tempDir:/apps")
-        sh "timeout 60 sh -c \"while [[ ! -f $tempDir/testapp1/app_id || ! -f $tempDir/testapp2/app_id ]]; do echo 'Waiting for server to start'; sleep 1; done\""
-
-        // Techinically this is only needed for Android, but since all tests are
-        // executed on same host and tasks are grouped in same stage we just do it
-        // here
-        forwardAdbPorts()
-
-        tasks.each { task ->
-            task()
-        }
-    } finally {
-        // We assume that creating these containers and the docker network can be considered an atomic operation.
-        if (mongoDbRealmContainer != null && mongoDbRealmCommandServerContainer != null) {
-            try {
-                archiveServerLogs(mongoDbRealmContainer.id, mongoDbRealmCommandServerContainer.id)
-            } finally {
-                mongoDbRealmContainer.stop()
-                mongoDbRealmCommandServerContainer.stop()
-                sh "docker network rm ${dockerNetworkId}"
+        try {
+            // Prepare Docker containers with MongoDB Realm Test Server infrastructure for
+            // integration tests.
+            // TODO: How much of this logic can be moved to start_server.sh for shared logic with local testing.
+            def props = readProperties file: 'dependencies.list'
+            echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER}"
+            def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER}")
+            docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {
+              mdbRealmImage.pull()
+            }
+            def commandServerEnv = docker.build 'mongodb-realm-command-server', "tools/sync_test_server"
+            def tempDir = runCommand('mktemp -d -t app_config.XXXXXXXXXX')
+            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template testapp1 testapp2"
+    
+            sh "docker network create ${dockerNetworkId}"
+            mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000 -e AWS_ACCESS_KEY_ID='$BAAS_AWS_ACCESS_KEY_ID' -e AWS_SECRET_ACCESS_KEY='$BAAS_AWS_SECRET_ACCESS_KEY'")
+            mongoDbRealmCommandServerContainer = commandServerEnv.run("--rm -i -t -d --network container:${mongoDbRealmContainer.id} -v$tempDir:/apps")
+            sh "timeout 60 sh -c \"while [[ ! -f $tempDir/testapp1/app_id || ! -f $tempDir/testapp2/app_id ]]; do echo 'Waiting for server to start'; sleep 1; done\""
+    
+            // Techinically this is only needed for Android, but since all tests are
+            // executed on same host and tasks are grouped in same stage we just do it
+            // here
+            forwardAdbPorts()
+    
+            tasks.each { task ->
+                task()
+            }
+        } finally {
+            // We assume that creating these containers and the docker network can be considered an atomic operation.
+            if (mongoDbRealmContainer != null && mongoDbRealmCommandServerContainer != null) {
+                try {
+                    archiveServerLogs(mongoDbRealmContainer.id, mongoDbRealmCommandServerContainer.id)
+                } finally {
+                    mongoDbRealmContainer.stop()
+                    mongoDbRealmCommandServerContainer.stop()
+                    sh "docker network rm ${dockerNetworkId}"
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,8 @@ version = null
 // Wether or not to run test steps
 runTests = true
 isReleaseBranch = releaseBranches.contains(currentBranch)
+// Manually wipe the workspace before checking out the code. This happens automatically on release branches.
+forceWipeWorkspace = false
 
 // References to Docker containers holding the MongoDB Test server and infrastructure for
 // controlling it.
@@ -254,7 +256,7 @@ def runScm() {
     def repoExtensions = [
         [$class: 'SubmoduleOption', recursiveSubmodules: true]
     ]
-    if (isReleaseBranch) {
+    if (isReleaseBranch || forceWipeWorkspace) {
         repoExtensions += [
             [$class: 'WipeWorkspace'],
             [$class: 'CleanCheckout'],
@@ -428,6 +430,7 @@ def testWithServer(tasks) {
     // Work-around for https://github.com/docker/docker-credential-helpers/issues/82
     withCredentials([
             [$class: 'StringBinding', credentialsId: 'realm-kotlin-ci-password', variable: 'PASSWORD'],
+            [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'realm-kotlin-baas-aws-credentials', accessKeyVariable: 'BAAS_AWS_ACCESS_KEY_ID', secretKeyVariable: 'BAAS_AWS_SECRET_ACCESS_KEY']
     ]) {
         sh "security -v unlock-keychain -p $PASSWORD"
     }
@@ -447,7 +450,7 @@ def testWithServer(tasks) {
         sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template testapp1 testapp2"
 
         sh "docker network create ${dockerNetworkId}"
-        mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000")
+        mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000 -e AWS_ACCESS_KEY_ID='$BAAS_AWS_ACCESS_KEY_ID' -e AWS_SECRET_ACCESS_KEY='$BAAS_AWS_SECRET_ACCESS_KEY'")
         mongoDbRealmCommandServerContainer = commandServerEnv.run("--rm -i -t -d --network container:${mongoDbRealmContainer.id} -v$tempDir:/apps")
         sh "timeout 60 sh -c \"while [[ ! -f $tempDir/testapp1/app_id || ! -f $tempDir/testapp2/app_id ]]; do echo 'Waiting for server to start'; sleep 1; done\""
 

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,3 +1,3 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2021-04-22
+MONGODB_REALM_SERVER=2021-11-26

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -43,7 +43,16 @@ $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template tes
 # Run Stitch and Stitch CLI Docker images
 docker network create mongodb-realm-network
 docker build $DOCKERFILE_DIR -t mongodb-realm-command-server || { echo "Failed to build Docker image." ; exit 1 ; }
-ID=$(docker run --rm -i -t -d -v$APP_CONFIG_DIR:/apps --network mongodb-realm-network -p9090:9090 -p8888:8888 -p26000:26000 --name mongodb-realm docker.pkg.github.com/realm/ci/mongodb-realm-test-server:$MONGODB_REALM_VERSION)
+ID=$(docker run --rm -i -t -d -v$APP_CONFIG_DIR:/apps \
+     --network mongodb-realm-network \
+     -p9090:9090 \
+     -p8888:8888 \
+     -p26000:26000 \
+     --name mongodb-realm \
+     -e AWS_ACCESS_KEY_ID="${BAAS_AWS_ACCESS_KEY_ID}" \
+     -e AWS_SECRET_ACCESS_KEY="${BAAS_AWS_SECRET_ACCESS_KEY}" \
+     docker.pkg.github.com/realm/ci/mongodb-realm-test-server:$MONGODB_REALM_VERSION \
+)
 docker run --rm -i -t -d --network container:$ID -v$APP_CONFIG_DIR:/apps --name mongodb-realm-command-server mongodb-realm-command-server
 
 echo "Template apps are generated in/served from $APP_CONFIG_DIR"


### PR DESCRIPTION
This now requires globally available AWS credentials.
Also a small quality-of-life improvement for making it easier to manually wipe the workspace.