### PR TITLE
Add M1 support for library-base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [Sync] Added support for `User.logOut()` ([#245](https://github.com/realm/realm-kotlin/issues/245)).
 * Added supported for dates through a new property type: `RealmInstant`.
 * Allow to pass schema as a variable containing the involved `KClass`es and build configurations non-fluently ([#389](https://github.com/realm/realm-kotlin/issues/389)).
+* Added M1 support for `library-base` variant ([#483](https://github.com/realm/realm-kotlin/issues/483)).
 
 ### Fixed
 * Gradle metadata for pure Android projects. Now using `io.realm.kotlin:library-base:<VERSION>` should work correctly.
@@ -32,7 +33,7 @@
 * Updated to Android Gradle Plugin 7.1.0-beta05.
 * Updated to NDK 23.1.7779620.
 * Updated to Android targetSdk 31.
-* Updated to Android compileSdk 31. 
+* Updated to Android compileSdk 31.
 * Updated to Android Build Tools 31.0.0.
 * Updated to Ktlint version 0.43.0.
 * Updated to Ktlint Gradle Plugin 10.2.0.

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -135,6 +135,17 @@ kotlin {
             }
         }
     }
+    iosSimulatorArm64 {
+        compilations.getByName("main") {
+            cinterops.create("realm_wrapper") {
+                defFile = project.file("src/native/realm.def")
+                packageName = "realm_wrapper"
+                includeDirs("$absoluteCorePath/src/")
+            }
+            kotlinOptions.freeCompilerArgs +=
+                if (isReleaseBuild) nativeLibraryIncludesIosSimulatorUniversalRelease else nativeLibraryIncludesIosSimulatorUniversalDebug
+        }
+    }
 
     macosX64("macos") {
         compilations.getByName("main") {
@@ -150,6 +161,16 @@ kotlin {
             // ... and def file does not support using environment variables
             // https://github.com/JetBrains/kotlin-native/issues/3631
             // so resolving paths through gradle
+            kotlinOptions.freeCompilerArgs += if (isReleaseBuild) nativeLibraryIncludesMacosUniversalRelease else nativeLibraryIncludesMacosUniversalDebug
+        }
+    }
+    macosArm64 {
+        compilations.getByName("main") {
+            cinterops.create("realm_wrapper") {
+                defFile = project.file("src/native/realm.def")
+                packageName = "realm_wrapper"
+                includeDirs("$absoluteCorePath/src/")
+            }
             kotlinOptions.freeCompilerArgs += if (isReleaseBuild) nativeLibraryIncludesMacosUniversalRelease else nativeLibraryIncludesMacosUniversalDebug
         }
     }
@@ -194,6 +215,10 @@ kotlin {
             // FIXME HIERARCHICAL-BUILD Rename to nativeDarwin
             kotlin.srcDir("src/darwin/kotlin")
         }
+        val macosArm64Main by getting {
+            kotlin.srcDir("src/darwin/kotlin")
+        }
+
         val iosMain by getting {
             // TODO HIERARCHICAL-BUILD From 1.5.30-M1 we should be able to commonize cinterops using
             //  kotlin.mpp.enableCInteropCommonization=true (https://youtrack.jetbrains.com/issue/KT-40975)
@@ -201,8 +226,14 @@ kotlin {
             //  https://youtrack.jetbrains.com/issue/KT-48153
             kotlin.srcDir("src/darwin/kotlin")
         }
+        val iosSimulatorArm64Main by getting {
+            kotlin.srcDir("src/darwin/kotlin")
+        }
         val macosTest by getting {
             // FIXME HIERARCHICAL-BUILD Rename to nativeDarwinTest
+            kotlin.srcDir("src/darwinTest/kotlin")
+        }
+        val macosArm64Test by getting {
             kotlin.srcDir("src/darwinTest/kotlin")
         }
         val iosTest by getting {

--- a/packages/library-base/build.gradle.kts
+++ b/packages/library-base/build.gradle.kts
@@ -52,7 +52,9 @@ kotlin {
         publishLibraryVariants("release", "debug")
     }
     ios()
-    macosX64("macos") {}
+    iosSimulatorArm64()
+    macosX64("macos")
+    macosArm64()
     sourceSets {
         commonMain {
             dependencies {
@@ -106,8 +108,17 @@ kotlin {
             // TODO HMPP Should be shared source set
             kotlin.srcDir("src/darwin/kotlin")
         }
+        val macosArm64Main by getting {
+            kotlin.srcDir("src/darwin/kotlin")
+            kotlin.srcDir("src/macosMain/kotlin")
+        }
+
         getByName("iosArm64Main") {
             // TODO HMPP Should be shared source set
+            kotlin.srcDir("src/darwin/kotlin")
+            kotlin.srcDir("src/ios/kotlin")
+        }
+        val iosSimulatorArm64Main by getting {
             kotlin.srcDir("src/darwin/kotlin")
             kotlin.srcDir("src/ios/kotlin")
         }


### PR DESCRIPTION
- Currently Ktor client libcurl engine is not released with support for M1 this is why this PR is limited to the non-sync variant
- Once we add support for non-sync, we should consider using the new build system https://github.com/realm/realm-kotlin/issues/141 as well as stop building Universal Mach-O archive by using `ARCHS` flag
Example:

Building for `arm64`
```
xcodebuild -sdk iphonesimulator -configuration Debug -target install ARCHS=arm64 -UseModernBuildSystem=NO
```

Building for `X64`
```
xcodebuild -sdk iphonesimulator -configuration Debug -target install ARCHS=x86_64 -UseModernBuildSystem=NO
```

The PR has been tested against `MultiplatformDemo` and `JVMConsole` on a M1 macmini 
