### PR TITLE
Allow JVM lamdas and functional interfaces to be called from JNI

### DIFF
--- a/packages/library-base/proguard-rules-consumer-common.pro
+++ b/packages/library-base/proguard-rules-consumer-common.pro
@@ -60,6 +60,11 @@
     *;
 }
 
+# Preserve Function<X> methods as they back various functional interfaces called from JNI
+-keep class kotlin.jvm.functions.Function* {
+    *;
+}
+
 # Un-comment for debugging
 #-printconfiguration /tmp/full-r8-config.txt
 #-keepattributes LineNumberTable,SourceFile


### PR DESCRIPTION
Not 100% sure why this wasn't caught by our PR builds? 🤔 