### PR TITLE
Use C-API's realm changed notifications

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -33,6 +33,11 @@ value class ClassKey(val key: Long)
 @JvmInline
 value class ColumnKey(val key: Long)
 
+// TODO Again it would be awesome with marker interfaces for the various realm types, so we could
+//  add it as generic parameters here ...
+@JvmInline
+value class RegistrationToken(val value: Long)
+
 @Suppress("FunctionNaming", "LongParameterList")
 expect object RealmInterop {
     fun realm_get_version_id(realm: NativePointer): Long
@@ -68,6 +73,10 @@ expect object RealmInterop {
     // The dispatcher argument is only used on Native to build a core scheduler dispatching to the
     // dispatcher. The realm itself must also be opened on the same thread
     fun realm_open(config: NativePointer, dispatcher: CoroutineDispatcher? = null): NativePointer
+
+    fun realm_add_realm_changed_callback(realm: NativePointer, block: () -> Unit): RegistrationToken
+    fun realm_remove_realm_changed_callback(realm: NativePointer, token: RegistrationToken)
+
     fun realm_freeze(liveRealm: NativePointer): NativePointer
     fun realm_is_frozen(realm: NativePointer): Boolean
     fun realm_close(realm: NativePointer)

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -360,6 +360,22 @@ actual object RealmInterop {
         return realmPtr
     }
 
+    actual fun realm_add_realm_changed_callback(realm: NativePointer, block: () -> Unit): RegistrationToken {
+        return RegistrationToken(realm_wrapper.realm_add_realm_changed_callback(realm.cptr(),
+            staticCFunction { userData ->
+                safeUserData<() -> Unit>(userData)()
+            },
+            StableRef.create(block).asCPointer(),
+            staticCFunction { userdata ->
+                disposeUserData<(NativePointer, SyncErrorCallback) -> Unit>(userdata)
+            }
+        ).toLong())
+    }
+
+    actual fun realm_remove_realm_changed_callback(realm: NativePointer, token: RegistrationToken) {
+        realm_wrapper.realm_remove_realm_changed_callback(realm.cptr(), token.value.toULong())
+    }
+
     actual fun realm_freeze(liveRealm: NativePointer): NativePointer {
         return CPointerWrapper(realm_wrapper.realm_freeze(liveRealm.cptr<realm_t>()))
     }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -166,6 +166,14 @@ actual object RealmInterop {
         return realmPtr
     }
 
+    actual fun realm_add_realm_changed_callback(realm: NativePointer, block: () -> Unit): RegistrationToken {
+        return RegistrationToken(realmc.realm_add_realm_changed_callback(realm.cptr(), block))
+    }
+
+    actual fun realm_remove_realm_changed_callback(realm: NativePointer, token: RegistrationToken) {
+        return realmc.realm_remove_realm_changed_callback(realm.cptr(), token.value)
+    }
+
     actual fun realm_freeze(liveRealm: NativePointer): NativePointer {
         return LongPointerWrapper(realmc.realm_freeze(liveRealm.cptr()))
     }

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -72,6 +72,18 @@ std::string rlm_stdstr(realm_string_t val)
         get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
     };
 }
+// Reuse void callback typemap as template for `realm_on_realm_change_func_t`
+%apply (realm_app_void_completion_func_t, void* userdata, realm_free_userdata_func_t) {
+(realm_on_realm_change_func_t, void* userdata, realm_free_userdata_func_t)
+};
+%typemap(in) (realm_on_realm_change_func_t, void* userdata, realm_free_userdata_func_t) {
+    auto jenv = get_env(true);
+    $1 = reinterpret_cast<realm_on_realm_change_func_t>(realm_changed_callback);
+    $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
+    $3 = [](void *userdata) {
+        get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
+    };
+}
 
 // Primitive/built in type handling
 typedef jstring realm_string_t;

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -23,6 +23,20 @@
 using namespace realm::jni_util;
 using namespace realm::_impl;
 
+void
+realm_changed_callback(void* userdata) {
+    auto env = get_env(true);
+    static JavaClass java_callback_class(env, "kotlin/jvm/functions/Function0");
+    static JavaMethod java_callback_method(env, java_callback_class, "invoke",
+                                           "()Ljava/lang/Object;");
+    env->CallObjectMethod(static_cast<jobject>(userdata), java_callback_method);
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        throw std::runtime_error("An unexpected Error was thrown from Java. See LogCat");
+    }
+}
+
 // TODO OPTIMIZE Abstract pattern for all notification registrations for collections that receives
 //  changes as realm_collection_changes_t.
 realm_notification_token_t *

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -22,6 +22,9 @@
 #include "java_class_global_def.hpp"
 #include "utils.h"
 
+void
+realm_changed_callback(void* userdata);
+
 realm_notification_token_t*
 register_results_notification_cb(realm_results_t *results, jobject callback);
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/LiveRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/LiveRealm.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal
+
+import io.realm.internal.interop.RealmInterop
+import io.realm.internal.interop.RegistrationToken
+import io.realm.internal.interop.NativePointer
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * A live realm that can be updated and receive notifications on data and schema changes when
+ * updated by other threads.
+ *
+ * NOTE: Must be constructed with a single thread dispatch and must be constructed on the same
+ * thread that is backing the dispatcher.
+ */
+open class LiveRealm: BaseRealmImpl {
+
+    private val realmChangeRegistration: RegistrationToken
+
+    constructor(
+        configuration: InternalRealmConfiguration,
+        dispatcher: CoroutineDispatcher? = null
+    ) : super(configuration, RealmInterop.realm_open(configuration.nativeConfig, dispatcher))
+
+    init {
+        realmChangeRegistration = RealmInterop.realm_add_realm_changed_callback(realmReference.dbPointer, ::onRealmChanged)
+    }
+
+    var snapshot: RealmReference = RealmReference(realmReference.owner, RealmInterop.realm_freeze(realmReference.dbPointer))
+
+    open fun onRealmChanged() {
+        snapshot = RealmReference(realmReference.owner, RealmInterop.realm_freeze(realmReference.dbPointer))
+    }
+
+    override fun close() {
+        RealmInterop.realm_remove_realm_changed_callback(realmReference.dbPointer, realmChangeRegistration)
+        super.close()
+    }
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
@@ -27,7 +27,7 @@ import io.realm.isValid
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 
-internal class MutableRealmImpl : BaseRealmImpl, MutableRealm {
+internal class MutableRealmImpl : LiveRealm, MutableRealm {
 
     // TODO Also visible as a companion method to allow for `RealmObject.delete()`, but this
     //  has drawbacks. See https://github.com/realm/realm-kotlin/issues/181
@@ -49,6 +49,7 @@ internal class MutableRealmImpl : BaseRealmImpl, MutableRealm {
      * Create a MutableRealm which lifecycle must be managed by its own, i.e. any modifications
      * done inside the MutableRealm is not immediately reflected in the `parentRealm`.
      *
+     * // FIXME Revisit - This is not true anymore!
      * The core scheduler used to deliver notifications are:
      * - Android: The default Android scheduler, which delivers notifications on the looper of
      * the current thread.
@@ -58,7 +59,7 @@ internal class MutableRealmImpl : BaseRealmImpl, MutableRealm {
     internal constructor(
         configuration: InternalRealmConfiguration,
         dispatcher: CoroutineDispatcher? = null
-    ) : super(configuration, RealmInterop.realm_open(configuration.nativeConfig, dispatcher))
+    ) : super(configuration, dispatcher)
 
     internal fun beginTransaction() {
         try {


### PR DESCRIPTION
This PR changes the global realm notification mechanism to use the C-API `realm_on_realm_change_func_t` callback instead of just triggering change notifications as a superset of object/list/result notification callbacks. 

TODOs 
- [ ] Fix memory test on Android
- [ ] Fix immutability issues on Kotlin Native