### PR TITLE
Fine grained notifications on single object queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add support for fine grained notification on Realm objects. `RealmObject.asFlow()` yields `ObjectChange` that represent the `ObjectInitial`, `ObjectUpdated` or `ObjectDeleted` states.
 * Add support for fine grained notification on Realm lists. `RealmList.asFlow()` yields `ListChange` that represent the `InitialList`, `UpdatedList` or `DeletedList` states.
 * Add support for fine grained notification on Realm results. `RealmResults.asFlow()` yields `ListChange` that represent the `InitialList`, `UpdatedList` or `DeletedList` states.
+* Add support for fine grained notification on RealmSingleQuery. `RealmSingleQuery.asFlow()` yields `ObjectChange` that represent the events might happen on the first element of the query.
 
 ### Fixed
 * Refactor the compiler plugin to use API's compatible with Kotlin `1.6.20`. (Issue ([#619](https://github.com/realm/realm-kotlin/issues/619)).

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -81,6 +81,7 @@ expect object RealmInterop {
     fun realm_find_class(realm: NativePointer, name: String): ClassKey?
     fun realm_get_class(realm: NativePointer, classKey: ClassKey): ClassInfo
     fun realm_get_class_properties(realm: NativePointer, classKey: ClassKey, max: Long): List<PropertyInfo>
+    fun realm_equals(pointer1: NativePointer, pointer2: NativePointer): Boolean
 
     fun realm_release(p: NativePointer)
 

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -485,6 +485,10 @@ actual object RealmInterop {
         }
     }
 
+    actual fun realm_equals(pointer1: NativePointer, pointer2: NativePointer): Boolean {
+        return realm_wrapper.realm_equals((pointer1 as CPointerWrapper).ptr, (pointer2 as CPointerWrapper).ptr)
+    }
+
     actual fun realm_release(p: NativePointer) {
         realm_wrapper.realm_release((p as CPointerWrapper).ptr)
     }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -228,6 +228,10 @@ actual object RealmInterop {
         }
     }
 
+    actual fun realm_equals(pointer1: NativePointer, pointer2: NativePointer): Boolean {
+        return realmc.realm_equals(pointer1.cptr(), pointer2.cptr())
+    }
+
     actual fun realm_release(p: NativePointer) {
         realmc.realm_release((p as LongPointerWrapper).ptr)
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -18,6 +18,7 @@ package io.realm
 
 import io.realm.internal.MutableRealmImpl
 import io.realm.internal.RealmObjectInternal
+import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.realmObjectInternal
 import io.realm.notifications.ObjectChange
@@ -69,6 +70,45 @@ fun RealmObject.delete() {
  */
 fun RealmObject.isManaged(): Boolean {
     return realmObjectInternal().`$realm$IsManaged`
+}
+
+/**
+ * Checks whether or not two Realm objects represent the same underlying object, by advancing the
+ * [behind] object up to the [front] Realm version.
+ */
+internal fun equalsToResolvingIn(front: RealmObjectInternal, behind: RealmObjectInternal): Boolean {
+    val dbPointer: NativePointer = front.`$realm$Owner`!!.dbPointer
+    val resolvedPointer: NativePointer =
+        RealmInterop.realm_object_resolve_in(behind.`$realm$ObjectPointer`!!, dbPointer)
+            ?: return false
+
+    return RealmInterop.realm_equals(front.`$realm$ObjectPointer`!!, resolvedPointer)
+}
+
+/**
+ * Checks whether [this] and [other] represent the same underlying object or not.
+ */
+internal fun RealmObject.equalsTo(other: RealmObject?): Boolean {
+    if (other == null) return false
+    if (other !is RealmObjectInternal) return false
+
+    if (!isManaged() || !other.isManaged()) {
+        throw IllegalStateException("Cannot compare unmanaged objects.")
+    }
+
+    val thisInternal = this.realmObjectInternal()
+    val otherInternal = other.realmObjectInternal()
+
+    val versionId = thisInternal.`$realm$Owner`!!.version()
+    val otherVersionId = otherInternal.`$realm$Owner`!!.version()
+
+    return if (versionId > otherVersionId) {
+        equalsToResolvingIn(thisInternal, otherInternal)
+    } else if (versionId < otherVersionId) {
+        equalsToResolvingIn(otherInternal, thisInternal)
+    } else {
+        RealmInterop.realm_equals(thisInternal.`$realm$ObjectPointer`!!, otherInternal.`$realm$ObjectPointer`!!)
+    }
 }
 
 /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableNotifier.kt
@@ -9,6 +9,7 @@ import io.realm.notifications.Callback
 import io.realm.notifications.Cancellable
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.ChannelResult
 import kotlinx.coroutines.channels.awaitClose
@@ -92,46 +93,58 @@ internal class SuspendableNotifier(
     }
 
     internal fun <T, C> registerObserver(thawableObservable: Thawable<Observable<T, C>>): Flow<C> {
-        return callbackFlow {
-            val token: AtomicRef<Cancellable> = kotlinx.atomicfu.atomic(NO_OP_NOTIFICATION_TOKEN)
-            withContext(dispatcher) {
-                ensureActive()
-                val liveRef: Observable<T, C> = thawableObservable.thaw(realm.realmReference)
-                    ?: error("Cannot listen for changes on a deleted reference")
-                val interopCallback: io.realm.internal.interop.Callback =
-                    object : io.realm.internal.interop.Callback {
-                        override fun onChange(change: NativePointer) {
-                            // FIXME How to make sure the Realm isn't closed when handling this?
+        var cancelCallback: () -> Unit = {}
 
-                            // FIXME The Realm should have been frozen in `realmChanged`, but this isn't supported yet.
-                            //  Instead we create the frozen version ourselves (which is correct, but pretty inefficient)
-                            //  We also send it to the owner Realm, so it can keep track of its lifecycle
-                            val frozenRealm = RealmReference(
-                                owner,
-                                RealmInterop.realm_freeze(realm.realmReference.dbPointer)
-                            )
-                            notifyRealmChanged(frozenRealm)
-                            // Notifications need to be delivered with the version they where created on, otherwise
-                            // the fine-grained notification data might be out of sync.
-                            liveRef.emitFrozenUpdate(
-                                frozenRealm,
-                                change,
-                                this@callbackFlow
-                            )?.let {
-                                checkResult(it)
+        return object :
+            Cancellable,
+            Flow<C> by callbackFlow({
+                cancelCallback = {
+                    cancel()
+                }
+                val token: AtomicRef<Cancellable> =
+                    kotlinx.atomicfu.atomic(NO_OP_NOTIFICATION_TOKEN)
+                withContext(dispatcher) {
+                    ensureActive()
+                    val liveRef: Observable<T, C> = thawableObservable.thaw(realm.realmReference)
+                        ?: error("Cannot listen for changes on a deleted reference")
+                    val interopCallback: io.realm.internal.interop.Callback =
+                        object : io.realm.internal.interop.Callback {
+                            override fun onChange(change: NativePointer) {
+                                // FIXME How to make sure the Realm isn't closed when handling this?
+
+                                // FIXME The Realm should have been frozen in `realmChanged`, but this isn't supported yet.
+                                //  Instead we create the frozen version ourselves (which is correct, but pretty inefficient)
+                                //  We also send it to the owner Realm, so it can keep track of its lifecycle
+                                val frozenRealm = RealmReference(
+                                    owner,
+                                    RealmInterop.realm_freeze(realm.realmReference.dbPointer)
+                                )
+                                notifyRealmChanged(frozenRealm)
+                                // Notifications need to be delivered with the version they where created on, otherwise
+                                // the fine-grained notification data might be out of sync.
+                                liveRef.emitFrozenUpdate(
+                                    frozenRealm,
+                                    change,
+                                    this@callbackFlow
+                                )?.let {
+                                    checkResult(it)
+                                }
                             }
-                        }
-                    }.freeze<io.realm.internal.interop.Callback>() // Freeze to allow cleaning up on another thread
-                val newToken =
-                    NotificationToken<Callback<T>>(
-                        // FIXME What is this callback for anyway?
-                        callback = Callback { _, _ -> /* Do nothing */ },
-                        token = liveRef.registerForNotification(interopCallback)
-                    )
-                token.value = newToken
-            }
-            awaitClose {
-                token.value.cancel()
+                        }.freeze<io.realm.internal.interop.Callback>() // Freeze to allow cleaning up on another thread
+                    val newToken =
+                        NotificationToken<Callback<T>>(
+                            // FIXME What is this callback for anyway?
+                            callback = Callback { _, _ -> /* Do nothing */ },
+                            token = liveRef.registerForNotification(interopCallback)
+                        )
+                    token.value = newToken
+                }
+                awaitClose {
+                    token.value.cancel()
+                }
+            }) {
+            override fun cancel() {
+                cancelCallback()
             }
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/query/RealmQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/query/RealmQuery.kt
@@ -24,6 +24,7 @@ import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.notifications.ListChange
+import io.realm.notifications.ObjectChange
 import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
@@ -254,7 +255,7 @@ interface RealmSingleQuery<T : RealmObject> {
      *
      * @return a flow representing changes to the [RealmObject] resulting from running this query.
      */
-    fun asFlow(): Flow<T?>
+    fun asFlow(): Flow<ObjectChange<T>>
 }
 
 /**

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/QueryTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/QueryTests.kt
@@ -24,9 +24,13 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.internal.query.AggregatorQueryType
+import io.realm.notifications.DeletedObject
 import io.realm.notifications.InitialList
+import io.realm.notifications.InitialObject
 import io.realm.notifications.ListChange
+import io.realm.notifications.ObjectChange
 import io.realm.notifications.UpdatedList
+import io.realm.notifications.UpdatedObject
 import io.realm.query
 import io.realm.query.RealmQuery
 import io.realm.query.Sort
@@ -1626,48 +1630,22 @@ class QueryTests {
     }
 
     @Test
+    @Suppress("LongMethod")
     fun first_asFlow() {
-        val channel = Channel<QuerySample?>(1)
-        val value1 = 2
-        val value2 = 7
+        val channel = Channel<ObjectChange<QuerySample>>(2)
+
+        val dataset = arrayOf(
+            QuerySample(intField = 1),
+            QuerySample(intField = 2),
+            QuerySample(intField = 3),
+            QuerySample(intField = 4),
+            QuerySample(intField = 5)
+        )
 
         runBlocking {
-            val observer = async {
-                realm.query<QuerySample>("intField > $0", value1)
-                    .first()
-                    .asFlow()
-                    .collect { first ->
-                        channel.send(first)
-                    }
-            }
-
-            val firstNull = channel.receive()
-            assertNull(firstNull)
-
-            realm.writeBlocking {
-                copyToRealm(QuerySample(intField = value1))
-                copyToRealm(QuerySample(intField = value2))
-            }
-
-            val first = channel.receive()
-            assertNotNull(first)
-            assertEquals(value2, first.intField)
-            observer.cancel()
-            channel.close()
-        }
-    }
-
-    @Test
-    fun first_asFlow_deleteObservable() {
-        val channel = Channel<QuerySample?>(1)
-
-        runBlocking {
-            realm.writeBlocking {
-                copyToRealm(QuerySample())
-            }
-
             val observer = async {
                 realm.query<QuerySample>()
+                    .sort(QuerySample::intField.name, Sort.DESCENDING)
                     .first()
                     .asFlow()
                     .collect { first ->
@@ -1675,15 +1653,96 @@ class QueryTests {
                     }
             }
 
-            assertNotNull(channel.receive())
-
+            // Insert initial data set
+            // [5, 4, 3, 2, 1]
             realm.writeBlocking {
-                query<QuerySample>()
-                    .find()
-                    .delete()
+                dataset.forEach { querySample ->
+                    copyToRealm(querySample)
+                }
             }
 
-            assertNull(channel.receive())
+            channel.receive().let { objectChange ->
+                assertTrue(channel.isEmpty) // Validates that this is the first event and only event
+
+                assertIs<InitialObject<QuerySample>>(objectChange)
+                assertEquals(5, objectChange.obj.intField)
+            }
+
+            // Update the head element from value 5 to 6
+            // [6, 4, 3, 2, 1]
+            realm.writeBlocking {
+                query<QuerySample>("intField = $0", 5).first().find { querySample ->
+                    querySample!!.intField = 6
+                }
+            }
+
+            channel.receive().let { objectChange ->
+                assertIs<UpdatedObject<QuerySample>>(objectChange)
+                assertEquals(6, objectChange.obj.intField)
+            }
+
+            // Update the head element 6 to value 7
+            // [7, 4, 3, 2, 1]
+            realm.writeBlocking {
+                query<QuerySample>("intField = $0", 6).first().find { querySample ->
+                    querySample!!.intField = 7
+                }
+            }
+
+            channel.receive().let { objectChange ->
+                assertIs<UpdatedObject<QuerySample>>(objectChange)
+                assertEquals(7, objectChange.obj.intField)
+            }
+
+            // Delete the head element 6
+            // [4, 3, 2, 1]
+            realm.writeBlocking {
+                delete(query<QuerySample>("intField = $0", 7).first().find()!!)
+            }
+
+            assertIs<DeletedObject<QuerySample>>(channel.receive())
+
+            channel.receive().let { objectChange ->
+                assertIs<InitialObject<QuerySample>>(objectChange)
+                assertEquals(4, objectChange.obj.intField)
+            }
+
+            // Replace the head value with the second one
+            // [<7>, 4, 2, 1]
+            realm.writeBlocking {
+                query<QuerySample>("intField = $0", 3).first().find { querySample ->
+                    querySample!!.intField = 7
+                }
+            }
+
+            channel.receive().let { objectChange ->
+                assertIs<InitialObject<QuerySample>>(objectChange)
+                assertEquals(7, objectChange.obj.intField)
+            }
+
+            // Delete head element and update the new head
+            // [10, 2, 1]
+            realm.writeBlocking {
+                query<QuerySample>("intField = $0", 7).find().delete()
+                query<QuerySample>("intField = $0", 4).first().find { querySample ->
+                    querySample!!.intField = 10
+                }
+            }
+
+            assertIs<DeletedObject<QuerySample>>(channel.receive())
+
+            channel.receive().let { objectChange ->
+                assertIs<InitialObject<QuerySample>>(objectChange)
+                assertEquals(10, objectChange.obj.intField)
+            }
+
+            // Empty the list
+            // []
+            realm.writeBlocking {
+                query<QuerySample>().find().delete()
+            }
+
+            assertIs<DeletedObject<QuerySample>>(channel.receive())
 
             observer.cancel()
             channel.close()
@@ -1693,8 +1752,8 @@ class QueryTests {
     @Test
     fun first_asFlow_cancel() {
         runBlocking {
-            val channel1 = Channel<QuerySample?>(1)
-            val channel2 = Channel<QuerySample?>(1)
+            val channel1 = Channel<ObjectChange<QuerySample>>(2)
+            val channel2 = Channel<ObjectChange<QuerySample>>(2)
 
             val observer1 = async {
                 realm.query<QuerySample>()
@@ -1713,10 +1772,6 @@ class QueryTests {
                     }
             }
 
-            // First emission will be null
-            assertNull(channel1.receive())
-            assertNull(channel2.receive())
-
             // Write one object
             realm.write {
                 copyToRealm(QuerySample().apply { stringField = "Bar" })
@@ -1727,9 +1782,11 @@ class QueryTests {
             assertNotNull(channel2.receive())
             observer1.cancel()
 
-            // Write another object
+            // Update object
             realm.write {
-                copyToRealm(QuerySample().apply { stringField = "Baz" })
+                query<QuerySample>("stringField = $0", "Bar").first().find {
+                    it!!.stringField = "Baz"
+                }
             }
 
             // Assert emission and that the original channel hasn't been received
@@ -2398,4 +2455,8 @@ class QuerySample() : RealmObject {
     var nullableTimestampListField: RealmList<RealmInstant?> = realmListOf()
 
     var child: QuerySample? = null
+
+    override fun toString(): String {
+        return this.stringField
+    }
 }


### PR DESCRIPTION
With this PR we allow to observe `ObjectChange` events on flows from single object queries.

It is achieved by mapping the query `RealmResults` flow with the fine grained flows of the head of that list on that state.

We have added support for cancelling a flow, a flow can be casted into a `Cancellable`. It is required to stop observing object events when the head list changes because of a replacement, object flows only cancels automatically when the object gets deleted.

Realm flows are now cancellable because object flows only get cancel automatically when the object gets deleted and we needed a way to stop the flow when the query head gets replaced.

The new flow lifecycle is of the following:
- If subscribed on an empty query the flow will not yield any event until an element is added, then it would yield an `InitialObject` event for the first element. On a non-empty list it would start with an `InitialObject` event for its first element.
- Once subscribed and the `InitialObject` event is observed, sequential `UpdatedObject` instances would be observed if the first element is modified. If the element is deleted a `DeletedObject` would be yield.
- If the first element is replaced with a new value, an `InitialObject` would be yield for the new head, and would be follow with `UpdatedObject` on all its changes.