### PR TITLE
Update to latest core scheduler API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Internal
 * Downgraded to Gradle 7.2 as a work-around for https://youtrack.jetbrains.com/issue/KT-51325.
+* Updated to Realm Core 11.9.0, commit: 377a85d2a385a31ec91be7e5fe8c09d22365df97
 
 
 ## 0.9.0 (2022-01-28)

--- a/packages/cinterop/src/androidTest/java/io/realm/test/CinteropTest.kt
+++ b/packages/cinterop/src/androidTest/java/io/realm/test/CinteropTest.kt
@@ -58,7 +58,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("11.7.0", realmc.realm_get_library_version())
+        assertEquals("11.9.0", realmc.realm_get_library_version())
     }
 
     // Test various schema migration with automatic flag:

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/Errors.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/Errors.kt
@@ -97,3 +97,9 @@ class RealmCoreInvalidQueryStringException(message: String?) : RealmCoreExceptio
 class RealmCoreInvalidQueryException(message: String?) : RealmCoreException(message)
 // RLM_ERR_CALLBACK
 class RealmCoreCallbackException(message: String?) : RealmCoreException(message)
+// RLM_ERR_FILE_ACCESS_ERROR
+class RealmCoreFileAccessErrorException(message: String?) : RealmCoreException(message)
+// RLM_ERR_FILE_PERMISSION_DENIED
+class RealmCoreFilePermissionDeniedException(message: String?) : RealmCoreException(message)
+// RLM_ERR_DELETE_OPENED_REALM
+class RealmCoreDeleteOpenRealmException(message: String?) : RealmCoreException(message)

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/Errors.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/Errors.kt
@@ -59,6 +59,9 @@ fun coreErrorAsThrowable(nativeValue: realm_errno, message: String?): RealmCoreE
         realm_errno.RLM_ERR_INVALID_QUERY_STRING -> RealmCoreInvalidQueryStringException(message)
         realm_errno.RLM_ERR_INVALID_QUERY -> RealmCoreInvalidQueryException(message)
         realm_errno.RLM_ERR_CALLBACK -> RealmCoreCallbackException(message)
+        realm_errno.RLM_ERR_FILE_ACCESS_ERROR -> RealmCoreFileAccessErrorException(message)
+        realm_errno.RLM_ERR_FILE_PERMISSION_DENIED -> RealmCoreFilePermissionDeniedException(message)
+        realm_errno.RLM_ERR_DELETE_OPENED_REALM -> RealmCoreDeleteOpenRealmException(message)
         else -> RealmCoreUnknownException(message)
     }
 }

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -1504,7 +1504,7 @@ actual object RealmInterop {
                 staticCFunction<COpaquePointer?, Boolean> { userdata -> true },
             )
         ) ?: error("Couldn't create scheduler")
-        scheduler.set_scheduler(capi_scheduler!!)
+        scheduler.set_scheduler(capi_scheduler)
         scheduler.freeze()
         return capi_scheduler
     }

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -19,7 +19,6 @@
 package io.realm.internal.interop
 
 import io.realm.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
-import io.realm.internal.interop.RealmInterop.propertyInfo
 import io.realm.internal.interop.sync.AuthProvider
 import io.realm.internal.interop.sync.CoreUserState
 import io.realm.internal.interop.sync.MetadataMode
@@ -27,8 +26,6 @@ import io.realm.internal.interop.sync.NetworkTransport
 import io.realm.internal.interop.sync.Response
 import io.realm.mongodb.AppException
 import io.realm.mongodb.SyncException
-import kotlinx.atomicfu.AtomicRef
-import kotlinx.atomicfu.atomic
 import kotlinx.cinterop.BooleanVar
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ByteVarOf
@@ -49,7 +46,6 @@ import kotlinx.cinterop.convert
 import kotlinx.cinterop.cstr
 import kotlinx.cinterop.get
 import kotlinx.cinterop.getBytes
-import kotlinx.cinterop.invoke
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
@@ -87,6 +83,7 @@ import realm_wrapper.realm_object_t
 import realm_wrapper.realm_property_info_t
 import realm_wrapper.realm_release
 import realm_wrapper.realm_scheduler_notify_func_t
+import realm_wrapper.realm_scheduler_perform_work
 import realm_wrapper.realm_scheduler_t
 import realm_wrapper.realm_string_t
 import realm_wrapper.realm_sync_client_metadata_mode
@@ -95,7 +92,6 @@ import realm_wrapper.realm_user_t
 import realm_wrapper.realm_value_t
 import realm_wrapper.realm_value_type
 import realm_wrapper.realm_version_id_t
-import kotlin.collections.set
 import kotlin.native.concurrent.freeze
 import kotlin.native.internal.createCleaner
 
@@ -1460,75 +1456,57 @@ actual object RealmInterop {
 
     private fun createSingleThreadDispatcherScheduler(
         dispatcher: CoroutineDispatcher
-    ): CPointer<realm_scheduler_t>? {
+    ): CPointer<realm_scheduler_t> {
         printlntid("createSingleThreadDispatcherScheduler")
-        val scheduler = SingleThreadDispatcherScheduler(tid(), dispatcher).freeze()
+        val scheduler = SingleThreadDispatcherScheduler(tid(), dispatcher)
 
-        return realm_wrapper.realm_scheduler_new(
-            // userdata: kotlinx.cinterop.CValuesRef<*>?,
-            scheduler.ref,
+        val capi_scheduler: CPointer<realm_scheduler_t> = checkedPointerResult(
+            realm_wrapper.realm_scheduler_new(
+                // userdata: kotlinx.cinterop.CValuesRef<*>?,
+                scheduler.ref,
 
-            // free: realm_wrapper.realm_free_userdata_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Unit>>? */,
-            staticCFunction<COpaquePointer?, Unit> { userdata ->
-                printlntid("free")
-                userdata?.asStableRef<SingleThreadDispatcherScheduler>()?.dispose()
-            },
+                // free: realm_wrapper.realm_free_userdata_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Unit>>? */,
+                staticCFunction<COpaquePointer?, Unit> { userdata ->
+                    printlntid("free")
+                    userdata?.asStableRef<SingleThreadDispatcherScheduler>()?.dispose()
+                },
 
-            // notify: realm_wrapper.realm_scheduler_notify_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Unit>>? */,
-            staticCFunction<COpaquePointer?, Unit> { userdata ->
-                // Must be thread safe
-                val scheduler =
-                    userdata!!.asStableRef<SingleThreadDispatcherScheduler>().get()
-                printlntid("$scheduler notify")
-                try {
-                    scheduler.notify()
-                } catch (e: Exception) {
-                    // Should never happen, but is included for development to get some indicators
-                    // on errors instead of silent crashes.
-                    e.printStackTrace()
-                }
-            },
-
-            // is_on_thread: realm_wrapper.realm_scheduler_is_on_thread_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Boolean>>? */,
-            staticCFunction<COpaquePointer?, Boolean> { userdata ->
-                // Must be thread safe
-                val scheduler =
-                    userdata!!.asStableRef<SingleThreadDispatcherScheduler>().get()
-                printlntid("is_on_thread[$scheduler] ${scheduler.threadId} " + tid())
-                scheduler.threadId == tid()
-            },
-
-            // is_same_as: realm_wrapper.realm_scheduler_is_same_as_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */, kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Boolean>>? */,
-            staticCFunction<COpaquePointer?, COpaquePointer?, Boolean> { userdata, other ->
-                userdata == other
-            },
-
-            // can_deliver_notifications: realm_wrapper.realm_scheduler_can_deliver_notifications_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Boolean>>? */,
-            staticCFunction<COpaquePointer?, Boolean> { userdata -> true },
-
-            // set_notify_callback: realm_wrapper.realm_scheduler_set_notify_callback_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(
-            //     userdata kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */,
-            //     callback_userdata kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */,
-            //     free callback userdata realm_wrapper.realm_free_userdata_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Unit>>? */,
-            //     notify realm_wrapper.realm_scheduler_notify_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Unit>>? */) -> kotlin.Unit>>? */)
-            staticCFunction { userdata, notify_callback_userdata, free_notify_callback_userdata, notify_callback ->
-                try {
+                // notify: realm_wrapper.realm_scheduler_notify_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Unit>>? */,
+                staticCFunction<COpaquePointer?, Unit> { userdata ->
+                    // Must be thread safe
                     val scheduler =
                         userdata!!.asStableRef<SingleThreadDispatcherScheduler>().get()
-                    printlntid("set notify callback [$scheduler]: $notify_callback $notify_callback_userdata")
-                    scheduler.set_notify_callback(
-                        CoreCallback(
-                            notify_callback!!,
-                            notify_callback_userdata!!
-                        )
-                    )
-                } catch (e: Exception) {
-                    // Should never happen, but is included for development to get some indicators
-                    // on errors instead of silent crashes.
-                    e.printStackTrace()
-                }
-            }
-        )
+                    printlntid("$scheduler notify")
+                    try {
+                        scheduler.notify()
+                    } catch (e: Exception) {
+                        // Should never happen, but is included for development to get some indicators
+                        // on errors instead of silent crashes.
+                        e.printStackTrace()
+                    }
+                },
+
+                // is_on_thread: realm_wrapper.realm_scheduler_is_on_thread_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Boolean>>? */,
+                staticCFunction<COpaquePointer?, Boolean> { userdata ->
+                    // Must be thread safe
+                    val scheduler =
+                        userdata!!.asStableRef<SingleThreadDispatcherScheduler>().get()
+                    printlntid("is_on_thread[$scheduler] ${scheduler.threadId} " + tid())
+                    scheduler.threadId == tid()
+                },
+
+                // is_same_as: realm_wrapper.realm_scheduler_is_same_as_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */, kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Boolean>>? */,
+                staticCFunction<COpaquePointer?, COpaquePointer?, Boolean> { userdata, other ->
+                    userdata == other
+                },
+
+                // can_deliver_notifications: realm_wrapper.realm_scheduler_can_deliver_notifications_func_t? /* = kotlinx.cinterop.CPointer<kotlinx.cinterop.CFunction<(kotlinx.cinterop.COpaquePointer? /* = kotlinx.cinterop.CPointer<out kotlinx.cinterop.CPointed>? */) -> kotlin.Boolean>>? */,
+                staticCFunction<COpaquePointer?, Boolean> { userdata -> true },
+            )
+        ) ?: error("Couldn't create scheduler")
+        scheduler.set_scheduler(capi_scheduler!!)
+        scheduler.freeze()
+        return capi_scheduler
     }
 
     private fun <R> handleAppCallback(
@@ -1610,7 +1588,6 @@ actual object RealmInterop {
     )
 
     interface Scheduler {
-        fun set_notify_callback(coreCallback: CoreCallback)
         fun notify()
     }
 
@@ -1618,25 +1595,23 @@ actual object RealmInterop {
         val threadId: ULong,
         dispatcher: CoroutineDispatcher
     ) : Scheduler {
-        val callback: AtomicRef<CoreCallback?> = atomic(null)
         val scope: CoroutineScope = CoroutineScope(dispatcher)
         val ref: CPointer<out CPointed>
+        lateinit var scheduler: CPointer<realm_scheduler_t>
 
         init {
             ref = StableRef.create(this).asCPointer()
         }
 
-        override fun set_notify_callback(coreCallback: CoreCallback) {
-            callback.value = coreCallback
+        fun set_scheduler(scheduler: CPointer<realm_scheduler_t>) {
+            this.scheduler = scheduler
         }
 
         override fun notify() {
             val function: suspend CoroutineScope.() -> Unit = {
                 try {
                     printlntid("on dispatcher")
-                    callback.value?.let {
-                        it.callback.invoke(it.callbackUserdata)
-                    }
+                    realm_wrapper.realm_scheduler_perform_work(scheduler)
                 } catch (e: Exception) {
                     // Should never happen, but is included for development to get some indicators
                     // on errors instead of silent crashes.

--- a/packages/cinterop/src/darwinTest/kotlin/io/realm/test/CinteropTest.kt
+++ b/packages/cinterop/src/darwinTest/kotlin/io/realm/test/CinteropTest.kt
@@ -82,7 +82,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("11.7.0", realm_get_library_version()!!.toKString())
+        assertEquals("11.9.0", realm_get_library_version()!!.toKString())
     }
 
     @Test

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/CoreErrorUtils.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/CoreErrorUtils.kt
@@ -60,6 +60,9 @@ object CoreErrorUtils {
             realm_errno_e.RLM_ERR_INVALID_QUERY_STRING -> RealmCoreInvalidQueryStringException(message)
             realm_errno_e.RLM_ERR_INVALID_QUERY -> RealmCoreInvalidQueryException(message)
             realm_errno_e.RLM_ERR_CALLBACK -> RealmCoreCallbackException(message)
+            realm_errno_e.RLM_ERR_FILE_ACCESS_ERROR -> RealmCoreFileAccessErrorException(message)
+            realm_errno_e.RLM_ERR_FILE_PERMISSION_DENIED -> RealmCoreFilePermissionDeniedException(message)
+            realm_errno_e.RLM_ERR_DELETE_OPENED_REALM -> RealmCoreDeleteOpenRealmException(message)
             else -> RealmCoreUnknownException(message)
         }
     }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -139,6 +139,7 @@ actual object RealmInterop {
 
     actual fun realm_open(config: NativePointer, dispatcher: CoroutineDispatcher?): NativePointer {
         // create a custom Scheduler for JVM if a Coroutine Dispatcher is provided other wise pass null to use the generic one
+
         val realmPtr = LongPointerWrapper(
             realmc.open_realm_with_scheduler(
                 (config as LongPointerWrapper).ptr,
@@ -844,11 +845,9 @@ actual object RealmInterop {
 private class JVMScheduler(dispatcher: CoroutineDispatcher) {
     val scope: CoroutineScope = CoroutineScope(dispatcher)
 
-    fun notifyCore(coreNotificationFunctionPointer: Long) {
+    fun notifyCore(schedulerPointer: Long) {
         val function: suspend CoroutineScope.() -> Unit = {
-            realmc.invoke_core_notify_callback(
-                coreNotificationFunctionPointer
-            )
+            realmc.invoke_core_notify_callback(schedulerPointer)
         }
         scope.launch(
             scope.coroutineContext,

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -183,7 +183,7 @@ register_object_notification_cb(realm_object_t *object, jobject callback) {
 }
 
 
-class CustomJVMScheduler : public realm::util::Scheduler {
+class CustomJVMScheduler {
 public:
     CustomJVMScheduler(jobject dispatchScheduler) : m_id(std::this_thread::get_id()) {
         JNIEnv *jenv = get_env();
@@ -196,35 +196,31 @@ public:
         get_env(true)->DeleteGlobalRef(m_jvm_dispatch_scheduler);
     }
 
-    void notify() override {
+    void set_scheduler(realm_scheduler_t* scheduler) {
+        m_scheduler = scheduler;
+    }
+
+    void notify() {
         auto jenv = get_env(true);
         jni_check_exception(jenv);
         jenv->CallVoidMethod(m_jvm_dispatch_scheduler, m_notify_method,
-                             reinterpret_cast<jlong>(&m_callback));
+                             reinterpret_cast<jlong>(m_scheduler));
     }
 
-    void set_notify_callback(std::function<void()> fn) override {
-        m_callback = std::move(fn);
-    }
-
-    bool is_on_thread() const noexcept override {
+    bool is_on_thread() const noexcept {
         return m_id == std::this_thread::get_id();
     }
 
-    bool is_same_as(const Scheduler *other) const noexcept override {
-        auto o = dynamic_cast<const CustomJVMScheduler *>(other);
-        return (o && (o->m_id == m_id));
-    }
-
-    bool can_deliver_notifications() const noexcept override {
+    bool can_invoke() const noexcept {
         return true;
     }
 
+
 private:
-    std::function<void()> m_callback;
     std::thread::id m_id;
     jmethodID m_notify_method;
     jobject m_jvm_dispatch_scheduler;
+    realm_scheduler_t *m_scheduler;
 };
 
 // Note: using jlong here will create a linker issue
@@ -235,24 +231,37 @@ private:
 //
 // I suspect this could be related to the fact that jni.h defines jlong differently between Android (typedef int64_t)
 // and JVM which is a (typedef long long) resulting in a different signature of the method that could be found by the linker.
-void invoke_core_notify_callback(int64_t core_notify_function) {
-    auto notify = reinterpret_cast<std::function<void()> *>(core_notify_function);
-    (*notify)();
+void invoke_core_notify_callback(int64_t scheduler) {
+    realm_scheduler_perform_work(reinterpret_cast<realm_scheduler_t *>(scheduler));
 }
 
-// TODO refactor to use public C-API https://github.com/realm/realm-kotlin/issues/496
 realm_t *open_realm_with_scheduler(int64_t config_ptr, jobject dispatchScheduler) {
-    auto *cfg = reinterpret_cast<realm_config_t * >(config_ptr);
+    auto config = reinterpret_cast<realm_config_t *>(config_ptr);
     // copy construct to not set the scheduler on the original Conf which could be used
-    // to open Frozen Realm for instance.
-    auto copyConf = *cfg;
+    // to open Frozen Realm for instance. realm_clone doesn't produce a copy but just increases the
+    // reference count.
+    // TODO refactor to use public C-API https://github.com/realm/realm-kotlin/issues/496
+    auto config_clone = *config;
+
     if (dispatchScheduler) {
-        copyConf.scheduler = std::make_shared<CustomJVMScheduler>(dispatchScheduler);
+        auto jvmScheduler = new CustomJVMScheduler(dispatchScheduler);
+        auto scheduler = realm_scheduler_new(
+                jvmScheduler,
+                [](void *userdata) { delete(static_cast<CustomJVMScheduler *>(userdata)); },
+                [](void *userdata) { static_cast<CustomJVMScheduler *>(userdata)->notify(); },
+                [](void *userdata) { return static_cast<CustomJVMScheduler *>(userdata)->is_on_thread(); },
+                [](const void *userdata, const void *userdata_other) { return userdata == userdata_other; },
+                [](void *userdata) { return static_cast<CustomJVMScheduler *>(userdata)->can_invoke(); }
+        );
+        jvmScheduler->set_scheduler(scheduler);
+        realm_config_set_scheduler(&config_clone, scheduler);
     } else {
-        copyConf.scheduler = realm::util::Scheduler::make_generic();
+        // TODO refactor to use public C-API https://github.com/realm/realm-kotlin/issues/496
+        auto scheduler =  new realm_scheduler_t{realm::util::Scheduler::make_generic()};
+        realm_config_set_scheduler(&config_clone, scheduler);
     }
 
-    return realm_open(&copyConf);
+    return realm_open(&config_clone);
 }
 
 jobject app_exception_from_app_error(JNIEnv* env, const realm_app_error_t* error) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -24,8 +24,11 @@ import io.realm.internal.interop.RealmCoreCallbackException
 import io.realm.internal.interop.RealmCoreColumnAlreadyExistsException
 import io.realm.internal.interop.RealmCoreColumnNotFoundException
 import io.realm.internal.interop.RealmCoreCrossTableLinkTargetException
+import io.realm.internal.interop.RealmCoreDeleteOpenRealmException
 import io.realm.internal.interop.RealmCoreDuplicatePrimaryKeyValueException
 import io.realm.internal.interop.RealmCoreException
+import io.realm.internal.interop.RealmCoreFileAccessErrorException
+import io.realm.internal.interop.RealmCoreFilePermissionDeniedException
 import io.realm.internal.interop.RealmCoreIndexOutOfBoundsException
 import io.realm.internal.interop.RealmCoreInvalidArgumentException
 import io.realm.internal.interop.RealmCoreInvalidPathErrorException
@@ -257,6 +260,10 @@ fun genericRealmCoreExceptionHandler(message: String, cause: RealmCoreException)
         is RealmCoreModifyPrimaryKeyException,
         is RealmCoreDuplicatePrimaryKeyValueException -> IllegalArgumentException("RealmCoreException ${cause.message} $message", cause)
         is RealmCoreNotInATransactionException,
+        is RealmCoreDeleteOpenRealmException,
+        is RealmCoreDeleteOpenRealmException,
+        is RealmCoreFileAccessErrorException,
+        is RealmCoreFilePermissionDeniedException,
         is RealmCoreLogicException -> IllegalStateException("RealmCoreException ${cause.message} $message", cause)
         is RealmCoreNoneException,
         is RealmCoreUnknownException,


### PR DESCRIPTION
I tried to eliminate our direct usage of the C++ core API #496, but we still don't have a way to do a real copy of the configuration and create a generic scheduler through the C-API. 

Closes #687 