### PR TITLE
Support coroutine 1.6.0's freeze transparency

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/util/PlatformUtils.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/util/PlatformUtils.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.util
+
+/**
+ * Method to freeze state.
+ * Calls the platform implementation of 'freeze' on native, and is a noop on other platforms.
+ *
+ * Note, this method refers to Kotlin Natives notion of frozen objects, and not Realms variant
+ * of frozen objects.
+ */
+expect fun <T> T.freezeOnOldMM(): T

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/PlatformUtils.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/PlatformUtils.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.util
+
+import kotlin.native.concurrent.freeze
+
+
+@OptIn(ExperimentalStdlibApi::class)
+actual fun <T> T.freezeOnOldMM(): T = if (isExperimentalMM()) { this } else { this.freeze() }

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/PlatformUtils.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/PlatformUtils.kt
@@ -18,6 +18,5 @@ package io.realm.internal.util
 
 import kotlin.native.concurrent.freeze
 
-
 @OptIn(ExperimentalStdlibApi::class)
 actual fun <T> T.freezeOnOldMM(): T = if (isExperimentalMM()) { this } else { this.freeze() }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/util/PlatformUtils.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/util/PlatformUtils.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.util
+
+// All freezing is no-ops on JVM
+actual fun <T> T.freezeOnOldMM(): T = this

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -5,7 +5,7 @@ import io.realm.Cancellable
 import io.realm.VersionId
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
-import io.realm.internal.platform.freeze
+import io.realm.internal.util.freezeOnOldMM
 import io.realm.internal.platform.runBlocking
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.coroutines.CoroutineDispatcher
@@ -116,7 +116,7 @@ internal class SuspendableNotifier(
                             liveRef.emitFrozenUpdate(frozenRealm, change, this@callbackFlow)
                                 ?.let { checkResult(it) }
                         }
-                    }.freeze<io.realm.internal.interop.Callback>() // Freeze to allow cleaning up on another thread
+                    }.freezeOnOldMM()
                 val newToken =
                     NotificationToken<Callback<T>>(
                         // FIXME What is this callback for anyway?

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -5,8 +5,8 @@ import io.realm.Cancellable
 import io.realm.VersionId
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
-import io.realm.internal.util.freezeOnOldMM
 import io.realm.internal.platform.runBlocking
+import io.realm.internal.util.freezeOnOldMM
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.BufferOverflow

--- a/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/CoroutineUtils.kt
+++ b/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/CoroutineUtils.kt
@@ -18,13 +18,16 @@ public actual fun <T> runBlocking(
  */
 actual fun singleThreadDispatcher(id: String): CoroutineDispatcher {
     // TODO Find a way to report incompatible coroutine library and memory model here:
-    //  - Works for base/sync with:
-    //    - Coroutine native-mt variants and either old or new memory model
-    //  Works for base with:
-    //    - Coroutine 1.6.0 and new memory model
-    //  Works for sync with:
-    //    - Coroutine 1.6.0 and new memory model and -Pkotlin.native.binary.freezing=disabled
-    //      (required for ktor to work, but not a requirement for our library to work after this PR)
+    //  Supported scenarios are:
+    //  - Coroutine 1.6.0-native-mt:
+    //    - base/sync works with both (old/new) memory models
+    //  - Coroutine 1.6.0 and new memory model
+    //    - base works without `kotlin.native.binary.freezing=disabled` from this PR
+    //    - sync work but only with `kotlin.native.binary.freezing=disabled` as this is required by
+    //      ktor
+    //  Not supported:
+    //  - Coroutine 1.6.0 and old memory model
+    //
     //  Could maybe reuse ktor check from with our custom freezeOnOldMM :thinking:
     //  https://github.com/ktorio/ktor/blob/1.6.5/ktor-client/ktor-client-core/posix/src/io/ktor/client/utils/CoroutineUtilsPosix.kt
     //  or just catch and rethrow the below 1.6.0 exception with an appropriate error message:

--- a/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/CoroutineUtils.kt
+++ b/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/CoroutineUtils.kt
@@ -17,6 +17,19 @@ public actual fun <T> runBlocking(
  * The default dispatcher for Darwin platforms spawns a new thread with a run loop.
  */
 actual fun singleThreadDispatcher(id: String): CoroutineDispatcher {
+    // TODO Find a way to report incompatible coroutine library and memory model here:
+    //  - Works for base/sync with:
+    //    - Coroutine native-mt variants and either old or new memory model
+    //  Works for base with:
+    //    - Coroutine 1.6.0 and new memory model
+    //  Works for sync with:
+    //    - Coroutine 1.6.0 and new memory model and -Pkotlin.native.binary.freezing=disabled
+    //      (required for ktor to work, but not a requirement for our library to work after this PR)
+    //  Could maybe reuse ktor check from with our custom freezeOnOldMM :thinking:
+    //  https://github.com/ktorio/ktor/blob/1.6.5/ktor-client/ktor-client-core/posix/src/io/ktor/client/utils/CoroutineUtilsPosix.kt
+    //  or just catch and rethrow the below 1.6.0 exception with an appropriate error message:
+    //  io.realm.test.shared.notifications.SystemNotificationTests.multipleSchedulersOnSameThread FAILED
+    //    kotlin.IllegalStateException: This API is only supported for experimental K/N memory model
     return newSingleThreadContext(id)
 }
 

--- a/packages/library-sync/build.gradle.kts
+++ b/packages/library-sync/build.gradle.kts
@@ -58,7 +58,6 @@ kotlin {
                 implementation(project(":cinterop"))
 
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}") {
-                    version { strictly(Versions.coroutines) }
                 }
                 implementation("org.jetbrains.kotlinx:atomicfu:${Versions.atomicfu}")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:${Versions.serialization}")
@@ -68,7 +67,6 @@ kotlin {
                 implementation("io.ktor:ktor-client-serialization:${Versions.ktor}")
                 implementation("io.ktor:ktor-client-logging:${Versions.ktor}")
 
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
                 implementation("org.jetbrains.kotlinx:atomicfu:${Versions.atomicfu}")
             }
         }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/AppConfiguration.kt
@@ -141,7 +141,7 @@ interface AppConfiguration {
                         appLogger.debug(message)
                     }
                 }
-            ).freeze() // Kotlin network client needs to be frozen before passed to the C-API
+            ).freeze() // MM: Catches userLoggers // Kotlin network client needs to be frozen before passed to the C-API
 
             return AppConfigurationImpl(
                 appId = appId,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/EmailPasswordAuth.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/EmailPasswordAuth.kt
@@ -33,7 +33,7 @@ class EmailPasswordAuth(
                 Validation.checkEmpty(password, "password"),
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }.freeze() // MM: Doesn't catch user references
             )
             return channel.receive()
                 .getOrThrow()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
@@ -45,7 +45,7 @@ internal class AppConfigurationImpl(
         platform = "$OS_NAME/$RUNTIME",
         platformVersion = OS_VERSION,
         sdkVersion = io.realm.internal.SDK_VERSION
-    ).freeze()
+    )//.freeze() // MM: Is this needed at all?
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
@@ -24,6 +24,7 @@ import io.realm.internal.interop.sync.NetworkTransport
 import io.realm.internal.platform.OS_NAME
 import io.realm.internal.platform.OS_VERSION
 import io.realm.internal.platform.RUNTIME
+import io.realm.internal.platform.freeze
 import io.realm.mongodb.AppConfiguration
 import io.realm.mongodb.AppConfiguration.Companion.DEFAULT_BASE_URL
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppConfigurationImpl.kt
@@ -24,7 +24,6 @@ import io.realm.internal.interop.sync.NetworkTransport
 import io.realm.internal.platform.OS_NAME
 import io.realm.internal.platform.OS_VERSION
 import io.realm.internal.platform.RUNTIME
-import io.realm.internal.platform.freeze
 import io.realm.mongodb.AppConfiguration
 import io.realm.mongodb.AppConfiguration.Companion.DEFAULT_BASE_URL
 
@@ -45,7 +44,7 @@ internal class AppConfigurationImpl(
         platform = "$OS_NAME/$RUNTIME",
         platformVersion = OS_VERSION,
         sdkVersion = io.realm.internal.SDK_VERSION
-    )//.freeze() // MM: Is this needed at all?
+    ).freeze() // MM: Is this needed at all?
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/AppImpl.kt
@@ -59,7 +59,7 @@ internal class AppImpl(
                 Validation.checkType<CredentialImpl>(credentials, "credentials").nativePointer,
                 channelResultCallback<NativePointer, User>(channel) { userPointer ->
                     UserImpl(userPointer, this)
-                }.freeze()
+                }.freeze() // MM: Catches AppImpl instance, leading to configuration and hence user callbacks
             )
             return channel.receive()
                 .getOrThrow()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
@@ -19,7 +19,7 @@ fun createClient(timeoutMs: Long, customLogger: Logger?): HttpClient {
     // Need to freeze value as it is used inside the client's init lambda block, which also
     // freezes captured objects too, see:
     // https://youtrack.jetbrains.com/issue/KTOR-1223#focus=Comments-27-4618681.0-0
-    val frozenTimeout = timeoutMs.freeze()
+    val frozenTimeout = timeoutMs.freeze() // MM: Doesn't catch user reference
     return createPlatformClient {
         // Charset defaults to UTF-8 (https://ktor.io/docs/http-plain-text.html#configuration)
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncConfigurationImpl.kt
@@ -43,7 +43,7 @@ internal class SyncConfigurationImpl(
                 override fun onSyncError(pointer: NativePointer, throwable: SyncException) {
                     errorHandler.onError(SyncSessionImpl(pointer), throwable)
                 }
-            }.freeze()
+            }.freeze() // MM: Catches errorHandler
         )
         RealmInterop.realm_config_set_sync_config(configuration.nativeConfig, nativeSyncConfig)
     }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/UserImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/UserImpl.kt
@@ -47,7 +47,7 @@ internal class UserImpl(
                 nativePointer,
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }.freeze() // MM: Doesn't catch user reference
             )
             return channel.receive()
                 .getOrThrow()


### PR DESCRIPTION
This PR makes our internal `freeze` calls a no-op when running with Kotlin's new experimental memory model. This way we avoid freezing coroutine primitive to support Coroutine 1.6.0's new _freeze transparency_.

NOTE: Since `ktor` 1.6.5 doesn't support that yet the `kotlin.native.binary.freezing=disabled` is still required for `library-sync`