### PR TITLE
Replace JCenter repository with Maven Central for 0.8.1

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,16 +31,12 @@ gradlePlugin {
 
 repositories {
     google()
-    jcenter()
     gradlePluginPortal()
 }
 
 
 // Setup dependencies for building the buildScript.
 buildscript {
-    repositories {
-        jcenter()
-    }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
     }

--- a/examples/kmm-sample/build.gradle.kts
+++ b/examples/kmm-sample/build.gradle.kts
@@ -25,6 +25,5 @@ allprojects {
         google()
         mavenCentral()
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
-        jcenter() // Required by detekt
     }
 }

--- a/packages/build.gradle.kts
+++ b/packages/build.gradle.kts
@@ -24,8 +24,13 @@ plugins {
 }
 
 allprojects {
+    buildscript {
+        repositories {
+            mavenCentral()
+        }
+    }
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     version = Realm.version

--- a/packages/library-base/build.gradle.kts
+++ b/packages/library-base/build.gradle.kts
@@ -21,9 +21,6 @@ plugins {
     id("org.jetbrains.dokka")
 }
 buildscript {
-    repositories {
-        mavenCentral()
-    }
     dependencies {
         classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${Versions.atomicfu}")
     }
@@ -37,7 +34,6 @@ project.extensions.configure(kotlinx.atomicfu.plugin.gradle.AtomicFUPluginExtens
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
     mavenLocal()
 }

--- a/packages/library-sync/build.gradle.kts
+++ b/packages/library-sync/build.gradle.kts
@@ -21,9 +21,6 @@ plugins {
     id("org.jetbrains.dokka")
 }
 buildscript {
-    repositories {
-        mavenCentral()
-    }
     dependencies {
         classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${Versions.atomicfu}")
     }
@@ -37,7 +34,6 @@ project.extensions.configure(kotlinx.atomicfu.plugin.gradle.AtomicFUPluginExtens
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
     mavenLocal()
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -38,7 +38,7 @@ allprojects {
             maven("file://${rootProject.rootDir.absolutePath}/../packages/build/m2-buildrepo")
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {


### PR DESCRIPTION
Backporting fix for #637 into releases: Replace JCenter repository with Maven Central. This is needed to be able to download Kotlin 1.6.10 since it cannot be found in jcenter as per 2022-01-17.