### PR TITLE
Upgrade to AGP 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Internal
 * Updated to Gradle 7.3.3.
-* Updated to Android Gradle Plugin 7.1.0-rc01.
+* Updated to Android Gradle Plugin 7.1.0.
 * Updated to AndroidX JUnit 1.1.3.
 * Updated to AndroidX Test 1.4.0.
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -56,7 +56,7 @@ object Versions {
         const val targetSdk = 31
         const val compileSdkVersion = 31
         const val buildToolsVersion = "31.0.0"
-        const val buildTools = "7.1.0-rc01" // https://maven.google.com/web/index.html?q=gradle#com.android.tools.build:gradle
+        const val buildTools = "7.1.0" // https://maven.google.com/web/index.html?q=gradle#com.android.tools.build:gradle
         const val ndkVersion = "23.1.7779620"
     }
     const val androidxStartup = "1.1.0" // https://maven.google.com/web/index.html?q=startup#androidx.startup:startup-runtime


### PR DESCRIPTION
Looks like AGP 7.1.0 is finally GA 🥳 