### PR TITLE
Ensure existence of valid transaction on frozen realm references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.10.2 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* Fix query syntax errors of seemingly correct query (Issue [#683](https://github.com/realm/realm-kotlin/issues/683))
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10.
+  * Coroutines 1.6.0-native-mt. Also compatible with Coroutines 1.6.0 but requires enabling of the new memory model and disabling of freezing, see https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility for details on that.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 0.10.1 (2022-03-24)
 
 ### Breaking Changes

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
@@ -65,9 +65,10 @@ public data class FrozenRealmReference(
     override val schemaMetadata: SchemaMetadata = CachedSchemaMetadata(dbPointer),
 ) : RealmReference {
     init {
-        // FIXME realm_freeze doesn't create a transaction, so if the version isn't kept alive we
-        //  can end up deleting the version. Don't know if there is a way to do this automatically
-        //  through the C-API.
+        // realm_open/realm_freeze doesn't implicitly create a transaction which can cause the
+        // underlying core version to be cleaned up if the realm is advanced before any objects,
+        // queries, etc. triggers creation of the transaction. Thus, we need to force a transaction
+        // on any realm references to keep the version around for future operations.
         RealmInterop.realm_begin_read(dbPointer)
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmReference.kt
@@ -63,7 +63,14 @@ public data class FrozenRealmReference(
     override val owner: BaseRealmImpl,
     override val dbPointer: NativePointer,
     override val schemaMetadata: SchemaMetadata = CachedSchemaMetadata(dbPointer),
-) : RealmReference
+) : RealmReference {
+    init {
+        // FIXME realm_freeze doesn't create a transaction, so if the version isn't kept alive we
+        //  can end up deleting the version. Don't know if there is a way to do this automatically
+        //  through the C-API.
+        RealmInterop.realm_begin_read(dbPointer)
+    }
+}
 
 /**
  * A **live realm reference** linking to the underlying live SharedRealm with the option to update

--- a/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
@@ -124,6 +124,9 @@ class SyncedRealmTests {
 
         val channel = Channel<ResultsChange<ChildPk>>(1)
 
+        // This query has caused trouble on CI
+        assertEquals(0, realm1.query<ChildPk>().find().size, realm1.toString())
+
         runBlocking {
             val observer = async {
                 realm2.query<ChildPk>()

--- a/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
@@ -105,7 +105,9 @@ class SyncedRealmTests {
             app.createUserAndLogIn(email, password)
         }
 
-        val partitionValue = Random.nextULong().toString()
+        // FIXME Need to reuse existing partition to provoke issue with advancing the live realm
+        //  and deleting the version referenced by the user facing frozen realm.
+        val partitionValue = "same"// Random.nextULong().toString()
 
         val dir1 = PlatformUtils.createTempDir()
         val config1 = createSyncConfig(directory = dir1, user = user, partitionValue = partitionValue)
@@ -118,7 +120,7 @@ class SyncedRealmTests {
         assertNotNull(realm2)
 
         val child = ChildPk().apply {
-            _id = "CHILD_A"
+            _id = "CHILD_A" + Random.nextULong().toString()
             name = "A"
         }
 


### PR DESCRIPTION
This PR ensures that we have a valid transaction on each frozen realm reference. Failing to have that could cause core to clean up the version and that would render us invalid to query, create objects, etc. from that specific version. 

Closes #683 