### PR TITLE
Add better error messages when deleting unsupported objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * None.
 
 ### Enhancements
+* Improved exception message when attempting to delete frozen objects. (Issue [#616](https://github.com/realm/realm-kotlin/issues/616))
 * Added `RealmConfiguration.Builder.compactOnLaunch()`, which can be used to control if a Realm file should be compacted when opened.
 
 ### Fixed

--- a/packages/library-base/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -77,9 +77,17 @@ public interface MutableRealm : TypedRealm {
     ): RealmQuery<T>
 
     /**
-     * Deletes the object from the underlying Realm.
+     * Deletes the object from the underlying Realm. Only live objects can be deleted. Frozen
+     * objects can be converted to live using [MutableRealm.findLatest].
      *
-     * @throws IllegalArgumentException if the object is not managed by Realm.
+     * ```
+     * val frozenObj = realm.query<Sample>.first().find()
+     * realm.write {
+     *   findLatest(frozenObject)?.delete()
+     * }
+     * ```
+     *
+     * @throws IllegalArgumentException if the object is frozen or not managed by Realm.
      */
     public fun <T : RealmObject> delete(obj: T)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/MutableRealm.kt
@@ -77,17 +77,18 @@ public interface MutableRealm : TypedRealm {
     ): RealmQuery<T>
 
     /**
-     * Deletes the object from the underlying Realm. Only live objects can be deleted. Frozen
-     * objects can be converted to live using [MutableRealm.findLatest].
+     * Deletes the object from the underlying Realm. Only live objects can be deleted.
+     *
+     * Frozen objects can be converted using [MutableRealm.findLatest]:
      *
      * ```
      * val frozenObj = realm.query<Sample>.first().find()
      * realm.write {
-     *   findLatest(frozenObject)?.delete()
+     *   findLatest(frozenObject)?.let { delete(it) }
      * }
      * ```
      *
-     * @throws IllegalArgumentException if the object is frozen or not managed by Realm.
+     * @throws IllegalArgumentException if the object is invalid, frozen or not managed by Realm.
      */
     public fun <T : RealmObject> delete(obj: T)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
@@ -42,7 +42,7 @@ internal class MutableRealmImpl : LiveRealm, MutableRealm {
 
         private fun checkObjectValid(obj: RealmObjectInternal) {
             if (!obj.isValid()) {
-                throw IllegalArgumentException("Cannot perform this operation on an invalid/deleted object")
+                throw IllegalArgumentException("This operation cannot be performed on invalid/deleted objects.")
             }
         }
     }
@@ -111,8 +111,14 @@ internal class MutableRealmImpl : LiveRealm, MutableRealm {
     }
 
     override fun <T : RealmObject> delete(obj: T) {
-        // TODO It is easy to call this with a wrong object. Should we use `findLatest` behind the scenes?
+        if (obj !is RealmObjectInternal) {
+            throw IllegalArgumentException("Unmanaged objects cannot be deleted.")
+        }
         val internalObject = obj as RealmObjectInternal
+        if (internalObject.isFrozen()) {
+            throw IllegalArgumentException("Frozen objects cannot be deleted. They must be " +
+                "converted to live objects first by using `MutableRealm.findLatest(frozenObject)`.")
+        }
         checkObjectValid(internalObject)
         internalObject.`$realm$ObjectPointer`?.let { RealmInterop.realm_object_delete(it) }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/MutableRealmImpl.kt
@@ -116,8 +116,10 @@ internal class MutableRealmImpl : LiveRealm, MutableRealm {
         }
         val internalObject = obj as RealmObjectInternal
         if (internalObject.isFrozen()) {
-            throw IllegalArgumentException("Frozen objects cannot be deleted. They must be " +
-                "converted to live objects first by using `MutableRealm.findLatest(frozenObject)`.")
+            throw IllegalArgumentException(
+                "Frozen objects cannot be deleted. They must be converted to live objects first " +
+                    "by using `MutableRealm.findLatest(frozenObject)`."
+            )
         }
         checkObjectValid(internalObject)
         internalObject.`$realm$ObjectPointer`?.let { RealmInterop.realm_object_delete(it) }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/MutableRealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/MutableRealmTests.kt
@@ -17,6 +17,7 @@ package io.realm.test.shared
 
 import io.realm.Realm
 import io.realm.RealmConfiguration
+import io.realm.entities.Sample
 import io.realm.entities.StringPropertyWithPrimaryKey
 import io.realm.entities.link.Child
 import io.realm.entities.link.Parent
@@ -167,6 +168,50 @@ class MutableRealmTests {
                     assertNotNull(findLatest(child))
                 }
                 delay(100)
+            }
+        }
+    }
+
+    @Test
+    fun delete() {
+        realm.writeBlocking {
+            val liveObject = copyToRealm(Parent())
+            assertEquals(1, query<Parent>().count().find())
+            delete(liveObject)
+            assertEquals(0, query<Parent>().count().find())
+        }
+    }
+
+    @Test
+    fun delete_deletedObjectThrows() {
+        realm.writeBlocking {
+            val liveObject = copyToRealm(Parent())
+            assertEquals(1, query<Parent>().count().find())
+            delete(liveObject)
+            assertEquals(0, query<Parent>().count().find())
+            assertFailsWith<IllegalArgumentException> {
+                delete(liveObject)
+            }
+        }
+    }
+
+    @Test
+    fun delete_unmanagedObjectsThrows() {
+        realm.writeBlocking {
+            assertFailsWith<IllegalArgumentException> {
+                delete(Parent())
+            }
+        }
+    }
+
+    @Test
+    fun delete_frozenObjectsThrows() {
+        val frozenObj = realm.writeBlocking {
+            copyToRealm(Parent())
+        }
+        realm.writeBlocking {
+            assertFailsWith<IllegalArgumentException> {
+                delete(frozenObj)
             }
         }
     }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/MutableRealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/MutableRealmTests.kt
@@ -17,7 +17,6 @@ package io.realm.test.shared
 
 import io.realm.Realm
 import io.realm.RealmConfiguration
-import io.realm.entities.Sample
 import io.realm.entities.StringPropertyWithPrimaryKey
 import io.realm.entities.link.Child
 import io.realm.entities.link.Parent


### PR DESCRIPTION
Closes #616 

This throws better `IllegalArgumentException`'s for a number of cases when deleting objects in states that are not supported. 