### PR TITLE
Synchronously process project configurations to avoid exceptions when running parallel builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.9.0 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* Added API for inspecting the schema of the realm with `BaseRealm.schema()` ([#238](https://github.com/realm/realm-kotlin/issues/238)).
+
+### Fixed
+* None.
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10.
+  * Coroutines 1.5.2-native-mt.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 0.8.0 (2021-12-17)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.0 (YYYY-MM-DD)
+## 0.8.1 (2022-01-17)
 
 ### Breaking Changes
 * None.
@@ -7,7 +7,7 @@
 * Added API for inspecting the schema of the realm with `BaseRealm.schema()` ([#238](https://github.com/realm/realm-kotlin/issues/238)).
 
 ### Fixed
-* None.
+* Synchronously process project configurations to avoid exceptions when running parallel builds [#626](https://github.com/realm/realm-kotlin/issues/626).
 
 ### Compatibility
 * This release is compatible with:

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -17,7 +17,7 @@
 
 object Realm {
     val ciBuild = (System.getenv("JENKINS_HOME") != null)
-    const val version = "0.8.1-SNAPSHOT"
+    const val version = "0.9.0-SNAPSHOT"
     const val group = "io.realm.kotlin"
     const val projectUrl = "https://realm.io"
     const val pluginPortalId = "io.realm.kotlin"

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/ClassInfo.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/ClassInfo.kt
@@ -16,10 +16,18 @@
 
 package io.realm.internal.interop
 
-// FIXME API-INTERNAL Compiler does not pick up the actual if not in a separate file, so not
-//  following RealmEnums.kt structure, but might have to move anyway, so keeping the structure
-//  unaligned for now.
-actual enum class ClassFlag(override val nativeValue: Int) : NativeEnumerated {
-    RLM_CLASS_NORMAL(realm_class_flags_e.RLM_CLASS_NORMAL),
-    RLM_CLASS_EMBEDDED(realm_class_flags_e.RLM_CLASS_EMBEDDED),
+data class ClassInfo(
+    val name: String,
+    val primaryKey: String?,
+    val numProperties: Long,
+    val numComputedProperties: Long = 0,
+    val key: ClassKey = INVALID_CLASS_KEY,
+    val flags: Int = ClassFlags.RLM_CLASS_NORMAL
+) {
+    companion object {
+        // Convenience wrapper to ease maintaining compiler plugin
+        fun create(name: String, primaryKey: String?, numProperties: Long): ClassInfo {
+            return ClassInfo(name, primaryKey, numProperties, 0)
+        }
+    }
 }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/Link.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/Link.kt
@@ -20,7 +20,7 @@ package io.realm.internal.interop
 // FIXME Do we need a type variable here?
 // TODO OPTIMIZE Consider just wrapping a native pointer?
 class Link(
-    var tableKey: Long,
+    var classKey: ClassKey,
     // Could potentially be narrowed to Int, but Swig automatically returns long for the underlying
     // uint32_t, while cinterop uses UInt!?
     var objKey: Long,

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/PropertyInfo.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/PropertyInfo.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.interop
+
+import io.realm.internal.interop.PropertyFlags.RLM_PROPERTY_INDEXED
+import io.realm.internal.interop.PropertyFlags.RLM_PROPERTY_NORMAL
+import io.realm.internal.interop.PropertyFlags.RLM_PROPERTY_NULLABLE
+import io.realm.internal.interop.PropertyFlags.RLM_PROPERTY_PRIMARY_KEY
+
+@Suppress("LongParameterList")
+// TODO OPTIMIZE We could hold on to the native allocated memory and only read values lazily
+//  This would avoid transferring anything not need. A better option would probably be to
+//  implement as custom serializer, so that we could transfer the full struct in one bridge crossing.
+data class PropertyInfo( // Kotlin variant of realm_property_info
+    val name: String,
+    val publicName: String? = null,
+    val type: PropertyType,
+    val collectionType: CollectionType = CollectionType.RLM_COLLECTION_TYPE_NONE,
+    val linkTarget: String? = null,
+    val linkOriginPropertyName: String? = null,
+    val key: PropertyKey = INVALID_PROPERTY_KEY,
+    val flags: Int = RLM_PROPERTY_NORMAL
+) {
+    val isNullable: Boolean = flags and PropertyFlags.RLM_PROPERTY_NULLABLE != 0
+    val isPrimaryKey: Boolean = flags and PropertyFlags.RLM_PROPERTY_PRIMARY_KEY != 0
+    val isIndexed: Boolean = flags and PropertyFlags.RLM_PROPERTY_INDEXED != 0
+
+    companion object {
+        // Convenience wrapper to ease maintaining compiler plugin
+        fun create(
+            name: String,
+            publicName: String?,
+            type: PropertyType,
+            collectionType: CollectionType,
+            linkTarget: String?,
+            linkOriginPropertyName: String?,
+            isNullable: Boolean,
+            isPrimaryKey: Boolean,
+            isIndexed: Boolean
+        ): PropertyInfo {
+            val flags =
+                (if (isNullable) RLM_PROPERTY_NULLABLE else 0) or (if (isPrimaryKey) RLM_PROPERTY_PRIMARY_KEY else 0) or (if (isIndexed) RLM_PROPERTY_INDEXED else 0)
+            return PropertyInfo(
+                name,
+                publicName,
+                type,
+                collectionType,
+                linkTarget,
+                linkOriginPropertyName,
+                INVALID_PROPERTY_KEY,
+                flags
+            )
+        }
+    }
+}

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmEnums.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmEnums.kt
@@ -27,9 +27,9 @@ expect enum class SchemaMode {
     RLM_SCHEMA_MODE_MANUAL,
 }
 
-expect enum class ClassFlag {
-    RLM_CLASS_NORMAL,
-    RLM_CLASS_EMBEDDED,
+expect object ClassFlags {
+    val RLM_CLASS_NORMAL: Int
+    val RLM_CLASS_EMBEDDED: Int
 }
 
 expect enum class PropertyType {
@@ -45,20 +45,26 @@ expect enum class PropertyType {
     // Consider adding property methods to make it easier to do generic code on all types. Or is this exactly what collection type is about
     // fun isList()
     // fun isReference()
+    companion object {
+        fun from(nativeValue: Int): PropertyType
+    }
 }
 
 expect enum class CollectionType {
     RLM_COLLECTION_TYPE_NONE,
     RLM_COLLECTION_TYPE_LIST,
     RLM_COLLECTION_TYPE_SET,
-    RLM_COLLECTION_TYPE_DICTIONARY,
+    RLM_COLLECTION_TYPE_DICTIONARY;
+    companion object {
+        fun from(nativeValue: Int): CollectionType
+    }
 }
 
-expect enum class PropertyFlag {
-    RLM_PROPERTY_NORMAL,
-    RLM_PROPERTY_NULLABLE,
-    RLM_PROPERTY_PRIMARY_KEY,
-    RLM_PROPERTY_INDEXED,
+expect object PropertyFlags {
+    val RLM_PROPERTY_NORMAL: Int
+    val RLM_PROPERTY_NULLABLE: Int
+    val RLM_PROPERTY_PRIMARY_KEY: Int
+    val RLM_PROPERTY_INDEXED: Int
 }
 
 expect enum class SchemaValidationMode {

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmEnums.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmEnums.kt
@@ -42,9 +42,9 @@ actual enum class SchemaMode(override val nativeValue: realm_schema_mode) : Nati
     RLM_SCHEMA_MODE_MANUAL(realm_schema_mode_e.RLM_SCHEMA_MODE_MANUAL),
 }
 
-actual enum class ClassFlag(override val nativeValue: UInt) : NativeEnumerated {
-    RLM_CLASS_NORMAL(realm_wrapper.RLM_CLASS_NORMAL),
-    RLM_CLASS_EMBEDDED(realm_wrapper.RLM_CLASS_EMBEDDED),
+actual object ClassFlags {
+    actual val RLM_CLASS_NORMAL = realm_wrapper.RLM_CLASS_NORMAL.toInt()
+    actual val RLM_CLASS_EMBEDDED = realm_wrapper.RLM_CLASS_EMBEDDED.toInt()
 }
 
 actual enum class PropertyType(override val nativeValue: UInt) : NativeEnumerated {
@@ -54,21 +54,32 @@ actual enum class PropertyType(override val nativeValue: UInt) : NativeEnumerate
     RLM_PROPERTY_TYPE_OBJECT(realm_wrapper.RLM_PROPERTY_TYPE_OBJECT),
     RLM_PROPERTY_TYPE_FLOAT(realm_wrapper.RLM_PROPERTY_TYPE_FLOAT),
     RLM_PROPERTY_TYPE_DOUBLE(realm_wrapper.RLM_PROPERTY_TYPE_DOUBLE),
-    RLM_PROPERTY_TYPE_TIMESTAMP(realm_wrapper.RLM_PROPERTY_TYPE_TIMESTAMP),
+    RLM_PROPERTY_TYPE_TIMESTAMP(realm_wrapper.RLM_PROPERTY_TYPE_TIMESTAMP);
+
+    actual companion object {
+        actual fun from(nativeValue: Int): PropertyType {
+            return values().find { it.nativeValue == nativeValue.toUInt() } ?: error("Unknown property type: $nativeValue")
+        }
+    }
 }
 
 actual enum class CollectionType(override val nativeValue: UInt) : NativeEnumerated {
     RLM_COLLECTION_TYPE_NONE(realm_wrapper.RLM_COLLECTION_TYPE_NONE),
     RLM_COLLECTION_TYPE_LIST(realm_wrapper.RLM_COLLECTION_TYPE_LIST),
     RLM_COLLECTION_TYPE_SET(realm_wrapper.RLM_COLLECTION_TYPE_SET),
-    RLM_COLLECTION_TYPE_DICTIONARY(realm_wrapper.RLM_COLLECTION_TYPE_DICTIONARY),
+    RLM_COLLECTION_TYPE_DICTIONARY(realm_wrapper.RLM_COLLECTION_TYPE_DICTIONARY);
+    actual companion object {
+        actual fun from(nativeValue: Int): CollectionType {
+            return values().find { it.nativeValue == nativeValue.toUInt() } ?: error("Unknown collection type: $nativeValue")
+        }
+    }
 }
 
-actual enum class PropertyFlag(override val nativeValue: UInt) : NativeEnumerated {
-    RLM_PROPERTY_NORMAL(realm_wrapper.RLM_PROPERTY_NORMAL),
-    RLM_PROPERTY_NULLABLE(realm_wrapper.RLM_PROPERTY_NULLABLE),
-    RLM_PROPERTY_PRIMARY_KEY(realm_wrapper.RLM_PROPERTY_PRIMARY_KEY),
-    RLM_PROPERTY_INDEXED(realm_wrapper.RLM_PROPERTY_INDEXED),
+actual object PropertyFlags {
+    actual val RLM_PROPERTY_NORMAL: Int = realm_wrapper.RLM_PROPERTY_NORMAL.toInt()
+    actual val RLM_PROPERTY_NULLABLE: Int = realm_wrapper.RLM_PROPERTY_NULLABLE.toInt()
+    actual val RLM_PROPERTY_PRIMARY_KEY: Int = realm_wrapper.RLM_PROPERTY_PRIMARY_KEY.toInt()
+    actual val RLM_PROPERTY_INDEXED: Int = realm_wrapper.RLM_PROPERTY_INDEXED.toInt()
 }
 
 actual enum class SchemaValidationMode(override val nativeValue: UInt) : NativeEnumerated {

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -19,6 +19,7 @@
 package io.realm.internal.interop
 
 import io.realm.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
+import io.realm.internal.interop.RealmInterop.propertyInfo
 import io.realm.internal.interop.sync.AuthProvider
 import io.realm.internal.interop.sync.CoreUserState
 import io.realm.internal.interop.sync.MetadataMode
@@ -38,11 +39,13 @@ import kotlinx.cinterop.CPointerVar
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.MemScope
 import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.UIntVar
 import kotlinx.cinterop.ULongVar
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.cValue
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.cstr
 import kotlinx.cinterop.get
 import kotlinx.cinterop.getBytes
@@ -63,6 +66,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import platform.posix.posix_errno
 import platform.posix.pthread_threadid_np
+import platform.posix.size_tVar
 import platform.posix.strerror
 import platform.posix.uint8_tVar
 import realm_wrapper.realm_app_error_t
@@ -94,6 +98,9 @@ import realm_wrapper.realm_version_id_t
 import kotlin.collections.set
 import kotlin.native.concurrent.freeze
 import kotlin.native.internal.createCleaner
+
+actual val INVALID_CLASS_KEY: ClassKey by lazy { ClassKey(realm_wrapper.RLM_INVALID_CLASS_KEY.toLong()) }
+actual val INVALID_PROPERTY_KEY: PropertyKey by lazy { PropertyKey(realm_wrapper.RLM_INVALID_PROPERTY_KEY) }
 
 private fun throwOnError() {
     memScoped {
@@ -231,21 +238,21 @@ actual object RealmInterop {
         return realm_wrapper.realm_get_library_version().safeKString("library_version")
     }
 
-    actual fun realm_schema_new(tables: List<Table>): NativePointer {
-        val count = tables.size
+    actual fun realm_schema_new(schema: List<Pair<ClassInfo, List<PropertyInfo>>>): NativePointer {
+        val count = schema.size
+
         memScoped {
             val cclasses = allocArray<realm_class_info_t>(count)
             val cproperties = allocArray<CPointerVar<realm_property_info_t>>(count)
-            for ((i, clazz) in tables.withIndex()) {
-                val properties = clazz.properties
+            for ((i, entry) in schema.withIndex()) {
+                val (clazz, properties) = entry
                 // Class
                 cclasses[i].apply {
                     name = clazz.name.cstr.ptr
                     primary_key = (clazz.primaryKey ?: "").cstr.ptr
                     num_properties = properties.size.toULong()
                     num_computed_properties = 0U
-                    flags =
-                        clazz.flags.fold(0) { flags, element -> flags or element.nativeValue.toInt() }
+                    flags = clazz.flags
                 }
                 cproperties[i] =
                     allocArray<realm_property_info_t>(properties.size).getPointer(memScope)
@@ -253,12 +260,11 @@ actual object RealmInterop {
                     cproperties[i]!![j].apply {
                         name = property.name.cstr.ptr
                         public_name = "".cstr.ptr
-                        link_target = property.linkTarget.cstr.ptr
+                        link_target = property.linkTarget?.cstr?.ptr ?: "".cstr.ptr
                         link_origin_property_name = "".cstr.ptr
                         type = property.type.nativeValue
                         collection_type = property.collectionType.nativeValue
-                        flags =
-                            property.flags.fold(0) { flags, element -> flags or element.nativeValue.toInt() }
+                        flags = property.flags
                     }
                 }
             }
@@ -387,6 +393,94 @@ actual object RealmInterop {
         return realm_wrapper.realm_get_num_classes(realm.cptr()).toLong()
     }
 
+    actual fun realm_get_class_keys(realm: NativePointer): List<ClassKey> {
+        memScoped {
+            val max = realm_get_num_classes(realm)
+            val keys = allocArray<UIntVar>(max)
+            val outCount = alloc<size_tVar>()
+            checkedBooleanResult(realm_wrapper.realm_get_class_keys(realm.cptr(), keys, max.convert(), outCount.ptr))
+            if (max != outCount.value.toLong()) {
+                error("Invalid schema: Insufficient keys; got ${outCount.value}, expected $max")
+            }
+            return (0 until max).map { ClassKey(keys[it].toLong()) }
+        }
+    }
+
+    actual fun realm_find_class(realm: NativePointer, name: String): ClassKey? {
+        memScoped {
+            val found = alloc<BooleanVar>()
+            val classInfo = alloc<realm_class_info_t>()
+            checkedBooleanResult(
+                realm_wrapper.realm_find_class(
+                    realm.cptr(),
+                    name,
+                    found.ptr,
+                    classInfo.ptr
+                )
+            )
+            return if (found.value) {
+                ClassKey(classInfo.key.toLong())
+            } else {
+                null
+            }
+        }
+    }
+
+    actual fun realm_get_class(realm: NativePointer, classKey: ClassKey): ClassInfo {
+        memScoped {
+            val classInfo = alloc<realm_class_info_t>()
+            realm_wrapper.realm_get_class(realm.cptr(), classKey.key.toUInt(), classInfo.ptr)
+            return with(classInfo) {
+                ClassInfo(
+                    name.safeKString("name"),
+                    primary_key?.toKString(),
+                    num_properties.convert(),
+                    num_computed_properties.convert(),
+                    ClassKey(key.toLong()),
+                    flags
+                )
+            }
+        }
+    }
+
+    actual fun realm_get_class_properties(
+        realm: NativePointer,
+        classKey: ClassKey,
+        max: Long
+    ): List<PropertyInfo> {
+        memScoped {
+            val properties = allocArray<realm_property_info_t>(max)
+            val outCount = alloc<size_tVar>()
+            realm_wrapper.realm_get_class_properties(
+                realm.cptr(),
+                classKey.key.convert(),
+                properties,
+                max.convert(),
+                outCount.ptr
+            )
+            outCount.value.toLong().let { count ->
+                return if (count > 0) {
+                    (0 until outCount.value.toLong()).map {
+                        with(properties[it]) {
+                            PropertyInfo(
+                                name.safeKString("name"),
+                                public_name?.toKString(),
+                                PropertyType.from(type.toInt()),
+                                CollectionType.from(collection_type.toInt()),
+                                link_target?.toKString(),
+                                link_origin_property_name?.toKString(),
+                                PropertyKey(key),
+                                flags
+                            )
+                        }
+                    }
+                } else {
+                    emptyList()
+                }
+            }
+        }
+    }
+
     actual fun realm_release(p: NativePointer) {
         realm_wrapper.realm_release((p as CPointerWrapper).ptr)
     }
@@ -413,25 +507,6 @@ actual object RealmInterop {
 
     actual fun realm_is_in_transaction(realm: NativePointer): Boolean {
         return realm_wrapper.realm_is_writable(realm.cptr())
-    }
-
-    actual fun realm_find_class(realm: NativePointer, name: String): ClassKey {
-        memScoped {
-            val found = alloc<BooleanVar>()
-            val classInfo = alloc<realm_class_info_t>()
-            checkedBooleanResult(
-                realm_wrapper.realm_find_class(
-                    realm.cptr(),
-                    name,
-                    found.ptr,
-                    classInfo.ptr
-                )
-            )
-            if (!found.value) {
-                throw IllegalArgumentException("Class \"$name\" not found")
-            }
-            return ClassKey(classInfo.key.toLong())
-        }
     }
 
     actual fun realm_object_create(realm: NativePointer, classKey: ClassKey): NativePointer {
@@ -479,17 +554,17 @@ actual object RealmInterop {
         val link: CValue<realm_link_t> =
             realm_wrapper.realm_object_as_link(obj.cptr())
         link.useContents {
-            return Link(this.target_table.toLong(), this.target)
+            return Link(ClassKey(this.target_table.toLong()), this.target)
         }
     }
 
-    actual fun realm_get_col_key(realm: NativePointer, table: String, col: String): ColumnKey {
+    actual fun realm_get_col_key(realm: NativePointer, className: String, col: String): PropertyKey {
         memScoped {
-            return ColumnKey(propertyInfo(realm, classInfo(realm, table), col).key)
+            return PropertyKey(propertyInfo(realm, classInfo(realm, className), col).key)
         }
     }
 
-    actual fun <T> realm_get_value(obj: NativePointer, key: ColumnKey): T {
+    actual fun <T> realm_get_value(obj: NativePointer, key: PropertyKey): T {
         memScoped {
             val value: realm_value_t = alloc()
             checkedBooleanResult(realm_wrapper.realm_get_value(obj.cptr(), key.key, value.ptr))
@@ -520,7 +595,7 @@ actual object RealmInterop {
         } as T
     }
 
-    actual fun <T> realm_set_value(o: NativePointer, key: ColumnKey, value: T, isDefault: Boolean) {
+    actual fun <T> realm_set_value(o: NativePointer, key: PropertyKey, value: T, isDefault: Boolean) {
         memScoped {
             checkedBooleanResult(
                 realm_wrapper.realm_set_value_by_ref(
@@ -533,7 +608,7 @@ actual object RealmInterop {
         }
     }
 
-    actual fun realm_get_list(obj: NativePointer, key: ColumnKey): NativePointer {
+    actual fun realm_get_list(obj: NativePointer, key: PropertyKey): NativePointer {
         return CPointerWrapper(realm_wrapper.realm_get_list(obj.cptr(), key.key))
     }
 
@@ -680,7 +755,7 @@ actual object RealmInterop {
 
     actual fun realm_query_parse(
         realm: NativePointer,
-        table: String,
+        className: String,
         query: String,
         vararg args: Any?
     ): NativePointer {
@@ -695,7 +770,7 @@ actual object RealmInterop {
             return CPointerWrapper(
                 realm_wrapper.realm_query_parse(
                     realm.cptr(),
-                    classInfo(realm, table).key,
+                    classInfo(realm, className).key,
                     query,
                     count.toULong(),
                     cArgs
@@ -721,7 +796,7 @@ actual object RealmInterop {
             if (value.type != realm_value_type.RLM_TYPE_LINK) {
                 error("Query did not return link but ${value.type}")
             }
-            return Link(value.link.target, value.link.target_table.toLong())
+            return Link(ClassKey(value.link.target), value.link.target_table.toLong())
         }
     }
 
@@ -767,7 +842,7 @@ actual object RealmInterop {
         val ptr = checkedPointerResult(
             realm_wrapper.realm_get_object(
                 realm.cptr(),
-                link.tableKey.toUInt(),
+                link.classKey.key.toUInt(),
                 link.objKey
             )
         )
@@ -1213,7 +1288,7 @@ actual object RealmInterop {
         if (this.type != realm_value_type.RLM_TYPE_LINK) {
             error("Value is not of type link: $this.type")
         }
-        return Link(this.link.target_table.toLong(), this.link.target)
+        return Link(ClassKey(this.link.target_table.toLong()), this.link.target)
     }
 
     private fun CPointer<ByteVar>?.safeKString(identifier: String? = null): String {

--- a/packages/cinterop/src/darwinTest/kotlin/io/realm/test/CinteropTest.kt
+++ b/packages/cinterop/src/darwinTest/kotlin/io/realm/test/CinteropTest.kt
@@ -16,15 +16,15 @@
 
 package io.realm.test
 
-import io.realm.internal.interop.ClassFlag
+import io.realm.internal.interop.ClassFlags
+import io.realm.internal.interop.ClassInfo
 import io.realm.internal.interop.CollectionType
-import io.realm.internal.interop.Property
-import io.realm.internal.interop.PropertyFlag
+import io.realm.internal.interop.PropertyFlags
+import io.realm.internal.interop.PropertyInfo
 import io.realm.internal.interop.PropertyType
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.interop.SchemaMode
 import io.realm.internal.interop.SchemaValidationMode
-import io.realm.internal.interop.Table
 import io.realm.internal.interop.coreErrorAsThrowable
 import io.realm.internal.interop.set
 import io.realm.internal.interop.toKString
@@ -145,17 +145,17 @@ class CinteropTest {
     @Test
     fun cinterop_realmInterop() {
         val tables = listOf(
-            Table(
+            ClassInfo(
                 name = "foo",
                 primaryKey = "",
-                flags = setOf(ClassFlag.RLM_CLASS_NORMAL),
-                properties = listOf(
-                    Property(
-                        name = "int",
-                        type = PropertyType.RLM_PROPERTY_TYPE_INT,
-                        collectionType = CollectionType.RLM_COLLECTION_TYPE_NONE,
-                        flags = setOf(PropertyFlag.RLM_PROPERTY_NORMAL)
-                    )
+                flags = ClassFlags.RLM_CLASS_NORMAL,
+                numProperties = 1,
+            ) to listOf(
+                PropertyInfo(
+                    name = "int",
+                    type = PropertyType.RLM_PROPERTY_TYPE_INT,
+                    collectionType = CollectionType.RLM_COLLECTION_TYPE_NONE,
+                    flags = PropertyFlags.RLM_PROPERTY_NORMAL,
                 )
             )
         )

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/ClassFlags.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/ClassFlags.kt
@@ -16,12 +16,7 @@
 
 package io.realm.internal.interop
 
-// FIXME API-INTERNAL Compiler does not pick up the actual if not in a separate file, so not
-//  following RealmEnums.kt structure, but might have to move anyway, so keeping the structure
-//  unaligned for now.
-actual enum class PropertyFlag(override val nativeValue: Int) : NativeEnumerated {
-    RLM_PROPERTY_NORMAL(realm_property_flags_e.RLM_PROPERTY_NORMAL),
-    RLM_PROPERTY_NULLABLE(realm_property_flags_e.RLM_PROPERTY_NULLABLE),
-    RLM_PROPERTY_PRIMARY_KEY(realm_property_flags_e.RLM_PROPERTY_PRIMARY_KEY),
-    RLM_PROPERTY_INDEXED(realm_property_flags_e.RLM_PROPERTY_INDEXED),
+actual object ClassFlags {
+    actual val RLM_CLASS_NORMAL = realm_class_flags_e.RLM_CLASS_NORMAL
+    actual val RLM_CLASS_EMBEDDED = realm_class_flags_e.RLM_CLASS_EMBEDDED
 }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/CollectionType.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/CollectionType.kt
@@ -23,5 +23,11 @@ actual enum class CollectionType(override val nativeValue: Int) : NativeEnumerat
     RLM_COLLECTION_TYPE_NONE(realm_collection_type_e.RLM_COLLECTION_TYPE_NONE),
     RLM_COLLECTION_TYPE_LIST(realm_collection_type_e.RLM_COLLECTION_TYPE_LIST),
     RLM_COLLECTION_TYPE_SET(realm_collection_type_e.RLM_COLLECTION_TYPE_SET),
-    RLM_COLLECTION_TYPE_DICTIONARY(realm_collection_type_e.RLM_COLLECTION_TYPE_DICTIONARY),
+    RLM_COLLECTION_TYPE_DICTIONARY(realm_collection_type_e.RLM_COLLECTION_TYPE_DICTIONARY);
+
+    actual companion object {
+        actual fun from(nativeValue: Int): CollectionType {
+            return values().find { it.nativeValue == nativeValue } ?: error("Unknown collection type: $nativeValue")
+        }
+    }
 }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/PropertyFlags.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/PropertyFlags.kt
@@ -16,16 +16,9 @@
 
 package io.realm.internal.interop
 
-// FIXME API-SCHEMA Platform independent property definition. Maybe rework into utility method
-//  called in Realm object's companion schema mechanism depending on how we relate this to the
-//  actual schema/runtime realm_property_info_t.
-@Suppress("LongParameterList")
-data class Property(
-    val name: String,
-    val publicName: String = "",
-    val type: PropertyType,
-    val collectionType: CollectionType = CollectionType.RLM_COLLECTION_TYPE_NONE,
-    val linkTarget: String = "",
-    val linkOriginPropertyName: String = "",
-    val flags: Set<PropertyFlag> = setOf(PropertyFlag.RLM_PROPERTY_NORMAL)
-)
+actual object PropertyFlags {
+    actual val RLM_PROPERTY_NORMAL: Int = realm_property_flags_e.RLM_PROPERTY_NORMAL
+    actual val RLM_PROPERTY_NULLABLE: Int = realm_property_flags_e.RLM_PROPERTY_NULLABLE
+    actual val RLM_PROPERTY_PRIMARY_KEY: Int = realm_property_flags_e.RLM_PROPERTY_PRIMARY_KEY
+    actual val RLM_PROPERTY_INDEXED: Int = realm_property_flags_e.RLM_PROPERTY_INDEXED
+}

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/PropertyType.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/PropertyType.kt
@@ -29,9 +29,9 @@ actual enum class PropertyType(override val nativeValue: Int) : NativeEnumerated
     RLM_PROPERTY_TYPE_TIMESTAMP(realm_property_type_e.RLM_PROPERTY_TYPE_TIMESTAMP);
 
     // TODO OPTIMIZE
-    companion object {
-        fun of(i: Int): PropertyType {
-            return values().find { it.nativeValue == i } ?: error("Unknown type: $i")
+    actual companion object {
+        actual fun from(nativeValue: Int): PropertyType {
+            return values().find { it.nativeValue == nativeValue } ?: error("Unknown property type: $nativeValue")
         }
     }
 }

--- a/packages/gradle-plugin/src/main/kotlin/io/realm/gradle/RealmAnalytics.kt
+++ b/packages/gradle-plugin/src/main/kotlin/io/realm/gradle/RealmAnalytics.kt
@@ -83,6 +83,7 @@ internal class RealmAnalytics : TaskExecutionAdapter() {
         }
     }
 
+    @Synchronized
     private fun sendMetricIfNeeded(project: Project) {
         if (!METRIC_PROCESSED) {
             val disableAnalytics: Boolean = project.gradle.startParameter.isOffline || "true".equals(System.getenv()["REALM_DISABLE_ANALYTICS"], ignoreCase = true)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/BaseRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/BaseRealm.kt
@@ -14,6 +14,8 @@
  */
 package io.realm
 
+import io.realm.schema.RealmSchema
+
 /**
  * Base class for all Realm instances ([Realm] and [MutableRealm]).
  */
@@ -22,6 +24,13 @@ interface BaseRealm : Versioned {
      * Configuration used to configure this Realm instance.
      */
     val configuration: Configuration
+
+    /**
+     * Returns an immutable schema of the realm.
+     *
+     * @return the schema of the realm.
+     */
+    fun schema(): RealmSchema
 
     /**
      * Returns the current number of active versions in the Realm file. A large number of active versions can have

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/BaseRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/BaseRealmImpl.kt
@@ -22,6 +22,8 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
+import io.realm.internal.schema.RealmSchemaImpl
+import io.realm.schema.RealmSchema
 import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
@@ -60,6 +62,14 @@ abstract class BaseRealmImpl internal constructor(
 
     init {
         log.info("Realm opened: ${configuration.path}")
+    }
+
+    // FIXME Currently constructs a new instance on each invocation. We could cache this pr. schema
+    //  update, but requires that we initialize it all on the actual schema update to allow freezing
+    //  it. If we make the schema backed by the actual realm_class_info_t/realm_property_info_t
+    //  initialization it would probably be acceptable to initialize on schema updates
+    override fun schema(): RealmSchema {
+        return RealmSchemaImpl.fromRealm(realmReference)
     }
 
     open fun <T : RealmObject> objects(clazz: KClass<T>): RealmResults<T> {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/ConfigurationImpl.kt
@@ -87,7 +87,11 @@ open class ConfigurationImpl constructor(
         RealmInterop.realm_config_set_schema_mode(nativeConfig, schemaMode)
         RealmInterop.realm_config_set_schema_version(config = nativeConfig, version = schemaVersion)
 
-        val nativeSchema = RealmInterop.realm_schema_new(mapOfKClassWithCompanion.values.map { it.`$realm$schema`() })
+        val nativeSchema = RealmInterop.realm_schema_new(
+            mapOfKClassWithCompanion.values.map { it ->
+                it.`$realm$schema`().let { it.cinteropClass to it.cinteropProperties }
+            }
+        )
 
         RealmInterop.realm_config_set_schema(nativeConfig, nativeSchema)
         RealmInterop.realm_config_set_max_number_of_active_versions(nativeConfig, maxNumberOfActiveVersions)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
@@ -42,8 +42,8 @@ internal class UnmanagedRealmList<E> : RealmList<E>, MutableList<E> by mutableLi
  * Implementation for managed lists, backed by Realm.
  */
 internal class ManagedRealmList<E>(
-    val nativePointer: NativePointer,
-    val metadata: ListOperatorMetadata
+    private val nativePointer: NativePointer,
+    private val metadata: ListOperatorMetadata
 ) : AbstractMutableList<E>(), RealmList<E>, Observable<ManagedRealmList<E>> {
 
     private val operator = ListOperator<E>(metadata)
@@ -74,15 +74,6 @@ internal class ManagedRealmList<E>(
         } catch (exception: RealmCoreException) {
             throw genericRealmCoreExceptionHandler("Could not add element at list index $index", exception)
         }
-    }
-
-    // FIXME bug in AbstractMutableList.addAll native implementation:
-    //  https://youtrack.jetbrains.com/issue/KT-47211
-    //  Remove this method once the native implementation has a check for valid index
-    override fun addAll(index: Int, elements: Collection<E>): Boolean {
-        metadata.realm.checkClosed()
-        rangeCheckForAdd(index)
-        return super.addAll(index, elements)
     }
 
     override fun clear() {
@@ -152,12 +143,6 @@ internal class ManagedRealmList<E>(
     // TODO from LifeCycle interface
     internal fun isValid(): Boolean {
         return RealmInterop.realm_list_is_valid(nativePointer)
-    }
-
-    private fun rangeCheckForAdd(index: Int) {
-        if (index < 0 || index > size) {
-            throw IndexOutOfBoundsException("Index: '$index', Size: '$size'")
-        }
     }
 }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectCompanion.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectCompanion.kt
@@ -16,7 +16,7 @@
 
 package io.realm.internal
 
-import io.realm.internal.interop.Table
+import io.realm.internal.schema.RealmClassImpl
 import kotlin.reflect.KMutableProperty1
 
 // TODO MEDIATOR/API-INTERNAL Consider adding type parameter for the class
@@ -24,6 +24,6 @@ import kotlin.reflect.KMutableProperty1
 interface RealmObjectCompanion {
     val `$realm$fields`: List<KMutableProperty1<*, *>>?
     val `$realm$primaryKey`: KMutableProperty1<*, *>?
-    fun `$realm$schema`(): Table
+    fun `$realm$schema`(): RealmClassImpl
     fun `$realm$newInstance`(): Any
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -19,9 +19,9 @@ package io.realm.internal
 import io.realm.RealmInstant
 import io.realm.RealmList
 import io.realm.RealmObject
-import io.realm.internal.interop.ColumnKey
 import io.realm.internal.interop.Link
 import io.realm.internal.interop.NativePointer
+import io.realm.internal.interop.PropertyKey
 import io.realm.internal.interop.RealmCoreException
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.interop.Timestamp
@@ -88,7 +88,7 @@ object RealmObjectHelper {
         val realm: RealmReference =
             obj.`$realm$Owner` ?: throw IllegalStateException("Invalid/deleted object")
         val o = obj.`$realm$ObjectPointer` ?: throw IllegalStateException("Invalid/deleted object")
-        val key: ColumnKey =
+        val key: PropertyKey =
             RealmInterop.realm_get_col_key(realm.dbPointer, obj.`$realm$TableName`!!, col)
         val listPtr: NativePointer = RealmInterop.realm_get_list(o, key)
         val clazz: KClass<*> = R::class

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/RealmClassImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/RealmClassImpl.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.schema
+
+import io.realm.internal.interop.ClassInfo
+import io.realm.internal.interop.PropertyInfo
+import io.realm.schema.RealmClass
+import io.realm.schema.RealmProperty
+import io.realm.schema.ValuePropertyType
+
+data class RealmClassImpl(
+    // Optimization: Store the schema in the C-API alike structure directly from compiler plugin to
+    // avoid unnecessary repeated initializations for realm_schema_new
+    val cinteropClass: ClassInfo,
+    val cinteropProperties: List<PropertyInfo>
+) : RealmClass {
+
+    override val name: String = cinteropClass.name
+    override val properties: Collection<RealmProperty> = cinteropProperties.map {
+        RealmPropertyImpl.fromCoreProperty(it)
+    }
+    override val primaryKey: RealmProperty? = properties.firstOrNull {
+        it.type.run { this is ValuePropertyType && isPrimaryKey }
+    }
+
+    override fun get(key: String): RealmProperty? = properties.firstOrNull { it.name == key }
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/RealmPropertyImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/RealmPropertyImpl.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.schema
+
+import io.realm.internal.interop.PropertyInfo
+import io.realm.schema.ListPropertyType
+import io.realm.schema.RealmProperty
+import io.realm.schema.RealmPropertyType
+import io.realm.schema.ValuePropertyType
+
+internal data class RealmPropertyImpl(
+    override var name: String,
+    override var type: RealmPropertyType,
+) : RealmProperty {
+
+    override val isNullable: Boolean = when (type) {
+        is ValuePropertyType -> type.isNullable
+        is ListPropertyType -> false
+    }
+
+    companion object {
+        fun fromCoreProperty(corePropertyImpl: PropertyInfo): RealmPropertyImpl {
+            return with(corePropertyImpl) {
+                val storageType =
+                    io.realm.internal.schema.RealmStorageTypeImpl.fromCorePropertyType(type)
+                val type = when (collectionType) {
+                    io.realm.internal.interop.CollectionType.RLM_COLLECTION_TYPE_NONE -> ValuePropertyType(
+                        storageType,
+                        isNullable,
+                        isPrimaryKey,
+                        isIndexed
+                    )
+                    io.realm.internal.interop.CollectionType.RLM_COLLECTION_TYPE_LIST -> ListPropertyType(
+                        storageType,
+                        isNullable
+                    )
+                    else -> error("Unsupported type $collectionType")
+                }
+                RealmPropertyImpl(name, type)
+            }
+        }
+    }
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/RealmSchemaImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/RealmSchemaImpl.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.schema
+
+import io.realm.internal.RealmReference
+import io.realm.internal.interop.RealmInterop
+import io.realm.schema.RealmClass
+import io.realm.schema.RealmSchema
+
+data class RealmSchemaImpl(
+    override val classes: Collection<RealmClass>
+) : RealmSchema {
+
+    override fun get(className: String): RealmClass? = classes.firstOrNull { it.name == className }
+
+    companion object {
+        fun fromRealm(realmReference: RealmReference): RealmSchemaImpl {
+            val dbPointer = realmReference.dbPointer
+            val classKeys = RealmInterop.realm_get_class_keys(dbPointer)
+            return RealmSchemaImpl(
+                classKeys.map {
+                    val table = RealmInterop.realm_get_class(dbPointer, it)
+                    val properties =
+                        RealmInterop.realm_get_class_properties(dbPointer, it, table.numProperties)
+                    RealmClassImpl(table, properties)
+                }
+            )
+        }
+    }
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/RealmStorageTypeImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/RealmStorageTypeImpl.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.schema
+
+import io.realm.schema.RealmStorageType
+
+object RealmStorageTypeImpl {
+    fun fromCorePropertyType(type: io.realm.internal.interop.PropertyType): RealmStorageType {
+        return when (type) {
+            io.realm.internal.interop.PropertyType.RLM_PROPERTY_TYPE_INT -> RealmStorageType.INT
+            io.realm.internal.interop.PropertyType.RLM_PROPERTY_TYPE_BOOL -> RealmStorageType.BOOL
+            io.realm.internal.interop.PropertyType.RLM_PROPERTY_TYPE_STRING -> RealmStorageType.STRING
+            io.realm.internal.interop.PropertyType.RLM_PROPERTY_TYPE_OBJECT -> RealmStorageType.OBJECT
+            io.realm.internal.interop.PropertyType.RLM_PROPERTY_TYPE_FLOAT -> RealmStorageType.FLOAT
+            io.realm.internal.interop.PropertyType.RLM_PROPERTY_TYPE_DOUBLE -> RealmStorageType.DOUBLE
+            io.realm.internal.interop.PropertyType.RLM_PROPERTY_TYPE_TIMESTAMP -> RealmStorageType.TIMESTAMP
+            else -> error("Unknown storage type: $type")
+        }
+    }
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmClass.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmClass.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.schema
+
+/**
+ * A [RealmClass] describing the object model of a specific class.
+ */
+interface RealmClass {
+    /**
+     * The name of the object model.
+     */
+    val name: String
+
+    /**
+     * The properties of the object model.
+     */
+    val properties: Collection<RealmProperty>
+
+    /**
+     * The primary key property of the object model or `null` if the object model doesn't have a
+     * primary key.
+     */
+    val primaryKey: RealmProperty?
+
+    /**
+     * Index operator to lookup a specific [RealmProperty] from it's property name.
+     *
+     * @return the [RealmProperty] with the given `propertyName` or `null` if no such property exists.
+     */
+    operator fun get(key: String): RealmProperty?
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmProperty.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmProperty.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.schema
+
+/**
+ * A [RealmProperty] describes the properties of a class property in the object model.
+ */
+interface RealmProperty {
+    /**
+     * Returns the name of the property in the object model.
+     */
+    val name: String
+
+    /**
+     * Returns the type of the property in the object model.
+     */
+    val type: RealmPropertyType
+
+    /**
+     * Returns whether or not the property is allowed to be null in the corresponding `RealmObject`
+     *
+     * For [ValuePropertyType] this will be the same as [RealmPropertyType.isNullable]. For all
+     * other property types it will always be false.
+     */
+    val isNullable: Boolean
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmPropertyType.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmPropertyType.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.schema
+
+import kotlin.reflect.KClass
+
+/**
+ * A [RealmPropertyType] describes the type of a specific property in the object model.
+ */
+sealed interface RealmPropertyType {
+    /**
+     * The type that is used when storing the property values in the realm.
+     */
+    val storageType: RealmStorageType
+
+    /**
+     * Indicates whether the storage element can be `null`.
+     */
+    val isNullable: Boolean
+
+    companion object {
+        // TODO Not as good as RealmPropertyType::class.sealedClasses as this has to be manually
+        //  adjusted, but since KClass<T>.sealedClasses is only available for JVM this is the next
+        //  best thing (at least uncovered until now ... without writing a compiler plugin) that
+        //  allows to define the options centrally and use it to verify exhaustiveness in tests.
+        //  JUST DON'T FORGET TO UPDATE ON WHEN ADDING NEW SUBCLASSES :see_no_evil:
+        //  We could do a JVM test that verifies that it is exhaustive :thinking:
+        internal val subTypes: Set<KClass<out RealmPropertyType>> = setOf(ValuePropertyType::class, ListPropertyType::class)
+    }
+}
+
+/**
+ * A [ValuePropertyType] describes singular value properties.
+ */
+data class ValuePropertyType(
+    override val storageType: RealmStorageType,
+    override val isNullable: Boolean,
+    /**
+     * Indicates whether this property is the primary key of the class in the object model.
+     */
+    val isPrimaryKey: Boolean,
+    /**
+     * Indicates whether there is an index associated with this property.
+     */
+    val isIndexed: Boolean
+) : RealmPropertyType
+
+data class ListPropertyType(
+    override val storageType: RealmStorageType,
+    override val isNullable: Boolean = false
+) : RealmPropertyType

--- a/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmSchema.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmSchema.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.schema
+
+/**
+ * A **schema** that describes the object model of the underlying realm.
+ */
+// FIXME Find out where the transaction version of the schema fits into the API ... maybe as part of
+//  https://github.com/realm/realm-kotlin/issues/600
+interface RealmSchema {
+    /**
+     * Collection of the [RealmClass]es of the schema.
+     */
+    val classes: Collection<RealmClass>
+
+    /**
+     * Index operator to lookup a specific [RealmClass] from it's class name.
+     *
+     * @return the [RealmClass] with the given `className` or `null` if no such class exists.
+     */
+    operator fun get(className: String): RealmClass?
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmStorageType.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/schema/RealmStorageType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Realm Inc.
+ * Copyright 2021 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package io.realm.internal.interop
+package io.realm.schema
 
-// FIXME API-SCHEMA Platform independent class definition. Maybe rework into utility method called in Realm
-//  object's companion schema mechanism depending on how we relate this to the actual schema/runtime
-//  realm_class_info_t.
-data class Table(
-    val name: String,
-    val primaryKey: String?,
-    val flags: Set<ClassFlag> = setOf(ClassFlag.RLM_CLASS_NORMAL),
-    val properties: List<Property>
-)
+/**
+ * The various types that are used when storing the property values in the realm.
+ */
+enum class RealmStorageType {
+    BOOL,
+    INT,
+    STRING,
+    OBJECT,
+    FLOAT,
+    DOUBLE,
+    TIMESTAMP;
+}

--- a/packages/plugin-compiler/build.gradle.kts
+++ b/packages/plugin-compiler/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:${Versions.kotlinCompileTesting}")
     // Have to be mentioned explicitly as it is not an api dependency of library
-    testImplementation(project(":cinterop"))
+    implementation(project(":cinterop"))
     testImplementation(project(":library-base"))
     testImplementation(project(":library-sync"))
 }

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
@@ -32,7 +32,7 @@ internal object Names {
     val OBJECT_POINTER = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}ObjectPointer")
     // names must match `RealmObjectInternal` properties
     val REALM_OWNER = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}Owner")
-    val OBJECT_TABLE_NAME = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}TableName")
+    val OBJECT_CLASS_NAME = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}TableName")
     val OBJECT_IS_MANAGED = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}IsManaged")
     val MEDIATOR = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}Mediator")
 
@@ -47,11 +47,8 @@ internal object Names {
     val REALM_OBJECT_HELPER_SET_LIST = Name.identifier("setList")
 
     // Schema related names
-    val CLASS_FLAG_NORMAL = Name.identifier("RLM_CLASS_NORMAL")
-    val PROPERTY_FLAG_NORMAL = Name.identifier("RLM_PROPERTY_NORMAL")
-    val PROPERTY_FLAG_NULLABLE = Name.identifier("RLM_PROPERTY_NULLABLE")
-    val PROPERTY_FLAG_PRIMARY_KEY = Name.identifier("RLM_PROPERTY_PRIMARY_KEY")
-    val PROPERTY_FLAG_INDEX = Name.identifier("RLM_PROPERTY_INDEXED")
+    val CLASS_INFO_CREATE = Name.identifier("create")
+    val PROPERTY_INFO_CREATE = Name.identifier("create")
     val PROPERTY_TYPE_OBJECT = Name.identifier("RLM_PROPERTY_TYPE_OBJECT")
     val PROPERTY_COLLECTION_TYPE_NONE = Name.identifier("RLM_COLLECTION_TYPE_NONE")
     val PROPERTY_COLLECTION_TYPE_LIST = Name.identifier("RLM_COLLECTION_TYPE_LIST")
@@ -74,6 +71,7 @@ internal object FqNames {
     val REALM_OBJECT_HELPER = FqName("io.realm.internal.RealmObjectHelper")
     val REALM_REFERENCE = FqName("io.realm.internal.RealmReference")
     val REALM_MEDIATOR_INTERFACE = FqName("io.realm.internal.Mediator")
+    val REALM_CLASS_IMPL = FqName("io.realm.internal.schema.RealmClassImpl")
     val REALM_CONFIGURATION = FqName("io.realm.RealmConfiguration")
     val SYNC_CONFIGURATION = FqName("io.realm.mongodb.SyncConfiguration")
     val REALM_CONFIGURATION_BUILDER = FqName("io.realm.RealmConfiguration.Builder")
@@ -88,12 +86,10 @@ internal object FqNames {
     val KOTLIN_COLLECTIONS_MAPOF = FqName("kotlin.collections.mapOf")
     val KOTLIN_REFLECT_KPROPERTY1 = FqName("kotlin.reflect.KMutableProperty1")
     // Schema related types
-    val TABLE = FqName("io.realm.internal.interop.Table")
-    val CLASS_FLAG = FqName("io.realm.internal.interop.ClassFlag")
-    val PROPERTY = FqName("io.realm.internal.interop.Property")
+    val CLASS_INFO = FqName("io.realm.internal.interop.ClassInfo")
+    val PROPERTY_INFO = FqName("io.realm.internal.interop.PropertyInfo")
     val PROPERTY_TYPE = FqName("io.realm.internal.interop.PropertyType")
     val COLLECTION_TYPE = FqName("io.realm.internal.interop.CollectionType")
-    val PROPERTY_FLAG = FqName("io.realm.internal.interop.PropertyFlag")
     val PRIMARY_KEY_ANNOTATION = FqName("io.realm.annotations.PrimaryKey")
     val INDEX_ANNOTATION = FqName("io.realm.annotations.Index")
     val IGNORE_ANNOTATION = FqName("io.realm.annotations.Ignore")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/IrUtils.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/IrUtils.kt
@@ -67,10 +67,12 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.types.typeWith
+import org.jetbrains.kotlin.ir.util.companionObject
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.getPropertyGetter
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.isVararg
+import org.jetbrains.kotlin.ir.util.nameForIrSerialization
 import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -161,6 +163,13 @@ internal fun IrPluginContext.lookupConstructorInClass(
     return referenceConstructors(fqName).first {
         filter(it)
     }
+}
+
+internal fun <T> IrClass.lookupCompanionDeclaration(
+    name: Name
+): T {
+    return this.companionObject()?.declarations?.first { it.nameForIrSerialization == name } as T
+        ?: error("Cannot find companion method ${name.asString()} on ${this.name}")
 }
 
 object SchemaCollector {

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -16,12 +16,11 @@
 
 package io.realm.compiler
 
-import io.realm.compiler.FqNames.CLASS_FLAG
+import io.realm.compiler.FqNames.CLASS_INFO
 import io.realm.compiler.FqNames.COLLECTION_TYPE
 import io.realm.compiler.FqNames.INDEX_ANNOTATION
 import io.realm.compiler.FqNames.PRIMARY_KEY_ANNOTATION
-import io.realm.compiler.FqNames.PROPERTY
-import io.realm.compiler.FqNames.PROPERTY_FLAG
+import io.realm.compiler.FqNames.PROPERTY_INFO
 import io.realm.compiler.FqNames.PROPERTY_TYPE
 import io.realm.compiler.FqNames.REALM_INSTANT
 import io.realm.compiler.FqNames.REALM_MEDIATOR_INTERFACE
@@ -29,17 +28,14 @@ import io.realm.compiler.FqNames.REALM_MODEL_COMPANION
 import io.realm.compiler.FqNames.REALM_NATIVE_POINTER
 import io.realm.compiler.FqNames.REALM_OBJECT_INTERNAL_INTERFACE
 import io.realm.compiler.FqNames.REALM_REFERENCE
-import io.realm.compiler.FqNames.TABLE
-import io.realm.compiler.Names.CLASS_FLAG_NORMAL
+import io.realm.compiler.Names.CLASS_INFO_CREATE
 import io.realm.compiler.Names.MEDIATOR
+import io.realm.compiler.Names.OBJECT_CLASS_NAME
 import io.realm.compiler.Names.OBJECT_IS_MANAGED
 import io.realm.compiler.Names.OBJECT_POINTER
-import io.realm.compiler.Names.OBJECT_TABLE_NAME
 import io.realm.compiler.Names.PROPERTY_COLLECTION_TYPE_LIST
 import io.realm.compiler.Names.PROPERTY_COLLECTION_TYPE_NONE
-import io.realm.compiler.Names.PROPERTY_FLAG_INDEX
-import io.realm.compiler.Names.PROPERTY_FLAG_NULLABLE
-import io.realm.compiler.Names.PROPERTY_FLAG_PRIMARY_KEY
+import io.realm.compiler.Names.PROPERTY_INFO_CREATE
 import io.realm.compiler.Names.PROPERTY_TYPE_OBJECT
 import io.realm.compiler.Names.REALM_OBJECT_COMPANION_FIELDS_MEMBER
 import io.realm.compiler.Names.REALM_OBJECT_COMPANION_NEW_INSTANCE_METHOD
@@ -60,8 +56,11 @@ import org.jetbrains.kotlin.ir.builders.declarations.addProperty
 import org.jetbrains.kotlin.ir.builders.declarations.addValueParameter
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irBoolean
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irGetField
+import org.jetbrains.kotlin.ir.builders.irGetObject
+import org.jetbrains.kotlin.ir.builders.irLong
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.builders.irString
@@ -69,7 +68,9 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
 import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrExpressionBody
+import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrExpressionBodyImpl
@@ -105,25 +106,18 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
             .symbol.createType(true, emptyList())
     private val realmObjectCompanionInterface =
         pluginContext.lookupClassOrThrow(REALM_MODEL_COMPANION)
-    private val table = pluginContext.lookupClassOrThrow(TABLE)
+    private val classInfoClass = pluginContext.lookupClassOrThrow(CLASS_INFO)
+    val classInfoCreateMethod = classInfoClass.lookupCompanionDeclaration<IrSimpleFunction>(CLASS_INFO_CREATE)
 
-    private val tableConstructor =
-        table.primaryConstructor ?: error("Couldn't find constructor for $TABLE")
-    private val classFlag: IrClass = pluginContext.lookupClassOrThrow(CLASS_FLAG)
-    private val classFlags =
-        classFlag.declarations.filterIsInstance<IrEnumEntry>()
-    private val propertyClass = pluginContext.lookupClassOrThrow(PROPERTY)
-    private val propertyConstructor =
-        propertyClass.primaryConstructor ?: error("Couldn't find constructor for $TABLE")
+    private val propertyClass = pluginContext.lookupClassOrThrow(PROPERTY_INFO)
+    val propertyCreateMethod = propertyClass.lookupCompanionDeclaration<IrSimpleFunction>(PROPERTY_INFO_CREATE)
+
     private val propertyType: IrClass = pluginContext.lookupClassOrThrow(PROPERTY_TYPE)
     private val propertyTypes =
         propertyType.declarations.filterIsInstance<IrEnumEntry>()
     private val collectionType: IrClass = pluginContext.lookupClassOrThrow(COLLECTION_TYPE)
     private val collectionTypes =
         collectionType.declarations.filterIsInstance<IrEnumEntry>()
-    private val propertyFlag: IrClass = pluginContext.lookupClassOrThrow(PROPERTY_FLAG)
-    private val propertyFlags =
-        propertyFlag.declarations.filterIsInstance<IrEnumEntry>()
 
     private val realmReferenceClass: IrClass = pluginContext.lookupClassOrThrow(REALM_REFERENCE)
     private val mediatorInterface: IrClass = pluginContext.lookupClassOrThrow(REALM_MEDIATOR_INTERFACE)
@@ -133,6 +127,10 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         pluginContext.lookupClassOrThrow(FqNames.KOTLIN_COLLECTIONS_LIST)
     private val kProperty1Class: IrClass =
         pluginContext.lookupClassOrThrow(FqNames.KOTLIN_REFLECT_KPROPERTY1)
+    val realmClassImpl = pluginContext.lookupClassOrThrow(FqNames.REALM_CLASS_IMPL)
+    val realmClassCtor = pluginContext.lookupConstructorInClass(FqNames.REALM_CLASS_IMPL) {
+        it.owner.valueParameters.size == 2
+    }
 
     fun addProperties(irClass: IrClass): IrClass =
         irClass.apply {
@@ -140,7 +138,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
             addVariableProperty(realmModelInternalInterface, REALM_OWNER, realmReferenceClass.defaultType.makeNullable(), ::irNull)
             addVariableProperty(
                 realmModelInternalInterface,
-                OBJECT_TABLE_NAME,
+                OBJECT_CLASS_NAME,
                 pluginContext.irBuiltIns.stringType.makeNullable(),
                 ::irNull
             )
@@ -244,46 +242,44 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         function.body = pluginContext.blockBody(function.symbol) {
             +irReturn(
                 IrConstructorCallImpl(
-                    startOffset,
-                    endOffset,
-                    type = table.defaultType,
-                    symbol = tableConstructor.symbol,
-                    constructorTypeArgumentsCount = 0,
+                    startOffset, endOffset,
+                    realmClassImpl.defaultType,
+                    realmClassCtor,
                     typeArgumentsCount = 0,
-                    valueArgumentsCount = 4
+                    constructorTypeArgumentsCount = 0,
+                    valueArgumentsCount = 2,
                 ).apply {
-                    var arg = 0
-                    // Name
-                    putValueArgument(arg++, irString(irClass.name.identifier))
-                    // Primary key
                     putValueArgument(
-                        arg++,
-                        if (primaryKey != null) irString(primaryKey) else {
-                            IrConstImpl.constNull(
-                                startOffset,
-                                endOffset,
-                                pluginContext.irBuiltIns.nothingNType
+                        0,
+                        IrCallImpl(
+                            startOffset,
+                            endOffset,
+                            type = classInfoClass.defaultType,
+                            symbol = classInfoCreateMethod.symbol,
+                            typeArgumentsCount = 0,
+                            valueArgumentsCount = 3
+                        ).apply {
+                            dispatchReceiver = irGetObject(classInfoClass.companionObject()!!.symbol)
+                            var arg = 0
+                            // Name
+                            putValueArgument(arg++, irString(irClass.name.identifier))
+                            // Primary key
+                            putValueArgument(
+                                arg++,
+                                if (primaryKey != null) irString(primaryKey) else {
+                                    IrConstImpl.constNull(
+                                        startOffset,
+                                        endOffset,
+                                        pluginContext.irBuiltIns.nothingNType
+                                    )
+                                }
                             )
+                            // num properties
+                            putValueArgument(arg++, irLong(fields.size.toLong()))
                         }
                     )
-                    // Flags
                     putValueArgument(
-                        arg++,
-                        buildSetOf(
-                            pluginContext, startOffset, endOffset, classFlag.defaultType,
-                            listOf(
-                                IrGetEnumValueImpl(
-                                    startOffset = UNDEFINED_OFFSET,
-                                    endOffset = UNDEFINED_OFFSET,
-                                    type = classFlag.defaultType,
-                                    symbol = classFlags.first { it.name == CLASS_FLAG_NORMAL }.symbol
-                                )
-                            )
-                        )
-                    )
-                    // Properties
-                    putValueArgument(
-                        arg++,
+                        1,
                         buildListOf(
                             pluginContext, startOffset, endOffset, propertyClass.defaultType,
                             fields.map { entry ->
@@ -328,16 +324,6 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                 val primaryKey = backingField.hasAnnotation(PRIMARY_KEY_ANNOTATION)
                                 val isIndexed = backingField.hasAnnotation(INDEX_ANNOTATION)
 
-                                val propertyFlags = mutableListOf<Name>()
-                                if (nullable) {
-                                    propertyFlags.add(PROPERTY_FLAG_NULLABLE)
-                                }
-                                if (primaryKey) {
-                                    propertyFlags.add(PROPERTY_FLAG_PRIMARY_KEY)
-                                }
-                                if (isIndexed) {
-                                    propertyFlags.add(PROPERTY_FLAG_INDEX)
-                                }
                                 val validPrimaryKeyTypes = with(pluginContext.irBuiltIns) {
                                     setOf(
                                         byteType,
@@ -362,15 +348,15 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                     )
                                 }
 
-                                IrConstructorCallImpl(
+                                IrCallImpl(
                                     startOffset,
                                     endOffset,
                                     type = propertyClass.defaultType,
-                                    symbol = propertyConstructor.symbol,
-                                    constructorTypeArgumentsCount = 0,
+                                    symbol = propertyCreateMethod.symbol,
                                     typeArgumentsCount = 0,
-                                    valueArgumentsCount = 7
+                                    valueArgumentsCount = 9
                                 ).apply {
+                                    dispatchReceiver = irGetObject(propertyClass.companionObject()!!.symbol)
                                     var arg = 0
                                     // Name
                                     putValueArgument(arg++, irString(entry.key))
@@ -425,17 +411,12 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                     )
                                     // Link property name
                                     putValueArgument(arg++, irString(""))
-                                    // Property flags
-                                    putValueArgument(
-                                        arg++,
-                                        buildSetOf(
-                                            pluginContext,
-                                            startOffset,
-                                            endOffset,
-                                            propertyFlag.defaultType,
-                                            propertyFlags(propertyFlags)
-                                        )
-                                    )
+                                    // isNullable
+                                    putValueArgument(arg++, irBoolean(nullable))
+                                    // isPrimaryKey
+                                    putValueArgument(arg++, irBoolean(primaryKey))
+                                    // isIndexed
+                                    putValueArgument(arg++, irBoolean(isIndexed))
                                 }
                             }
                         )
@@ -455,16 +436,6 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
 
     private fun getListType(generics: List<CoreType>?): PropertyType =
         checkNotNull(generics) { "Missing type for list." }[0].propertyType
-
-    private fun propertyFlags(flags: List<Name>): List<IrGetEnumValueImpl> =
-        flags.map { flag ->
-            IrGetEnumValueImpl(
-                startOffset = UNDEFINED_OFFSET,
-                endOffset = UNDEFINED_OFFSET,
-                type = propertyFlag.defaultType,
-                symbol = propertyFlags.first { flag == it.name }.symbol
-            )
-        }
 
     // Generate body for the synthetic new instance method defined inside the Companion instance previously declared via `RealmModelSyntheticCompanionExtension`
     fun addNewInstanceMethodBody(irClass: IrClass) {

--- a/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
@@ -1387,374 +1387,382 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:kotlin.Any
         FUN name:$realm$schema visibility:public modality:OPEN <> ($this:sample.input.Sample.Companion) returnType:kotlin.Any
           overridden:
-            public abstract fun $realm$schema (): io.realm.internal.interop.Table declared in io.realm.internal.RealmObjectCompanion
+            public abstract fun $realm$schema (): io.realm.internal.schema.RealmClassImpl declared in io.realm.internal.RealmObjectCompanion
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample.Companion
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun $realm$schema (): kotlin.Any declared in sample.input.Sample.Companion'
-              CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, primaryKey: kotlin.String?, flags: kotlin.collections.Set<io.realm.internal.interop.ClassFlag>, properties: kotlin.collections.List<io.realm.internal.interop.Property>) [primary] declared in io.realm.internal.interop.Table' type=io.realm.internal.interop.Table origin=null
-                name: CONST String type=kotlin.String value="Sample"
-                primaryKey: CONST String type=kotlin.String value="id"
-                flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.ClassFlag> origin=null
-                  <T>: io.realm.internal.interop.ClassFlag
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.ClassFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.ClassFlag>
-                    GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_CLASS_NORMAL' type=io.realm.internal.interop.ClassFlag
-                properties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.Property> origin=null
-                  <T>: io.realm.internal.interop.Property
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.Property> varargElementType=kotlin.collections.List<io.realm.internal.interop.Property>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+              CONSTRUCTOR_CALL 'public constructor <init> (cinteropClass: io.realm.internal.interop.ClassInfo, cinteropProperties: kotlin.collections.List<io.realm.internal.interop.PropertyInfo>) [primary] declared in io.realm.internal.schema.RealmClassImpl' type=io.realm.internal.schema.RealmClassImpl origin=null
+                cinteropClass: CALL 'public final fun create (name: kotlin.String, primaryKey: kotlin.String?, numProperties: kotlin.Long): io.realm.internal.interop.ClassInfo declared in io.realm.internal.interop.ClassInfo.Companion' type=io.realm.internal.interop.ClassInfo origin=null
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.ClassInfo.Companion
+                  name: CONST String type=kotlin.String value="Sample"
+                  primaryKey: CONST String type=kotlin.String value="id"
+                  numProperties: CONST Long type=kotlin.Long value=33
+                cinteropProperties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.PropertyInfo> origin=null
+                  <T>: io.realm.internal.interop.PropertyInfo
+                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyInfo> varargElementType=kotlin.collections.List<io.realm.internal.interop.PropertyInfo>
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="id"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_PRIMARY_KEY' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=true
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="stringField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_STRING' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_INDEXED' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=true
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="byteField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="charField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="shortField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="intField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_INDEXED' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=true
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="longField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="booleanField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_BOOL' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="floatField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_FLOAT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="doubleField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_DOUBLE' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="timestampField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_TIMESTAMP' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="child"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_OBJECT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value="Child"
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="stringListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_STRING' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="byteListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="charListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="shortListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="intListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="longListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="booleanListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_BOOL' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="floatListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_FLOAT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="doubleListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_DOUBLE' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="timestampListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_TIMESTAMP' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="objectListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_OBJECT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value="Sample"
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableStringListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_STRING' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableByteListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableCharListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableShortListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableIntListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableLongListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_INT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableBooleanListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_BOOL' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableFloatListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_FLOAT' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableDoubleListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_DOUBLE' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="nullableTimestampListField"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_TIMESTAMP' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_LIST' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
         FUN name:$realm$newInstance visibility:public modality:OPEN <> ($this:sample.input.Sample.Companion) returnType:kotlin.Any
           overridden:
             public abstract fun $realm$newInstance (): kotlin.Any declared in io.realm.internal.RealmObjectCompanion
@@ -2057,31 +2065,30 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:kotlin.Any
         FUN name:$realm$schema visibility:public modality:OPEN <> ($this:sample.input.Child.Companion) returnType:kotlin.Any
           overridden:
-            public abstract fun $realm$schema (): io.realm.internal.interop.Table declared in io.realm.internal.RealmObjectCompanion
+            public abstract fun $realm$schema (): io.realm.internal.schema.RealmClassImpl declared in io.realm.internal.RealmObjectCompanion
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child.Companion
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun $realm$schema (): kotlin.Any declared in sample.input.Child.Companion'
-              CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, primaryKey: kotlin.String?, flags: kotlin.collections.Set<io.realm.internal.interop.ClassFlag>, properties: kotlin.collections.List<io.realm.internal.interop.Property>) [primary] declared in io.realm.internal.interop.Table' type=io.realm.internal.interop.Table origin=null
-                name: CONST String type=kotlin.String value="Child"
-                primaryKey: CONST Null type=kotlin.Nothing? value=null
-                flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.ClassFlag> origin=null
-                  <T>: io.realm.internal.interop.ClassFlag
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.ClassFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.ClassFlag>
-                    GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_CLASS_NORMAL' type=io.realm.internal.interop.ClassFlag
-                properties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.Property> origin=null
-                  <T>: io.realm.internal.interop.Property
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.Property> varargElementType=kotlin.collections.List<io.realm.internal.interop.Property>
-                    CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, publicName: kotlin.String, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String, linkOriginPropertyName: kotlin.String, flags: kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>) [primary] declared in io.realm.internal.interop.Property' type=io.realm.internal.interop.Property origin=null
+              CONSTRUCTOR_CALL 'public constructor <init> (cinteropClass: io.realm.internal.interop.ClassInfo, cinteropProperties: kotlin.collections.List<io.realm.internal.interop.PropertyInfo>) [primary] declared in io.realm.internal.schema.RealmClassImpl' type=io.realm.internal.schema.RealmClassImpl origin=null
+                cinteropClass: CALL 'public final fun create (name: kotlin.String, primaryKey: kotlin.String?, numProperties: kotlin.Long): io.realm.internal.interop.ClassInfo declared in io.realm.internal.interop.ClassInfo.Companion' type=io.realm.internal.interop.ClassInfo origin=null
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.ClassInfo.Companion
+                  name: CONST String type=kotlin.String value="Child"
+                  primaryKey: CONST Null type=kotlin.Nothing? value=null
+                  numProperties: CONST Long type=kotlin.Long value=1
+                cinteropProperties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.PropertyInfo> origin=null
+                  <T>: io.realm.internal.interop.PropertyInfo
+                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyInfo> varargElementType=kotlin.collections.List<io.realm.internal.interop.PropertyInfo>
+                    CALL 'public final fun create (name: kotlin.String, publicName: kotlin.String?, type: io.realm.internal.interop.PropertyType, collectionType: io.realm.internal.interop.CollectionType, linkTarget: kotlin.String?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.interop.PropertyInfo.Companion' type=io.realm.internal.interop.PropertyInfo origin=null
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.PropertyInfo.Companion
                       name: CONST String type=kotlin.String value="name"
                       publicName: CONST String type=kotlin.String value=""
                       type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_STRING' type=io.realm.internal.interop.PropertyType
                       collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.internal.interop.CollectionType
                       linkTarget: CONST String type=kotlin.String value=""
                       linkOriginPropertyName: CONST String type=kotlin.String value=""
-                      flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag> origin=null
-                        <T>: io.realm.internal.interop.PropertyFlag
-                        elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.PropertyFlag>
-                          GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_NULLABLE' type=io.realm.internal.interop.PropertyFlag
+                      isNullable: CONST Boolean type=kotlin.Boolean value=true
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
         FUN name:$realm$newInstance visibility:public modality:OPEN <> ($this:sample.input.Child.Companion) returnType:kotlin.Any
           overridden:
             public abstract fun $realm$newInstance (): kotlin.Any declared in io.realm.internal.RealmObjectCompanion

--- a/packages/plugin-compiler/src/test/resources/schema/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/schema/expected/00_ValidateIrBeforeLowering.ir
@@ -28,20 +28,19 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:kotlin.Any
         FUN name:$realm$schema visibility:public modality:OPEN <> ($this:schema.input.A.Companion) returnType:kotlin.Any
           overridden:
-            public abstract fun $realm$schema (): io.realm.internal.interop.Table declared in io.realm.internal.RealmObjectCompanion
+            public abstract fun $realm$schema (): io.realm.internal.schema.RealmClassImpl declared in io.realm.internal.RealmObjectCompanion
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A.Companion
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun $realm$schema (): kotlin.Any declared in schema.input.A.Companion'
-              CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, primaryKey: kotlin.String?, flags: kotlin.collections.Set<io.realm.internal.interop.ClassFlag>, properties: kotlin.collections.List<io.realm.internal.interop.Property>) [primary] declared in io.realm.internal.interop.Table' type=io.realm.internal.interop.Table origin=null
-                name: CONST String type=kotlin.String value="A"
-                primaryKey: CONST Null type=kotlin.Nothing? value=null
-                flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.ClassFlag> origin=null
-                  <T>: io.realm.internal.interop.ClassFlag
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.ClassFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.ClassFlag>
-                    GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_CLASS_NORMAL' type=io.realm.internal.interop.ClassFlag
-                properties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.Property> origin=null
-                  <T>: io.realm.internal.interop.Property
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.Property> varargElementType=kotlin.collections.List<io.realm.internal.interop.Property>
+              CONSTRUCTOR_CALL 'public constructor <init> (cinteropClass: io.realm.internal.interop.ClassInfo, cinteropProperties: kotlin.collections.List<io.realm.internal.interop.PropertyInfo>) [primary] declared in io.realm.internal.schema.RealmClassImpl' type=io.realm.internal.schema.RealmClassImpl origin=null
+                cinteropClass: CALL 'public final fun create (name: kotlin.String, primaryKey: kotlin.String?, numProperties: kotlin.Long): io.realm.internal.interop.ClassInfo declared in io.realm.internal.interop.ClassInfo.Companion' type=io.realm.internal.interop.ClassInfo origin=null
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.ClassInfo.Companion
+                  name: CONST String type=kotlin.String value="A"
+                  primaryKey: CONST Null type=kotlin.Nothing? value=null
+                  numProperties: CONST Long type=kotlin.Long value=0
+                cinteropProperties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.PropertyInfo> origin=null
+                  <T>: io.realm.internal.interop.PropertyInfo
+                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyInfo> varargElementType=kotlin.collections.List<io.realm.internal.interop.PropertyInfo>
         FUN name:$realm$newInstance visibility:public modality:OPEN <> ($this:schema.input.A.Companion) returnType:kotlin.Any
           overridden:
             public abstract fun $realm$newInstance (): kotlin.Any declared in io.realm.internal.RealmObjectCompanion
@@ -266,20 +265,19 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:kotlin.Any
         FUN name:$realm$schema visibility:public modality:OPEN <> ($this:schema.input.B.Companion) returnType:kotlin.Any
           overridden:
-            public abstract fun $realm$schema (): io.realm.internal.interop.Table declared in io.realm.internal.RealmObjectCompanion
+            public abstract fun $realm$schema (): io.realm.internal.schema.RealmClassImpl declared in io.realm.internal.RealmObjectCompanion
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B.Companion
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun $realm$schema (): kotlin.Any declared in schema.input.B.Companion'
-              CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, primaryKey: kotlin.String?, flags: kotlin.collections.Set<io.realm.internal.interop.ClassFlag>, properties: kotlin.collections.List<io.realm.internal.interop.Property>) [primary] declared in io.realm.internal.interop.Table' type=io.realm.internal.interop.Table origin=null
-                name: CONST String type=kotlin.String value="B"
-                primaryKey: CONST Null type=kotlin.Nothing? value=null
-                flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.ClassFlag> origin=null
-                  <T>: io.realm.internal.interop.ClassFlag
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.ClassFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.ClassFlag>
-                    GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_CLASS_NORMAL' type=io.realm.internal.interop.ClassFlag
-                properties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.Property> origin=null
-                  <T>: io.realm.internal.interop.Property
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.Property> varargElementType=kotlin.collections.List<io.realm.internal.interop.Property>
+              CONSTRUCTOR_CALL 'public constructor <init> (cinteropClass: io.realm.internal.interop.ClassInfo, cinteropProperties: kotlin.collections.List<io.realm.internal.interop.PropertyInfo>) [primary] declared in io.realm.internal.schema.RealmClassImpl' type=io.realm.internal.schema.RealmClassImpl origin=null
+                cinteropClass: CALL 'public final fun create (name: kotlin.String, primaryKey: kotlin.String?, numProperties: kotlin.Long): io.realm.internal.interop.ClassInfo declared in io.realm.internal.interop.ClassInfo.Companion' type=io.realm.internal.interop.ClassInfo origin=null
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.ClassInfo.Companion
+                  name: CONST String type=kotlin.String value="B"
+                  primaryKey: CONST Null type=kotlin.Nothing? value=null
+                  numProperties: CONST Long type=kotlin.Long value=0
+                cinteropProperties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.PropertyInfo> origin=null
+                  <T>: io.realm.internal.interop.PropertyInfo
+                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyInfo> varargElementType=kotlin.collections.List<io.realm.internal.interop.PropertyInfo>
         FUN name:$realm$newInstance visibility:public modality:OPEN <> ($this:schema.input.B.Companion) returnType:kotlin.Any
           overridden:
             public abstract fun $realm$newInstance (): kotlin.Any declared in io.realm.internal.RealmObjectCompanion
@@ -504,20 +502,19 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:kotlin.Any
         FUN name:$realm$schema visibility:public modality:OPEN <> ($this:schema.input.C.Companion) returnType:kotlin.Any
           overridden:
-            public abstract fun $realm$schema (): io.realm.internal.interop.Table declared in io.realm.internal.RealmObjectCompanion
+            public abstract fun $realm$schema (): io.realm.internal.schema.RealmClassImpl declared in io.realm.internal.RealmObjectCompanion
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C.Companion
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun $realm$schema (): kotlin.Any declared in schema.input.C.Companion'
-              CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, primaryKey: kotlin.String?, flags: kotlin.collections.Set<io.realm.internal.interop.ClassFlag>, properties: kotlin.collections.List<io.realm.internal.interop.Property>) [primary] declared in io.realm.internal.interop.Table' type=io.realm.internal.interop.Table origin=null
-                name: CONST String type=kotlin.String value="C"
-                primaryKey: CONST Null type=kotlin.Nothing? value=null
-                flags: CALL 'public final fun setOf <T> (vararg elements: T of kotlin.collections.SetsKt.setOf): kotlin.collections.Set<T of kotlin.collections.SetsKt.setOf> declared in kotlin.collections.SetsKt' type=kotlin.collections.Set<io.realm.internal.interop.ClassFlag> origin=null
-                  <T>: io.realm.internal.interop.ClassFlag
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.ClassFlag> varargElementType=kotlin.collections.Set<io.realm.internal.interop.ClassFlag>
-                    GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_CLASS_NORMAL' type=io.realm.internal.interop.ClassFlag
-                properties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.Property> origin=null
-                  <T>: io.realm.internal.interop.Property
-                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.Property> varargElementType=kotlin.collections.List<io.realm.internal.interop.Property>
+              CONSTRUCTOR_CALL 'public constructor <init> (cinteropClass: io.realm.internal.interop.ClassInfo, cinteropProperties: kotlin.collections.List<io.realm.internal.interop.PropertyInfo>) [primary] declared in io.realm.internal.schema.RealmClassImpl' type=io.realm.internal.schema.RealmClassImpl origin=null
+                cinteropClass: CALL 'public final fun create (name: kotlin.String, primaryKey: kotlin.String?, numProperties: kotlin.Long): io.realm.internal.interop.ClassInfo declared in io.realm.internal.interop.ClassInfo.Companion' type=io.realm.internal.interop.ClassInfo origin=null
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.internal.interop.ClassInfo.Companion
+                  name: CONST String type=kotlin.String value="C"
+                  primaryKey: CONST Null type=kotlin.Nothing? value=null
+                  numProperties: CONST Long type=kotlin.Long value=0
+                cinteropProperties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.internal.interop.PropertyInfo> origin=null
+                  <T>: io.realm.internal.interop.PropertyInfo
+                  elements: VARARG type=kotlin.Array<io.realm.internal.interop.PropertyInfo> varargElementType=kotlin.collections.List<io.realm.internal.interop.PropertyInfo>
         FUN name:$realm$newInstance visibility:public modality:OPEN <> ($this:schema.input.C.Companion) returnType:kotlin.Any
           overridden:
             public abstract fun $realm$newInstance (): kotlin.Any declared in io.realm.internal.RealmObjectCompanion

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmListTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmListTests.kt
@@ -71,7 +71,7 @@ class RealmListTests {
 
     @Test
     fun realmListInitializer_realmListOf() {
-        val realmListFromArgsEmpty: RealmList<String> = realmListOf<String>()
+        val realmListFromArgsEmpty: RealmList<String> = realmListOf()
         assertTrue(realmListFromArgsEmpty.isEmpty())
 
         val realmListFromArgs: RealmList<String> = realmListOf("1", "2")
@@ -83,15 +83,15 @@ class RealmListTests {
         val realmListFromEmptyCollection = emptyList<String>().toRealmList()
         assertTrue(realmListFromEmptyCollection.isEmpty())
 
-        val realmListFromSingleElementList = listOf<String>("1").toRealmList()
+        val realmListFromSingleElementList = listOf("1").toRealmList()
         assertContentEquals(listOf("1"), realmListFromSingleElementList)
-        val realmListFromSingleElementSet = setOf<String>("1").toRealmList()
-        assertContentEquals(listOf("1"), realmListFromSingleElementList)
+        val realmListFromSingleElementSet = setOf("1").toRealmList()
+        assertContentEquals(listOf("1"), realmListFromSingleElementSet)
 
-        val realmListFromMultiElementCollection = setOf<String>("1", "2").toRealmList()
+        val realmListFromMultiElementCollection = setOf("1", "2").toRealmList()
         assertContentEquals(listOf("1", "2"), realmListFromMultiElementCollection)
 
-        val realmListFromIterator = IntRange(0, 2).toRealmList()
+        val realmListFromIterator = (0..2).toRealmList()
         assertContentEquals(listOf(0, 1, 2), realmListFromIterator)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmSchemaTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmSchemaTests.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.test.shared
+
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import io.realm.entities.Sample
+import io.realm.entities.schema.SchemaVariations
+import io.realm.schema.ListPropertyType
+import io.realm.schema.RealmPropertyType
+import io.realm.schema.RealmStorageType
+import io.realm.schema.ValuePropertyType
+import io.realm.test.platform.PlatformUtils
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+private val SCHEMA_VARIATION_CLASS_NAME = SchemaVariations::class.simpleName!!
+
+/**
+ * Test of public schema API.
+ *
+ * This test suite doesn't exhaust all modeling features, but should have full coverage of the
+ * schema API code paths.
+ */
+public class RealmSchemaTests {
+
+    private lateinit var tmpDir: String
+    private lateinit var realm: Realm
+
+    @BeforeTest
+    fun setup() {
+        tmpDir = PlatformUtils.createTempDir()
+        val configuration =
+            RealmConfiguration.Builder(schema = setOf(SchemaVariations::class, Sample::class))
+                .path("$tmpDir/default.realm").build()
+        realm = Realm.open(configuration)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (!realm.isClosed()) {
+            realm.close()
+        }
+        PlatformUtils.deleteTempDir(tmpDir)
+    }
+
+    @Test
+    fun realmClass() {
+        val schema = realm.schema()
+
+        assertEquals(2, schema.classes.size)
+
+        val schemaVariationsDescriptor = schema[SCHEMA_VARIATION_CLASS_NAME]
+            ?: fail("Couldn't find class")
+        assertEquals(SCHEMA_VARIATION_CLASS_NAME, schemaVariationsDescriptor.name)
+        assertEquals("string", schemaVariationsDescriptor.primaryKey?.name)
+
+        val sampleName = "Sample"
+        val sampleDescriptor = schema[sampleName] ?: fail("Couldn't find class")
+        assertEquals(sampleName, sampleDescriptor.name)
+        assertNull(sampleDescriptor.primaryKey)
+    }
+
+    @Test
+    fun realmClass_notFound() {
+        val schema = realm.schema()
+        assertNull(schema["non-existing_class"])
+    }
+
+    @Test
+    fun realmProperty() {
+        val schema = realm.schema()
+
+        val schemaVariationsDescriptor = schema[SCHEMA_VARIATION_CLASS_NAME]
+            ?: fail("Couldn't find class")
+
+        schemaVariationsDescriptor["string"]!!.run {
+            assertEquals("string", name)
+            type.run {
+                assertIs<ValuePropertyType>(this)
+                assertEquals(RealmStorageType.STRING, storageType)
+                assertFalse(isNullable)
+                assertTrue(isPrimaryKey)
+                assertFalse(isIndexed)
+            }
+            assertFalse(isNullable)
+        }
+        schemaVariationsDescriptor["nullableString"]!!.run {
+            assertEquals("nullableString", name)
+            type.run {
+                assertIs<ValuePropertyType>(this)
+                assertEquals(RealmStorageType.STRING, storageType)
+                assertTrue(isNullable)
+                assertFalse(isPrimaryKey)
+                assertTrue(isIndexed)
+            }
+            assertTrue(isNullable)
+        }
+        schemaVariationsDescriptor["stringList"]!!.run {
+            assertEquals("stringList", name)
+            type.run {
+                assertIs<ListPropertyType>(this)
+                assertEquals(RealmStorageType.STRING, storageType)
+                assertFalse(this.isNullable)
+            }
+            assertFalse(isNullable)
+        }
+        schemaVariationsDescriptor["nullableStringList"]!!.run {
+            assertEquals("nullableStringList", name)
+            type.run {
+                assertIs<ListPropertyType>(this)
+                assertEquals(RealmStorageType.STRING, storageType)
+                assertTrue(this.isNullable)
+            }
+            assertFalse(isNullable)
+        }
+    }
+
+    @Test
+    fun realmProperty_notFound() {
+        val schema = realm.schema()
+        val schemaVariationDescriptor = schema[SCHEMA_VARIATION_CLASS_NAME]!!
+        assertNull(schemaVariationDescriptor["non-existing-property"])
+    }
+
+    // This test is just showing how we could use the public Schema API to perform exhaustive tests.
+    // It overlaps with the TypeDescriptor infrastructure, so we should probably just update the
+    // type descriptor infrastructure to use this information or make the various TypeDescriptor
+    // properties available through the public schema API, ex.
+    //
+    // class ValuePropertyType {
+    //     companion object {
+    //         val supportedStorageTypes: Set<RealmStorageTypes> = setOf( ....)
+    //     }
+    // }
+    @Test
+    @Suppress("NestedBlockDepth")
+    fun schema_optionCoverag() {
+        // Property options
+        @Suppress("invisible_member")
+        val propertyTypeMap =
+            RealmPropertyType.subTypes.map { it to RealmStorageType.values().toMutableSet() }.toMap()
+                .toMutableMap()
+
+        val schema = realm.schema()
+
+        // Verify properties of SchemaVariations
+        val classDescriptor = schema["SchemaVariations"] ?: fail("Couldn't find class")
+        assertEquals("SchemaVariations", classDescriptor.name)
+        for (property in classDescriptor.properties) {
+            property.type.run {
+                propertyTypeMap.getValue(this::class).remove(this.storageType)
+            }
+        }
+
+        assertTrue(
+            propertyTypeMap.none
+            { (_, v) -> v.isNotEmpty() },
+            "Field types not exhausted: $propertyTypeMap"
+        )
+    }
+}

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/SchemaTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/SchemaTests.kt
@@ -21,7 +21,7 @@ import io.realm.entities.Sample
 import io.realm.entities.link.Child
 import io.realm.entities.link.Parent
 import io.realm.internal.InternalConfiguration
-import io.realm.internal.interop.Table
+import io.realm.schema.RealmClass
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -88,9 +88,9 @@ class SchemaTests {
         for (clazz in schema) {
             assertTrue(conf.companionMap.containsKey(clazz))
             // make sure we can instantiate
-            val table: Table = conf.companionMap[clazz]!!.`$realm$schema`()
+            val classInfo: RealmClass = conf.companionMap[clazz]!!.`$realm$schema`()
             val newInstance: Any = conf.companionMap[clazz]!!.`$realm$newInstance`()
-            assertEquals(clazz.simpleName, table.name)
+            assertEquals(clazz.simpleName, classInfo.name)
             assertTrue(newInstance::class == clazz)
         }
     }

--- a/test/base/src/commonMain/kotlin/io/realm/entities/schema/SchemaVariations.kt
+++ b/test/base/src/commonMain/kotlin/io/realm/entities/schema/SchemaVariations.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities.schema
+
+import io.realm.RealmInstant
+import io.realm.RealmList
+import io.realm.RealmObject
+import io.realm.annotations.Index
+import io.realm.annotations.PrimaryKey
+import io.realm.entities.Sample
+import io.realm.realmListOf
+
+/**
+ * Class used for testing of the schema API; thus, doesn't exhaust modeling features but provides
+ * sufficient model features to cover all code paths of the schema API.
+ */
+class SchemaVariations : RealmObject {
+    // Value properties
+    var bool: Boolean = false
+    var byte: Byte = 0
+    var char: Char = 'a'
+    var short: Short = 5
+    var int: Int = 5
+    var long: Long = 5L
+    var float: Float = 5f
+    var double: Double = 5.0
+    @PrimaryKey
+    var string: String = "Realm"
+    var date: RealmInstant = RealmInstant.fromEpochSeconds(0, 0)
+    @Index
+    var nullableString: String? = "Realm"
+    var nullableRealmObject: Sample? = null
+
+    // List properties
+    var boolList: RealmList<Boolean> = realmListOf()
+    var byteList: RealmList<Byte> = realmListOf()
+    var charList: RealmList<Char> = realmListOf()
+    var shortList: RealmList<Short> = realmListOf()
+    var intList: RealmList<Int> = realmListOf()
+    var longList: RealmList<Long> = realmListOf()
+    var floatList: RealmList<Float> = realmListOf()
+    var doubleList: RealmList<Double> = realmListOf()
+    var stringList: RealmList<String> = realmListOf()
+    var dateList: RealmList<RealmInstant> = realmListOf()
+
+    var objectList: RealmList<Sample> = realmListOf()
+
+    var nullableStringList: RealmList<String?> = realmListOf()
+}


### PR DESCRIPTION
Fixes #626 

Added a quick fix that ensures no modifications to the configs are carried out while processing analytics in compile time.

This doesn't fix the issue per se but at least will give us time until we have a fix for https://github.com/realm/realm-kotlin/issues/498 which will likely solve the problem.