### PR TITLE
Remove build warnings

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
@@ -91,7 +91,7 @@ interface Configuration {
     // The property functions in this builder return the type of the builder itself, represented by
     // [S]. This is due to `library-base` not having visibility over `library-sync` and therefore
     // all function return types have to be typecast as [S].
-    @Suppress("UnnecessaryAbstractClass") // Actual implementations should rewire build() to companion map variant
+    @Suppress("UnnecessaryAbstractClass", "UNCHECKED_CAST") // Actual implementations should rewire build() to companion map variant
     abstract class SharedBuilder<T, S : SharedBuilder<T, S>>(
         var schema: Set<KClass<out RealmObject>> = setOf()
     ) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
@@ -77,7 +77,7 @@ internal class MutableRealmImpl : BaseRealmImpl, MutableRealm {
     }
 
     override fun <T : RealmObject> findLatest(obj: T): T? {
-        return if (obj == null || !obj.isValid()) {
+        return if (!obj.isValid()) {
             null
         } else if (!obj.isManaged()) {
             throw IllegalArgumentException(

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
@@ -185,7 +185,7 @@ internal class ListOperator<E>(
         return with(metadata) {
             when (clazz) {
                 Byte::class -> (value as Long).toByte()
-                Char::class -> (value as Long).toChar()
+                Char::class -> (value as Long).toInt().toChar()
                 Short::class -> (value as Long).toShort()
                 Int::class -> (value as Long).toInt()
                 Long::class,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -52,7 +52,7 @@ object RealmObjectHelper {
         val realm = obj.`$realm$Owner` ?: throw IllegalStateException("Invalid/deleted object")
         val o = obj.`$realm$ObjectPointer` ?: throw IllegalStateException("Invalid/deleted object")
         val key = RealmInterop.realm_get_col_key(realm.dbPointer, obj.`$realm$TableName`!!, col)
-        val res = RealmInterop.realm_get_value<Timestamp>(o, key)
+        val res = RealmInterop.realm_get_value<Timestamp?>(o, key)
         return if (res == null) null else RealmInstantImpl(res)
     }
 
@@ -66,7 +66,7 @@ object RealmObjectHelper {
         val realm = obj.`$realm$Owner` ?: throw IllegalStateException("Invalid/deleted object")
         val o = obj.`$realm$ObjectPointer` ?: throw IllegalStateException("Invalid/deleted object")
         val key = RealmInterop.realm_get_col_key(realm.dbPointer, obj.`$realm$TableName`!!, col)
-        val link = RealmInterop.realm_get_value<Link>(o, key)
+        val link = RealmInterop.realm_get_value<Link?>(o, key)
         if (link != null) {
             val value =
                 (obj.`$realm$Mediator`!!).createInstanceOf(R::class)
@@ -184,6 +184,7 @@ object RealmObjectHelper {
         setValue(obj, col, newValue)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     internal fun setList(obj: RealmObjectInternal, col: String, list: RealmList<Any?>) {
         TODO()
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -74,6 +74,7 @@ interface RealmObjectInternal : RealmObject, RealmStateHolder, io.realm.internal
         val managedModel = mediator.createInstanceOf(type)
         val dbPointer = liveRealm.dbPointer
         return RealmInterop.realm_object_resolve_in(`$realm$ObjectPointer`!!, dbPointer)?.let {
+            @Suppress("UNCHECKED_CAST")
             managedModel.manage(
                 liveRealm,
                 mediator,
@@ -107,7 +108,7 @@ interface RealmObjectInternal : RealmObject, RealmStateHolder, io.realm.internal
     }
 }
 
-internal inline fun RealmObject.realmObjectInternal(): RealmObjectInternal {
+internal fun RealmObject.realmObjectInternal(): RealmObjectInternal {
     return this as RealmObjectInternal
 }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
@@ -42,6 +42,7 @@ data class RealmReference(
         return RealmInterop.realm_is_closed(dbPointer)
     }
 
+    @Suppress("NOTHING_TO_INLINE") // Inline for more readable stack traces.
     inline fun checkClosed() {
         if (isClosed()) {
             throw IllegalStateException("Realm has been closed and is no longer accessible: ${owner.configuration.path}")

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -69,7 +69,7 @@ import kotlin.reflect.KProperty1
  * Add a check and error message for code that never be reached because it should have been
  * replaced by the Compiler Plugin.
  */
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "NOTHING_TO_INLINE")
 inline fun REPLACED_BY_IR(
     message: String = "This code should have been replaced by the Realm Compiler Plugin. " +
         "Has the `realm-kotlin` Gradle plugin been applied to the project?"
@@ -159,10 +159,10 @@ internal fun <T> copyToRealm(
         if (!elementToCopy.isManaged()) {
             val instance: RealmObjectInternal = element
             val companion = mediator.companionOf(instance::class)
-            val members =
-                companion.`$realm$fields` as List<KMutableProperty1<RealmObjectInternal, Any?>>
-
+            @Suppress("UNCHECKED_CAST")
+            val members = companion.`$realm$fields` as List<KMutableProperty1<RealmObjectInternal, Any?>>
             val target = companion.`$realm$primaryKey`?.let { primaryKey ->
+                @Suppress("UNCHECKED_CAST")
                 create(
                     mediator,
                     realmPointer,
@@ -201,6 +201,7 @@ internal fun <T> copyToRealm(
                     member.set(target, it)
                 }
             }
+            @Suppress("UNCHECKED_CAST")
             elementToCopy = target as T
         }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -52,7 +52,7 @@ internal class SuspendableNotifier(
     )
 
     private val realmInitializer = lazy {
-        val dbPointer = RealmInterop.realm_open((owner.configuration as InternalConfiguration).nativeConfig, dispatcher)
+        val dbPointer = RealmInterop.realm_open(owner.configuration.nativeConfig, dispatcher)
         object : BaseRealmImpl(owner.configuration, dbPointer) {
             /* Realms used by the Notifier is just a basic Live Realm */
         }
@@ -137,6 +137,7 @@ internal class SuspendableNotifier(
      *
      * FIXME Callers of this method must make sure it is called on the correct [SuspendableNotifier.dispatcher].
      */
+    @Suppress("UNUSED_PARAMETER")
     internal fun registerRealmChangedListener(callback: Callback<Pair<NativePointer, VersionId>>): Cancellable {
         TODO("Waiting for RealmInterop to have support for global Realm changed")
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/ScalarQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/ScalarQuery.kt
@@ -141,6 +141,7 @@ internal class MinMaxQuery<E : RealmObject, T : Any> constructor(
                 throw IllegalArgumentException("Use SumQuery instead.")
         }
         // TODO Expand to support other numeric types, e.g. Decimal128
+        @Suppress("UNCHECKED_CAST")
         return when (result) {
             null -> null
             is Timestamp -> RealmInstant.fromEpochSeconds(result.seconds, result.nanoSeconds)
@@ -202,6 +203,7 @@ internal class SumQuery<E : RealmObject, T : Any> constructor(
     private fun computeAggregatedValue(resultsPointer: NativePointer, colKey: Long): T {
         val result: T = RealmInterop.realm_results_sum(resultsPointer, colKey)
         // TODO Expand to support other numeric types, e.g. Decimal128
+        @Suppress("UNCHECKED_CAST")
         return when (result) {
             is Number -> when (type) {
                 Int::class -> result.toInt()


### PR DESCRIPTION
This PR reduces the amount of build warnings we have. This PR removes warnings found in `library-base`. Only two warnings should be left, which I'm not 100% sure what to do about:

```
w: Argument -module-name is passed multiple times. Only the last value will be used: io.realm.kotlin.library
w: /Users/cm/Realm/realm-kotlin/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt: (66, 52): Extension is shadowed by a member: public open fun freeze(frozenRealm: RealmReference): RealmObjectInternal?
```