### PR TITLE
Remove manual check from `addAll` with index in `RealmList`

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
@@ -42,8 +42,8 @@ internal class UnmanagedRealmList<E> : RealmList<E>, MutableList<E> by mutableLi
  * Implementation for managed lists, backed by Realm.
  */
 internal class ManagedRealmList<E>(
-    val nativePointer: NativePointer,
-    val metadata: ListOperatorMetadata
+    private val nativePointer: NativePointer,
+    private val metadata: ListOperatorMetadata
 ) : AbstractMutableList<E>(), RealmList<E>, Observable<ManagedRealmList<E>> {
 
     private val operator = ListOperator<E>(metadata)
@@ -74,15 +74,6 @@ internal class ManagedRealmList<E>(
         } catch (exception: RealmCoreException) {
             throw genericRealmCoreExceptionHandler("Could not add element at list index $index", exception)
         }
-    }
-
-    // FIXME bug in AbstractMutableList.addAll native implementation:
-    //  https://youtrack.jetbrains.com/issue/KT-47211
-    //  Remove this method once the native implementation has a check for valid index
-    override fun addAll(index: Int, elements: Collection<E>): Boolean {
-        metadata.realm.checkClosed()
-        rangeCheckForAdd(index)
-        return super.addAll(index, elements)
     }
 
     override fun clear() {
@@ -152,12 +143,6 @@ internal class ManagedRealmList<E>(
     // TODO from LifeCycle interface
     internal fun isValid(): Boolean {
         return RealmInterop.realm_list_is_valid(nativePointer)
-    }
-
-    private fun rangeCheckForAdd(index: Int) {
-        if (index < 0 || index > size) {
-            throw IndexOutOfBoundsException("Index: '$index', Size: '$size'")
-        }
     }
 }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmListTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmListTests.kt
@@ -71,7 +71,7 @@ class RealmListTests {
 
     @Test
     fun realmListInitializer_realmListOf() {
-        val realmListFromArgsEmpty: RealmList<String> = realmListOf<String>()
+        val realmListFromArgsEmpty: RealmList<String> = realmListOf()
         assertTrue(realmListFromArgsEmpty.isEmpty())
 
         val realmListFromArgs: RealmList<String> = realmListOf("1", "2")
@@ -83,15 +83,15 @@ class RealmListTests {
         val realmListFromEmptyCollection = emptyList<String>().toRealmList()
         assertTrue(realmListFromEmptyCollection.isEmpty())
 
-        val realmListFromSingleElementList = listOf<String>("1").toRealmList()
+        val realmListFromSingleElementList = listOf("1").toRealmList()
         assertContentEquals(listOf("1"), realmListFromSingleElementList)
-        val realmListFromSingleElementSet = setOf<String>("1").toRealmList()
-        assertContentEquals(listOf("1"), realmListFromSingleElementList)
+        val realmListFromSingleElementSet = setOf("1").toRealmList()
+        assertContentEquals(listOf("1"), realmListFromSingleElementSet)
 
-        val realmListFromMultiElementCollection = setOf<String>("1", "2").toRealmList()
+        val realmListFromMultiElementCollection = setOf("1", "2").toRealmList()
         assertContentEquals(listOf("1", "2"), realmListFromMultiElementCollection)
 
-        val realmListFromIterator = IntRange(0, 2).toRealmList()
+        val realmListFromIterator = (0..2).toRealmList()
         assertContentEquals(listOf(0, 1, 2), realmListFromIterator)
     }
 


### PR DESCRIPTION
The implementations for both JVM and native were not aligned - see https://youtrack.jetbrains.com/issue/KT-47211
This has been fixed so the manual check is no longer needed.