### PR TITLE
Link model definition errors to offending source code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements
 * Added API for inspecting the schema of the realm with `BaseRealm.schema()` ([#238](https://github.com/realm/realm-kotlin/issues/238)).
+* Added source code link to model definition compiler errors. ([#173](https://github.com/realm/realm-kotlin/issues/173))
 
 ### Fixed
 * None.

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -77,7 +77,7 @@ object Versions {
     // When updating the Kotlin version, also remember to update /examples/min-android-sample/build.gradle.kts
     const val kotlin = "1.6.0" // https://github.com/JetBrains/kotlin and https://kotlinlang.org/docs/releases.html#release-details
     const val kotlinCompileTesting = "1.4.2" // https://github.com/tschuchortdev/kotlin-compile-testing
-    const val ktlint = "0.43.0" // https://github.com/pinterest/ktlint
+    const val ktlint = "0.43.2" // https://github.com/pinterest/ktlint
     const val ktor = "1.6.5" // https://github.com/ktorio/ktor
     const val nexusPublishPlugin = "1.1.0" // https://github.com/gradle-nexus/publish-plugin
     const val okio = "3.0.0" // https://square.github.io/okio/#releases

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
@@ -31,6 +31,7 @@ import io.realm.compiler.Names.REALM_OBJECT_HELPER_SET_OBJECT
 import io.realm.compiler.Names.REALM_OBJECT_HELPER_SET_TIMESTAMP
 import io.realm.compiler.Names.REALM_OBJECT_HELPER_SET_VALUE
 import io.realm.compiler.Names.REALM_SYNTHETIC_PROPERTY_PREFIX
+import kotlin.collections.set
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
@@ -86,11 +87,6 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.StarProjectionImpl
 import org.jetbrains.kotlin.types.isNullable
 import org.jetbrains.kotlin.types.typeUtil.supertypes
-import kotlin.collections.set
-import org.jetbrains.kotlin.backend.jvm.codegen.fileParent
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
-import org.jetbrains.kotlin.ir.declarations.path
-import org.jetbrains.kotlin.ir.util.file
 
 /**
  * Modifies the IR tree to transform getter/setter to call the C-Interop layer to retrieve read the managed values from the Realm

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
@@ -31,7 +31,6 @@ import io.realm.compiler.Names.REALM_OBJECT_HELPER_SET_OBJECT
 import io.realm.compiler.Names.REALM_OBJECT_HELPER_SET_TIMESTAMP
 import io.realm.compiler.Names.REALM_OBJECT_HELPER_SET_VALUE
 import io.realm.compiler.Names.REALM_SYNTHETIC_PROPERTY_PREFIX
-import kotlin.collections.set
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
@@ -87,6 +86,7 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.StarProjectionImpl
 import org.jetbrains.kotlin.types.isNullable
 import org.jetbrains.kotlin.types.typeUtil.supertypes
+import kotlin.collections.set
 
 /**
  * Modifies the IR tree to transform getter/setter to call the C-Interop layer to retrieve read the managed values from the Realm

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/IrUtils.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/IrUtils.kt
@@ -426,6 +426,6 @@ fun IrDeclaration.locationOf(): CompilerMessageSourceLocation {
  * Method to indicate fatal issues that should not have happeneded; as opposed to user modeling
  * errors that are reported as compiler errors.
  */
-fun fatalError(message: Any): Nothing {
+fun fatalError(message: String): Nothing {
     error(message)
 }

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/IrUtils.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/IrUtils.kt
@@ -25,7 +25,6 @@ import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
@@ -406,19 +405,19 @@ fun IrBlockBuilder.createSafeCallConstruction(
     }
 }
 
-/** Finds the line and column of [irElement] within this file. */
+/** Finds the line and column of [IrDeclaration] */
 fun IrDeclaration.locationOf(): CompilerMessageSourceLocation {
     val sourceRangeInfo = file.fileEntry.getSourceRangeInfo(
-            beginOffset = startOffset,
-            endOffset = endOffset
+        beginOffset = startOffset,
+        endOffset = endOffset
     )
     return CompilerMessageLocationWithRange.create(
-            path = sourceRangeInfo.filePath,
-            lineStart = sourceRangeInfo.startLineNumber + 1,
-            columnStart = sourceRangeInfo.startColumnNumber + 1,
-            lineEnd = sourceRangeInfo.endLineNumber + 1,
-            columnEnd = sourceRangeInfo.endColumnNumber + 1,
-            lineContent = null
+        path = sourceRangeInfo.filePath,
+        lineStart = sourceRangeInfo.startLineNumber + 1,
+        columnStart = sourceRangeInfo.startColumnNumber + 1,
+        lineEnd = sourceRangeInfo.endLineNumber + 1,
+        columnEnd = sourceRangeInfo.endColumnNumber + 1,
+        lineContent = null
     )!!
 }
 

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Logger.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Logger.kt
@@ -17,11 +17,8 @@
 package io.realm.compiler
 
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import java.time.Instant
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
-import org.jetbrains.kotlin.cli.common.messages.IrMessageCollector
-import org.jetbrains.kotlin.ir.util.IrMessageLogger
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 
 // Logging to a temp file and to console/IDE (Build Output)
 lateinit var messageCollector: MessageCollector

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Logger.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Logger.kt
@@ -19,15 +19,16 @@ package io.realm.compiler
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import java.time.Instant
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.cli.common.messages.IrMessageCollector
+import org.jetbrains.kotlin.ir.util.IrMessageLogger
 
 // Logging to a temp file and to console/IDE (Build Output)
 lateinit var messageCollector: MessageCollector
-private fun logger(message: String, severity: CompilerMessageSeverity = CompilerMessageSeverity.WARNING) {
-    val formattedMessage by lazy {
-        "[Realm Compiler Plugin] ${Instant.now()} $message\n"
-    }
-    messageCollector.report(severity, formattedMessage)
+private fun logger(message: String, severity: CompilerMessageSeverity = CompilerMessageSeverity.WARNING, location: CompilerMessageSourceLocation? = null) {
+    val formattedMessage by lazy { "[Realm] $message" }
+    messageCollector.report(severity, formattedMessage, location)
 }
 fun logInfo(message: String) = logger(message, severity = CompilerMessageSeverity.INFO)
-fun logWarn(message: String) = logger(message, severity = CompilerMessageSeverity.WARNING)
-fun logError(message: String) = logger(message, severity = CompilerMessageSeverity.ERROR) // /!\ This will log and fail the compilation /!\
+fun logWarn(message: String, location: CompilerMessageSourceLocation? = null) = logger(message, severity = CompilerMessageSeverity.WARNING, location = location)
+fun logError(message: String, location: CompilerMessageSourceLocation? = null) = logger(message, severity = CompilerMessageSeverity.ERROR, location = location) // /!\ This will log and fail the compilation /!\

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelLoweringExtension.kt
@@ -110,7 +110,7 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
             irClass.addFakeOverrides(realmObjectInternalInterface, realmObjectInternalOverrides)
 
             // Add body for synthetic companion methods
-            val companion = irClass.companionObject() ?: error("RealmObject without companion")
+            val companion = irClass.companionObject() ?: fatalError("RealmObject without companion")
             generator.addCompanionFields(companion, SchemaCollector.properties[irClass])
             generator.addSchemaMethodBody(irClass)
             generator.addNewInstanceMethodBody(irClass)

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -188,7 +188,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
             0 -> null
             1 -> primaryKeyFields.entries.first().value.declaration
             else -> {
-                logError("RealmObject can only have one primary key")
+                logError("RealmObject can only have one primary key", companion.parentAsClass.locationOf())
                 null
             }
         }
@@ -220,7 +220,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
     @Suppress("LongMethod", "ComplexMethod")
     fun addSchemaMethodBody(irClass: IrClass) {
         val companionObject = irClass.companionObject() as? IrClass
-            ?: error("Companion object not available")
+            ?: fatalError("Companion object not available")
 
         val fields: MutableMap<String, SchemaProperty> =
             SchemaCollector.properties.getOrDefault(irClass, mutableMapOf())
@@ -231,7 +231,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
             0 -> null
             1 -> primaryKeyFields.entries.first().key
             else -> {
-                logError("RealmObject can only have one primary key")
+                logError("RealmObject can only have one primary key", irClass.locationOf())
                 null
             }
         }
@@ -313,13 +313,13 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
 
                                 val property = value.declaration
                                 val backingField = property.backingField
-                                    ?: error("Property without backing field or type.")
+                                    ?: fatalError("Property without backing field or type.")
                                 // Nullability applies to the generic type in collections
                                 val nullable = if (value.collectionType == CollectionType.NONE) {
                                     backingField.type.isNullable()
                                 } else {
                                     value.coreGenericTypes?.get(0)?.nullable
-                                        ?: error("Missing generic type while processing a collection field.")
+                                        ?: fatalError("Missing generic type while processing a collection field.")
                                 }
                                 val primaryKey = backingField.hasAnnotation(PRIMARY_KEY_ANNOTATION)
                                 val isIndexed = backingField.hasAnnotation(INDEX_ANNOTATION)
@@ -337,6 +337,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                 if (primaryKey && backingField.type.classifierOrFail !in validPrimaryKeyTypes) {
                                     logError(
                                         "Primary key ${property.name} is of type ${backingField.type.classifierOrFail.owner.symbol.descriptor.name} but must be of type ${validPrimaryKeyTypes.map { it.owner.symbol.descriptor.name }}",
+                                        property.locationOf()
                                     )
                                 }
                                 val indexableTypes = with(pluginContext.irBuiltIns) {
@@ -345,6 +346,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                 if (isIndexed && backingField.type.classifierOrFail !in indexableTypes) {
                                     logError(
                                         "Indexed key ${property.name} is of type ${backingField.type.classifierOrFail.owner.symbol.descriptor.name} but must be of type ${indexableTypes.map { it.owner.symbol.descriptor.name }}",
+                                        property.locationOf()
                                     )
                                 }
 
@@ -440,14 +442,14 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
     // Generate body for the synthetic new instance method defined inside the Companion instance previously declared via `RealmModelSyntheticCompanionExtension`
     fun addNewInstanceMethodBody(irClass: IrClass) {
         val companionObject = irClass.companionObject() as? IrClass
-            ?: error("Companion object not available")
+            ?: fatalError("Companion object not available")
 
         val function =
             companionObject.functions.first { it.name == REALM_OBJECT_COMPANION_NEW_INSTANCE_METHOD }
         function.dispatchReceiverParameter = companionObject.thisReceiver?.copyTo(function)
         function.body = pluginContext.blockBody(function.symbol) {
             val defaultCtor = irClass.primaryConstructor
-                ?: error("Can not find primary constructor")
+                ?: fatalError("Can not find primary constructor")
             +irReturn(
                 IrConstructorCallImpl( // CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in dev.nhachicha.A' type=dev.nhachicha.A origin=null
                     startOffset,
@@ -510,7 +512,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         // overridden:
         //   public abstract fun <get-realmPointer> (): kotlin.Long? declared in dev.nhachicha.RealmObjectInternal
         val propertyAccessorGetter = owner.getPropertyGetter(propertyName.asString())
-            ?: error("${propertyName.asString()} function getter symbol is not available")
+            ?: fatalError("${propertyName.asString()} function getter symbol is not available")
         getter.overriddenSymbols = listOf(propertyAccessorGetter)
 
         // BLOCK_BODY
@@ -540,7 +542,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         // overridden:
         //  public abstract fun <set-realmPointer> (<set-?>: kotlin.Long?): kotlin.Unit declared in dev.nhachicha.RealmObjectInternal
         val realmPointerSetter = owner.getPropertySetter(propertyName.asString())
-            ?: error("${propertyName.asString()} function getter symbol is not available")
+            ?: fatalError("${propertyName.asString()} function getter symbol is not available")
         setter.overriddenSymbols = listOf(realmPointerSetter)
 
         // VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long?

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
@@ -240,15 +240,6 @@ class GenerationExtensionTest {
         inputs.assertGeneratedIR()
     }
 
-    @Test
-    fun `compiler error context`() {
-        val inputs = Files("/error")
-
-        val result = compile(inputs)
-
-        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-    }
-
     private fun compile(
         inputs: Files,
         plugins: List<Registrar> = listOf(Registrar())

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
@@ -240,6 +240,15 @@ class GenerationExtensionTest {
         inputs.assertGeneratedIR()
     }
 
+    @Test
+    fun `compiler error context`() {
+        val inputs = Files("/error")
+
+        val result = compile(inputs)
+
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+    }
+
     private fun compile(
         inputs: Files,
         plugins: List<Registrar> = listOf(Registrar())

--- a/test/base/src/jvmTest/kotlin/io/realm/test/compiler/IndexTests.kt
+++ b/test/base/src/jvmTest/kotlin/io/realm/test/compiler/IndexTests.kt
@@ -78,7 +78,7 @@ class IndexTests {
                 assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
             } else {
                 assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, type.toString())
-                assertTrue(result.messages.contains("but must be of type"))
+                assertTrue(result.messages.contains(Regex("sources/indexing.kt: \\(7, 5\\): .*but must be of type")))
             }
         }
     }
@@ -92,6 +92,8 @@ class IndexTests {
                 """
                         import io.realm.RealmInstant
                         import io.realm.RealmObject
+                        import io.realm.RealmList
+                        import io.realm.realmListOf
                         import io.realm.RealmConfiguration
                         import io.realm.annotations.Index
 
@@ -106,5 +108,6 @@ class IndexTests {
             )
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, "anyType")
+        assertTrue(result.messages.contains("sources/indexing_collections.kt: (9, 5): [Realm] Indexed key indexedKey is of type RealmList but must be of type"))
     }
 }

--- a/test/base/src/jvmTest/kotlin/io/realm/test/compiler/list/ListTests.kt
+++ b/test/base/src/jvmTest/kotlin/io/realm/test/compiler/list/ListTests.kt
@@ -129,6 +129,13 @@ class ListTests {
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
         assertTrue(result.messages.contains("RealmLists cannot use a '*' projection"))
     }
+
+    @Test
+    fun `unsupported type in list - fails`() {
+        val result = compileFromSource(SourceFile.kotlin("nullableList.kt", UNSUPPORTED_TYPE))
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("Unsupported type for lists: 'A'"))
+    }
 }
 
 private val NON_NULLABLE_LIST_CODE = """
@@ -181,4 +188,19 @@ import java.lang.Exception
 class NullableTypeList : RealmObject {
     var list: RealmList<*> = realmListOf<String>()
 }
+""".trimIndent()
+
+private val UNSUPPORTED_TYPE = """
+    import io.realm.realmListOf
+    import io.realm.RealmInstant
+    import io.realm.RealmList
+    import io.realm.RealmObject
+
+    import java.lang.Exception
+
+    class A
+
+    class NullableTypeList : RealmObject {
+        var list: RealmList<A> = realmListOf()
+    }
 """.trimIndent()


### PR DESCRIPTION
This adds context with clickable link for model definition errors that allows navigation to the exact location of the erroneous definition.

<img width="908" alt="Screenshot 2022-01-19 at 11 21 46" src="https://user-images.githubusercontent.com/12733934/150111562-d4264186-8f40-4e36-b91c-4eb98b2ad9b5.png">

<img width="1183" alt="Screenshot 2022-01-19 at 10 47 23" src="https://user-images.githubusercontent.com/12733934/150106137-7f0ca4f7-04ac-4360-8042-77994351f509.png">

Further, separated all compiler plugin errors into a `fatalError` to be able to differentiate them from user modeling errors. 

Closes #173 