### PR TITLE
Refactor the compiler plugin to avoid breaking API in 1.6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* Updated to Gradle 7.3.3.
-* Updated to Android Gradle Plugin 7.1.0.
-* Updated to AndroidX JUnit 1.1.3.
-* Updated to AndroidX Test 1.4.0.
 
 
 ## 0.9.0 (2022-01-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 ### Fixed
-* Refactoring the compiler plugin to use API available in Kotlin `1.6.20` fixes ([#619](https://github.com/realm/realm-kotlin/issues/619)).
+* Refactor the compiler plugin to use API's compatible with Kotlin `1.6.20`. (Issue ([#619](https://github.com/realm/realm-kotlin/issues/619)).
 
 
 ### Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 0.10.0-SNAPSHOT (2022-MM-DD)
+
+### Breaking Changes
+
+### Enhancements
+
+### Fixed
+* Refactoring the compiler plugin to use API available in Kotlin `1.6.20` fixes ([#619](https://github.com/realm/realm-kotlin/issues/619)).
+
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10.
+  * Coroutines 1.6.0-native-mt. Also compatible with Coroutines 1.6.0 but requires enabling of the new memory model and disabling of freezing, see https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility for details on that.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* Updated to Gradle 7.3.3.
+* Updated to Android Gradle Plugin 7.1.0.
+* Updated to AndroidX JUnit 1.1.3.
+* Updated to AndroidX Test 1.4.0.
+
+
 ## 0.9.0 (2022-01-28)
 
 ### Breaking Changes

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
@@ -487,8 +487,8 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                                         symbol = backingField.symbol,
                                         receiver = irGet(receiver),
                                         value = irGet(setter.valueParameters.first()),
-                                        type = context.irBuiltIns.unitType)
-                                    ,
+                                        type = context.irBuiltIns.unitType
+                                    ),
                                     origin = IrStatementOrigin.IF
                                 )
                             )

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
@@ -45,7 +45,6 @@ import org.jetbrains.kotlin.ir.builders.irIfNull
 import org.jetbrains.kotlin.ir.builders.irIfThenElse
 import org.jetbrains.kotlin.ir.builders.irNull
 import org.jetbrains.kotlin.ir.builders.irReturn
-import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
@@ -58,6 +57,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrReturn
 import org.jetbrains.kotlin.ir.expressions.IrSetField
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.expressions.impl.IrSetFieldImpl
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrFail
@@ -402,7 +402,9 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                                 val temporary = scope.createTemporaryVariableDeclaration(
                                     cinteropCall.type,
                                     "coreValue",
-                                    false
+                                    false,
+                                    startOffset = startOffset,
+                                    endOffset = endOffset
                                 ).apply { initializer = cinteropCall }
                                 +createSafeCallConstruction(
                                     temporary,
@@ -479,11 +481,14 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                                     // For managed property call C-Interop function
                                     cinteropCall,
                                     // For unmanaged property set backing field
-                                    irSetField(
-                                        irGet(receiver),
-                                        backingField,
-                                        irGet(setter.valueParameters.first())
-                                    ),
+                                    IrSetFieldImpl(
+                                        startOffset = startOffset,
+                                        endOffset = endOffset,
+                                        symbol = backingField.symbol,
+                                        receiver = irGet(receiver),
+                                        value = irGet(setter.valueParameters.first()),
+                                        type = context.irBuiltIns.unitType)
+                                    ,
                                     origin = IrStatementOrigin.IF
                                 )
                             )

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -62,7 +62,6 @@ import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.builders.irLong
 import org.jetbrains.kotlin.ir.builders.irReturn
-import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
@@ -76,6 +75,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrExpressionBodyImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrPropertyReferenceImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrSetFieldImpl
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrFail
@@ -556,11 +556,14 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         }
         setter.body = DeclarationIrBuilder(pluginContext, setter.symbol).irBlockBody {
             at(startOffset, endOffset)
-            +irSetField(
-                irGet(setter.dispatchReceiverParameter!!),
-                property.backingField!!,
-                irGet(valueParameter)
-            )
+
+            +IrSetFieldImpl(
+                startOffset = startOffset,
+                endOffset = endOffset,
+                symbol = property.backingField!!.symbol,
+                receiver = irGet(setter.dispatchReceiverParameter!!),
+                value = irGet(valueParameter),
+                type = context.irBuiltIns.unitType)
         }
     }
 

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -563,7 +563,8 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                 symbol = property.backingField!!.symbol,
                 receiver = irGet(setter.dispatchReceiverParameter!!),
                 value = irGet(valueParameter),
-                type = context.irBuiltIns.unitType)
+                type = context.irBuiltIns.unitType
+            )
         }
     }
 


### PR DESCRIPTION
Some compiler API have changed in 1.6.20 (example https://github.com/realm/realm-kotlin/issues/619#issuecomment-1029962450) we can avoid bumping to `1.6.20` and still be compatible with `1.6.20` with the following refactors. 
