### PR TITLE
Synchronously process project configurations to avoid exceptions when running parallel builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.8.1 (2022-01-17)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* Synchronously process project configurations to avoid exceptions when running parallel builds [#626](https://github.com/realm/realm-kotlin/issues/626).
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10.
+  * Coroutines 1.5.2-native-mt.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 0.8.0 (2021-12-17)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.1 (2022-01-17)
+## 0.8.1-SNAPSHOT (YYYY-MM-DD)
 
 ### Breaking Changes
 * None.

--- a/packages/gradle-plugin/src/main/kotlin/io/realm/gradle/RealmAnalytics.kt
+++ b/packages/gradle-plugin/src/main/kotlin/io/realm/gradle/RealmAnalytics.kt
@@ -83,6 +83,7 @@ internal class RealmAnalytics : TaskExecutionAdapter() {
         }
     }
 
+    @Synchronized
     private fun sendMetricIfNeeded(project: Project) {
         if (!METRIC_PROCESSED) {
             val disableAnalytics: Boolean = project.gradle.startParameter.isOffline || "true".equals(System.getenv()["REALM_DISABLE_ANALYTICS"], ignoreCase = true)


### PR DESCRIPTION
Fixes #626 

Added a quick fix that ensures no modifications to the configs are carried out while processing analytics in compile time.

This doesn't fix the issue per se but at least will give us time until we have a fix for https://github.com/realm/realm-kotlin/issues/498 which will likely solve the problem.