### PR TITLE
RealmConfiguration.Builder.directory as replacement for RealmConfiguration.Builder.path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.10.0-SNAPSHOT (2022-MM-DD)
 
 ### Breaking Changes
-* None.
+* `RealmConfiguration.Builder.path()` has been replaced by ``RealmConfiguration.Builder.directory()`, which can combined with `RealmConfiguration.Builder.name()` to form the full path. (Isse [#346](https://github.com/realm/realm-kotlin/issues/346))
 
 ### Enhancements
 * Improved exception message when attempting to delete frozen objects. (Issue [#616](https://github.com/realm/realm-kotlin/issues/616))

--- a/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
@@ -58,9 +58,11 @@ public data class LogConfiguration(
     public val loggers: List<RealmLogger>
 )
 
+/**
+ * Base configuration options shared between all realm configuration types.
+ */
 public interface Configuration {
-    // Public properties making up the RealmConfiguration
-    // TODO Add more elaborate KDoc for all of these
+
     /**
      * Path to the realm file.
      */
@@ -126,7 +128,7 @@ public interface Configuration {
     public abstract class SharedBuilder<T, S : SharedBuilder<T, S>>(
         public var schema: Set<KClass<out RealmObject>> = setOf()
     ) {
-        protected var path: String? = null
+        protected var directory: String? = null
         protected var name: String = Realm.DEFAULT_FILE_NAME
         protected var logLevel: LogLevel = LogLevel.WARN
         protected var removeSystemLogger: Boolean = false
@@ -147,19 +149,21 @@ public interface Configuration {
         public abstract fun build(): T
 
         /**
-         * Sets the absolute path of the realm file.
+         * Sets the path to the directory that contains the realm file. If the directory does not
+         * exists, it and all intermediate directories will be created.
          *
-         * If not set the realm will be stored at the default app storage location for the platform.
-         *
-         * @param path either the canonical absolute path or a relative path from the current directory ('./').
+         * If not set the realm will be stored at the default app storage location for the platform:
          * ```
-         * // For JVM platforms the current directory is obtained using
+         * // For Android the default directory is obtained using
+         * Context.getFilesDir()
+         *
+         * // For JVM platforms the default directory is obtained using
          *  System.getProperty("user.dir")
          *
-         * // For macOS the current directory is obtained using
+         * // For macOS the default directory is obtained using
          * platform.Foundation.NSFileManager.defaultManager.currentDirectoryPath
          *
-         * // For iOS the current directory is obtained using
+         * // For iOS the default directory is obtained using
          * NSFileManager.defaultManager.URLForDirectory(
          *      NSDocumentDirectory,
          *      NSUserDomainMask,
@@ -168,8 +172,10 @@ public interface Configuration {
          *      null
          * )
          * ```
+         *
+         * @param directoryPath either the canonical absolute path or a relative path from the current directory ('./').
          */
-        public fun path(path: String?): S = apply { this.path = path } as S
+        public fun directory(directoryPath: String?): S = apply { this.directory = directoryPath } as S
 
         /**
          * Sets the filename of the realm file.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -62,7 +62,7 @@ public interface RealmConfiguration : Configuration {
             }
             allLoggers.addAll(userLoggers)
             return RealmConfigurationImpl(
-                path,
+                directory,
                 name,
                 schema,
                 LogConfiguration(logLevel, allLoggers),

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
@@ -26,7 +26,7 @@ import kotlin.reflect.KClass
 
 @Suppress("LongParameterList")
 internal class RealmConfigurationImpl(
-    path: String?,
+    directory: String?,
     name: String,
     schema: Set<KClass<out RealmObject>>,
     logConfig: LogConfiguration,
@@ -38,7 +38,7 @@ internal class RealmConfigurationImpl(
     override val deleteRealmIfMigrationNeeded: Boolean,
     compactOnLaunchCallback: CompactOnLaunchCallback?
 ) : ConfigurationImpl(
-    path,
+    directory,
     name,
     schema,
     logConfig,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/platform/SystemUtils.kt
@@ -27,6 +27,18 @@ public expect val OS_VERSION: String
 public expect fun appFilesDirectory(): String
 
 /**
+ * Normalize and prepare a platform dependant path to a realm file.
+ *
+ * This method will normalize the path to a standard format on the platform, validate the filename
+ * and create any intermediate directories required to store the the file.
+ *
+ * @throws IllegalArgumentException if the directory path is somehow not valid or the required
+ * directories cannot be created.
+ * @see https://github.com/realm/realm-kotlin/issues/699
+ */
+public expect fun prepareRealmFilePath(directoryPath: String, filename: String): String
+
+/**
  * Returns the default logger for the platform.
  */
 public expect fun createDefaultSystemLogger(tag: String, logLevel: LogLevel = LogLevel.NONE): RealmLogger

--- a/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/darwin/kotlin/io/realm/internal/platform/SystemUtils.kt
@@ -2,12 +2,17 @@ package io.realm.internal.platform
 
 import io.realm.log.LogLevel
 import io.realm.log.RealmLogger
+import kotlinx.cinterop.BooleanVar
+import kotlinx.cinterop.ObjCObjectVar
 import kotlinx.cinterop.ULongVar
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
+import platform.Foundation.NSError
 import platform.Foundation.NSProcessInfo
+import platform.Foundation.NSURL
 import platform.posix.pthread_threadid_np
 import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
@@ -36,3 +41,31 @@ public actual val <T> T.isFrozen: Boolean
     get() = this.isFrozen
 
 public actual fun Any.ensureNeverFrozen(): Unit = this.ensureNeverFrozen()
+
+// Depend on filesystem API's to handle edge cases around creating paths.
+public actual fun prepareRealmFilePath(directoryPath: String, filename: String): String {
+    val dir = NSURL.fileURLWithPath(directoryPath, isDirectory = true)
+    val fm = platform.Foundation.NSFileManager.defaultManager
+    memScoped {
+        val isDir = alloc<BooleanVar>()
+        val exists = fm.fileExistsAtPath(dir.absoluteString!!, isDirectory = isDir.ptr)
+        if (!exists) {
+            val errorPtr = alloc<ObjCObjectVar<NSError?>>()
+            fm.createDirectoryAtURL(
+                url = dir,
+                withIntermediateDirectories = true,
+                attributes = mapOf<Any?, Any>(),
+                errorPtr.ptr
+            )
+            errorPtr.ptr.pointed.value?.let {
+                throw IllegalArgumentException("Directories for Realm file could not be created: $directoryPath. Underlying cause: $it")
+            }
+        }
+        if (!isDir.value) {
+            throw IllegalArgumentException("Provided directory is a file: $directoryPath")
+        }
+    }
+
+    return NSURL.fileURLWithPath(filename, dir).absoluteString
+        ?: throw IllegalArgumentException("Could not resolve path components: '${directoryPath}' and '$filename'.")
+}

--- a/packages/library-base/src/jvmMain/kotlin/io/realm/internal/platform/SystemUtilsJvm.kt
+++ b/packages/library-base/src/jvmMain/kotlin/io/realm/internal/platform/SystemUtilsJvm.kt
@@ -2,12 +2,27 @@ package io.realm.internal.platform
 
 import io.realm.log.LogLevel
 import io.realm.log.RealmLogger
+import java.io.File
 
 public actual val OS_NAME: String = System.getProperty("os.name")
 public actual val OS_VERSION: String = System.getProperty("os.version")
 
 @Suppress("FunctionOnlyReturningConstant")
 public actual fun appFilesDirectory(): String = System.getProperty("user.dir") ?: "."
+
+// Depend on JVM filesystem API's to handle edge cases around creating paths.
+public actual fun prepareRealmFilePath(directoryPath: String, filename: String): String {
+    val dir = File(directoryPath).absoluteFile
+    if (!dir.exists()) {
+        if (!dir.mkdirs()) {
+            throw IllegalStateException("Directories for Realm file could not be created: $directoryPath")
+        }
+    }
+    if (dir.isFile) {
+        throw IllegalArgumentException("Provided directory is a file: $directoryPath")
+    }
+    return File(directoryPath, filename).absolutePath
+}
 
 public actual fun createDefaultSystemLogger(tag: String, logLevel: LogLevel): RealmLogger =
     StdOutLogger(tag, logLevel)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
@@ -140,7 +140,7 @@ public interface SyncConfiguration : Configuration {
             }
 
             val baseConfiguration = ConfigurationImpl(
-                path,
+                directory,
                 name,
                 schema,
                 LogConfiguration(logLevel, allLoggers),

--- a/test/base/src/androidTest/kotlin/io/realm/test/InstrumentedTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/InstrumentedTests.kt
@@ -45,7 +45,7 @@ class InstrumentedTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .build()
         realm = Realm.open(configuration)
     }

--- a/test/base/src/androidTest/kotlin/io/realm/test/MemoryTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/MemoryTests.kt
@@ -172,7 +172,8 @@ class MemoryTests {
 
     private fun openRealmFromTmpDir(): Realm {
         val configuration =
-            RealmConfiguration.Builder(schema = setOf(MemoryTest::class)).path("$tmpDir/default.realm")
+            RealmConfiguration.Builder(schema = setOf(MemoryTest::class))
+                .directory(tmpDir)
                 .build()
         return Realm.open(configuration)
     }

--- a/test/base/src/androidTest/kotlin/io/realm/test/RealmConfigurationTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/RealmConfigurationTests.kt
@@ -44,8 +44,9 @@ class RealmConfigurationTests {
     @Suppress("invisible_member")
     fun testDispatcherAsWriteDispatcher() {
         val configuration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path("$tmpDir/default.realm")
-            .writeDispatcher(singleThreadDispatcher("foo")).build()
+            .directory(tmpDir)
+            .writeDispatcher(singleThreadDispatcher("foo"))
+            .build()
         Realm.open(configuration).use { realm: Realm ->
             realm.writeBlocking {
                 copyToRealm(Sample())

--- a/test/base/src/androidTest/kotlin/io/realm/test/RealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/RealmTests.kt
@@ -36,7 +36,7 @@ class RealmTests {
 
     private val configuration: RealmConfiguration by lazy {
         RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class))
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .build()
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/CompactOnLaunchTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/CompactOnLaunchTests.kt
@@ -43,7 +43,7 @@ class CompactOnLaunchTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         configBuilder = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
     }
 
     @AfterTest

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/EncryptionTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/EncryptionTests.kt
@@ -51,7 +51,7 @@ class EncryptionTests {
             .Builder(
                 schema = setOf(Sample::class)
             )
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .encryptionKey(key)
             .build()
 
@@ -71,14 +71,14 @@ class EncryptionTests {
             .Builder(
                 schema = setOf(Sample::class)
             )
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .encryptionKey(actualKey)
             .build()
         Realm.open(encryptedConf).close()
 
         // Assert fails with no encryption key
         RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .build()
             .let { conf ->
                 assertFailsWith(IllegalArgumentException::class, "Encrypted Realm should not be openable with no encryption key") {
@@ -89,7 +89,7 @@ class EncryptionTests {
         // Assert fails with wrong encryption key
         val randomKey = Random.nextBytes(64)
         RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .encryptionKey(randomKey)
             .build()
             .let { conf ->
@@ -106,14 +106,14 @@ class EncryptionTests {
             .Builder(
                 schema = setOf(Sample::class)
             )
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .build()
         Realm.open(unencryptedConf).close()
 
         // Assert fails opening with encryption key
         val randomKey = Random.nextBytes(64)
         RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .encryptionKey(randomKey)
             .build()
             .let { conf ->

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/ImportTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/ImportTests.kt
@@ -44,7 +44,8 @@ class ImportTests {
         tmpDir = PlatformUtils.createTempDir()
         val configuration =
             RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class, Sample::class))
-                .path("$tmpDir/default.realm").build()
+                .directory(tmpDir)
+                .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/LinkTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/LinkTests.kt
@@ -38,7 +38,8 @@ class LinkTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class))
-            .path("$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/MigrationTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/MigrationTests.kt
@@ -34,9 +34,6 @@ class MigrationTests {
 
     private lateinit var tmpDir: String
 
-    private val path: String
-        get() = "$tmpDir/default.realm"
-
     @BeforeTest
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
@@ -50,7 +47,7 @@ class MigrationTests {
     @Test
     fun automaticMigrationAddingNewClasses() {
         RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path(path)
+            .directory(tmpDir)
             .build()
             .also {
                 Realm.open(it)
@@ -63,7 +60,7 @@ class MigrationTests {
             }
 
         RealmConfiguration.Builder(schema = setOf(Sample::class, Parent::class, Child::class))
-            .path(path)
+            .directory(tmpDir)
             .build()
             .also {
                 Realm.open(it).run {
@@ -91,7 +88,7 @@ class MigrationTests {
     @Test
     fun automaticMigrationRemovingClasses() {
         RealmConfiguration.Builder(schema = setOf(Sample::class, Parent::class, Child::class))
-            .path(path)
+            .directory(tmpDir)
             .build()
             .also {
                 Realm.open(it)
@@ -104,7 +101,7 @@ class MigrationTests {
             }
 
         RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class))
-            .path(path)
+            .directory(tmpDir)
             .build()
             .also {
                 Realm.open(it).run {
@@ -122,7 +119,7 @@ class MigrationTests {
     @Test
     fun resetFileShouldNotDeleteWhenAddingClass() {
         RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path(path)
+            .directory(tmpDir)
             .build()
             .also {
                 Realm.open(it).run {
@@ -134,7 +131,7 @@ class MigrationTests {
             }
 
         RealmConfiguration.Builder(schema = setOf(Sample::class, Parent::class, Child::class))
-            .path(path)
+            .directory(tmpDir)
             .deleteRealmIfMigrationNeeded()
             .build()
             .also {
@@ -153,7 +150,7 @@ class MigrationTests {
     @Test
     fun resetFileShouldNotDeleteWhenRemovingClass() {
         RealmConfiguration.Builder(schema = setOf(Sample::class, Parent::class, Child::class))
-            .path(path)
+            .directory(tmpDir)
             .build()
             .also {
                 Realm.open(it).run {
@@ -165,7 +162,7 @@ class MigrationTests {
             }
 
         RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class))
-            .path(path)
+            .directory(tmpDir)
             .deleteRealmIfMigrationNeeded()
             .build()
             .also {

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/MutableRealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/MutableRealmTests.kt
@@ -48,7 +48,7 @@ class MutableRealmTests {
                 Child::class,
                 StringPropertyWithPrimaryKey::class
             )
-        ).path("$tmpDir/default.realm").build()
+        ).directory(tmpDir).build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/NullabilityTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/NullabilityTests.kt
@@ -42,7 +42,7 @@ class NullabilityTests {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(
             schema = setOf(Nullability::class)
-        ).path("$tmpDir/default.realm").build()
+        ).directory(tmpDir).build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/PrimaryKeyTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/PrimaryKeyTests.kt
@@ -66,7 +66,7 @@ class PrimaryKeyTests {
 
                 )
             )
-                .path("$tmpDir/default.realm")
+                .directory(tmpDir)
                 .build()
         realm = Realm.open(configuration)
     }
@@ -206,7 +206,7 @@ class PrimaryKeyTests {
                 PrimaryKeyString::class,
                 PrimaryKeyStringNullable::class,
             )
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .build()
 
 //        @Suppress("invisible_reference", "invisible_member")

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/QueryTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/QueryTests.kt
@@ -65,7 +65,8 @@ class QueryTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(schema = setOf(QuerySample::class))
-            .path("$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/ReadMeTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/ReadMeTests.kt
@@ -23,7 +23,6 @@ import io.realm.query
 import io.realm.test.platform.PlatformUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.newSingleThreadContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -45,7 +44,7 @@ class ReadMeTests {
         tmpDir = PlatformUtils.createTempDir()
         val configuration =
             RealmConfiguration.Builder(schema = setOf(Person::class, Dog::class))
-                .path("$tmpDir/default.realm")
+                .directory(tmpDir)
                 .build()
         realm = Realm.open(configuration)
     }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmConfigurationTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmConfigurationTests.kt
@@ -23,11 +23,14 @@ import io.realm.internal.InternalConfiguration
 import io.realm.internal.platform.appFilesDirectory
 import io.realm.internal.platform.runBlocking
 import io.realm.log.LogLevel
+import io.realm.test.assertFailsWithMessage
 import io.realm.test.platform.PlatformUtils
+import io.realm.test.platform.platformFileSystem
 import io.realm.test.util.TestLogger
 import io.realm.test.util.use
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.newSingleThreadContext
+import okio.Path.Companion.toPath
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -109,7 +112,8 @@ class RealmConfigurationTests {
 
         val configFromBuilderWithCurrentDir: RealmConfiguration =
             RealmConfiguration.Builder(schema = setOf(Sample::class))
-                .path("./my_dir/foo.realm")
+                .directory("./my_dir")
+                .name("foo.realm")
                 .build()
         assertEquals(
             "${appFilesDirectory()}/my_dir/foo.realm",
@@ -118,24 +122,62 @@ class RealmConfigurationTests {
     }
 
     @Test
-    fun path() {
-        val realmPath = "HowToGetPlatformPath/default.realm"
-
-        val config =
-            RealmConfiguration.Builder(schema = setOf(Sample::class)).path(realmPath).build()
-        assertEquals(realmPath, config.path)
+    fun directory() {
+        val realmDir = tmpDir
+        val config = RealmConfiguration.Builder(schema = setOf(Sample::class))
+            .directory(realmDir)
+            .build()
+        assertEquals("$tmpDir/${Realm.DEFAULT_FILE_NAME}", config.path)
     }
 
     @Test
-    fun pathOverrideName() {
-        val realmPath = "<HowToGetPlatformPath>/custom.realm"
+    fun directory_endsWithSeparator() {
+        val realmDir = appFilesDirectory() + "/"
+        val config = RealmConfiguration.Builder(schema = setOf(Sample::class))
+            .directory(realmDir)
+            .build()
+        assertEquals("$realmDir${Realm.DEFAULT_FILE_NAME}", config.path)
+    }
+
+    @Test
+    fun directory_createIntermediateDirs() {
+        val realmDir = tmpDir + "/my/intermediate/dir"
+        val configBuilder = RealmConfiguration.Builder(schema = setOf(Sample::class))
+            .directory(realmDir)
+
+        // Building the config is what creates the folders
+        configBuilder.build()
+    }
+
+    @Test
+    fun directory_isFileThrows() {
+        val tmpFile = "$tmpDir/file"
+        platformFileSystem.write(tmpFile.toPath(), mustCreate = true) {
+            write(ByteArray(0))
+        }
+
+        val configBuilder = RealmConfiguration.Builder(schema = setOf(Sample::class))
+            .directory(tmpFile)
+            .name("file.realm")
+
+        assertFailsWithMessage<IllegalArgumentException>("Provided directory is a file") {
+            configBuilder.build()
+        }
+    }
+
+    @Test
+    fun directoryAndNameCombine() {
+        val realmDir = tmpDir
         val realmName = "my.realm"
+        val expectedPath = "$realmDir/$realmName"
 
         val config =
-            RealmConfiguration.Builder(setOf(Sample::class)).path(realmPath).name(realmName).build()
-        assertEquals(realmPath, config.path)
-        // Correct assert: assertEquals("custom.realm", config.name)
-        assertEquals("my.realm", config.name) // Current result
+            RealmConfiguration.Builder(setOf(Sample::class))
+                .directory(realmDir)
+                .name(realmName)
+                .build()
+        assertEquals(expectedPath, config.path)
+        assertEquals(realmName, config.name)
     }
 
     @Test
@@ -153,10 +195,20 @@ class RealmConfigurationTests {
     @Test
     fun name() {
         val realmName = "my.realm"
-
         val config = RealmConfiguration.Builder(schema = setOf(Sample::class)).name(realmName).build()
         assertEquals(realmName, config.name)
         assertTrue(config.path.endsWith(realmName))
+    }
+
+    // TODO This should probably throw an IllegalArgumentException, for now just document behaviour.
+    @Test
+    fun name_startsWithSeparetor() {
+        val realmDir = appFilesDirectory()
+        val config = RealmConfiguration.Builder(schema = setOf(Sample::class))
+            .directory(realmDir)
+            .name("/foo.realm")
+            .build()
+        assertEquals(config.path, "$realmDir/foo.realm")
     }
 
     @Test
@@ -271,7 +323,7 @@ class RealmConfigurationTests {
         val configuration =
             RealmConfiguration.Builder(schema = setOf(Sample::class))
                 .writeDispatcher(dispatcher)
-                .path("$tmpDir/default.realm")
+                .directory(tmpDir)
                 .build()
         val threadId: ULong =
             runBlocking((configuration as InternalConfiguration).writeDispatcher) { PlatformUtils.threadId() }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmInstantTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmInstantTests.kt
@@ -25,7 +25,8 @@ class RealmInstantTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path("$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmListTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmListTests.kt
@@ -58,7 +58,7 @@ class RealmListTests {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(
             schema = setOf(RealmListContainer::class, Level1::class, Level2::class, Level3::class)
-        ).path("$tmpDir/default.realm").build()
+        ).directory(tmpDir).build()
         realm = Realm.open(configuration)
     }
 
@@ -270,7 +270,11 @@ class RealmListTests {
 
     private fun getCloseableRealm(): Realm =
         RealmConfiguration.Builder(schema = setOf(RealmListContainer::class))
-            .path("$tmpDir/closeable.realm").build().let { Realm.open(it) }
+            .directory(tmpDir)
+            .name("closeable.realm")
+            .build().let {
+                Realm.open(it)
+            }
 
     // TODO investigate how to add properties/values directly so that it works for multiplatform
     @Suppress("UNCHECKED_CAST", "ComplexMethod")

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmObjectTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmObjectTests.kt
@@ -49,7 +49,8 @@ class RealmObjectTests : RealmStateTest {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class))
-            .path("$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
         parent = realm.writeBlocking { copyToRealm(Parent()) }
     }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmResultsTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmResultsTests.kt
@@ -43,7 +43,8 @@ class RealmResultsTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class))
-            .path("$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmSchemaTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmSchemaTests.kt
@@ -59,7 +59,8 @@ public class RealmSchemaTests {
         tmpDir = PlatformUtils.createTempDir()
         val configuration =
             RealmConfiguration.Builder(schema = setOf(SchemaVariations::class, Sample::class))
-                .path("$tmpDir/default.realm").build()
+                .directory(tmpDir)
+                .build()
         realm = Realm.open(configuration)
     }
 
@@ -191,7 +192,7 @@ public class RealmSchemaTests {
     fun multipleConstructors() {
         val config = RealmConfiguration
             .Builder(schema = setOf(MultipleConstructors::class))
-            .path("$tmpDir/default.realm").build()
+            .directory(tmpDir).build()
         val realm = Realm.open(config)
 
         val firstCtor = MultipleConstructors() // this uses all defaults: "John", "Doe", 42

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmTests.kt
@@ -62,8 +62,10 @@ class RealmTests {
     @BeforeTest
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
-        configuration = RealmConfiguration.Builder().path("$tmpDir/default.realm")
-            .schema(setOf(Parent::class, Child::class)).build()
+        configuration = RealmConfiguration.Builder()
+            .directory(tmpDir)
+            .schema(setOf(Parent::class, Child::class))
+            .build()
         realm = Realm.open(configuration)
     }
 
@@ -126,7 +128,7 @@ class RealmTests {
         val config = RealmConfiguration.Builder(
             schema = setOf(Parent::class, Child::class)
         ).maxNumberOfActiveVersions(1)
-            .path("$tmpDir/default.realm")
+            .directory(tmpDir)
             .build()
         realm = Realm.open(config)
         // Pin the version, so when starting a new transaction on the first Realm,

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/SampleTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/SampleTests.kt
@@ -49,7 +49,7 @@ class SampleTests {
         tmpDir = PlatformUtils.createTempDir()
         val configuration =
             RealmConfiguration.Builder(schema = setOf(Sample::class))
-                .path("$tmpDir/default.realm")
+                .directory(tmpDir)
                 .build()
         realm = Realm.open(configuration)
     }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/SchemaTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/SchemaTests.kt
@@ -58,7 +58,8 @@ class SchemaTests {
     fun usingBuilder() {
         var conf = RealmConfiguration.Builder()
             .schema(Sample::class, Parent::class, Child::class)
-            .path("/some/path").build()
+            .directory("/some/path")
+            .build()
         assertValidCompanionMap(conf, Sample::class, Parent::class, Child::class)
 
         conf = RealmConfiguration.Builder()

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/RealmListNotificationsTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/RealmListNotificationsTests.kt
@@ -26,7 +26,6 @@ import io.realm.test.platform.PlatformUtils
 import io.realm.test.shared.OBJECT_VALUES
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
@@ -48,7 +47,8 @@ class RealmListNotificationsTests : NotificationTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         configuration = RealmConfiguration.Builder(schema = setOf(RealmListContainer::class))
-            .path("$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/RealmNotificationsTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/RealmNotificationsTests.kt
@@ -25,7 +25,6 @@ import io.realm.test.NotificationTests
 import io.realm.test.platform.PlatformUtils
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.collect
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
@@ -42,7 +41,8 @@ class RealmNotificationsTests : NotificationTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         configuration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path(path = "$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/RealmObjectNotificationsTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/RealmObjectNotificationsTests.kt
@@ -25,7 +25,6 @@ import io.realm.test.platform.PlatformUtils
 import io.realm.test.util.update
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
@@ -47,7 +46,8 @@ class RealmObjectNotificationsTests : NotificationTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         configuration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path(path = "$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/RealmResultsNotificationsTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/RealmResultsNotificationsTests.kt
@@ -27,7 +27,6 @@ import io.realm.test.NotificationTests
 import io.realm.test.platform.PlatformUtils
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
@@ -49,7 +48,8 @@ class RealmResultsNotificationsTests : NotificationTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         configuration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path(path = "$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/SystemNotificationTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/notifications/SystemNotificationTests.kt
@@ -40,7 +40,8 @@ class SystemNotificationTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         configuration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path(path = "$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         realm = Realm.open(configuration)
     }
 

--- a/test/base/src/macosTest/kotlin/io/realm/test/MemoryTests.kt
+++ b/test/base/src/macosTest/kotlin/io/realm/test/MemoryTests.kt
@@ -163,7 +163,8 @@ class MemoryTests {
 
     private fun openRealmFromTmpDir(): Realm {
         val configuration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .path(path = "$tmpDir/default.realm").build()
+            .directory(tmpDir)
+            .build()
         return Realm.open(configuration)
     }
 

--- a/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
@@ -39,7 +39,6 @@ import io.realm.test.platform.PlatformUtils
 import io.realm.test.util.TestHelper.randomEmail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.takeWhile
 import kotlin.random.Random
 import kotlin.random.nextULong
@@ -109,12 +108,12 @@ class SyncedRealmTests {
         val partitionValue = Random.nextULong().toString()
 
         val dir1 = PlatformUtils.createTempDir()
-        val config1 = createSyncConfig(path = "$dir1/$DEFAULT_NAME", user = user, partitionValue = partitionValue)
+        val config1 = createSyncConfig(directory = dir1, user = user, partitionValue = partitionValue)
         val realm1 = Realm.open(config1)
         assertNotNull(realm1)
 
         val dir2 = PlatformUtils.createTempDir()
-        val config2 = createSyncConfig(path = "$dir2/$DEFAULT_NAME", user = user, partitionValue = partitionValue)
+        val config2 = createSyncConfig(directory = dir2, user = user, partitionValue = partitionValue)
         val realm2 = Realm.open(config2)
         assertNotNull(realm2)
 
@@ -163,11 +162,11 @@ class SyncedRealmTests {
         val partitionValue = Random.nextLong().toString()
         // Setup two realms that synchronizes with the backend
         val dir1 = PlatformUtils.createTempDir()
-        val config1 = createSyncConfig(path = "$dir1/$DEFAULT_NAME", partitionValue = partitionValue, user = user)
+        val config1 = createSyncConfig(directory = dir1, partitionValue = partitionValue, user = user)
         val realm1 = Realm.open(config1)
         assertNotNull(realm1)
         val dir2 = PlatformUtils.createTempDir()
-        val config2 = createSyncConfig(path = "$dir2/$DEFAULT_NAME", user = user)
+        val config2 = createSyncConfig(directory = dir2, user = user)
         val realm2 = Realm.open(config2)
         assertNotNull(realm2)
 
@@ -185,7 +184,7 @@ class SyncedRealmTests {
         // empirically it has shown not to be the case and cause trouble if opening the second or
         // third realm with the wrong sync-intended schema mode.
         val dir3 = PlatformUtils.createTempDir()
-        val config3 = createSyncConfig(path = "$dir3/$DEFAULT_NAME", user = user)
+        val config3 = createSyncConfig(directory = dir3, user = user)
         val realm3 = Realm.open(config3)
         assertNotNull(realm3)
 
@@ -211,8 +210,7 @@ class SyncedRealmTests {
             schema = setOf(ChildPk::class),
             user = user,
             partitionValue = DEFAULT_PARTITION_VALUE
-        ).path("$tmpDir/test1.realm")
-            .build()
+        ).directory(tmpDir).name("test1.realm").build()
         val realm1 = Realm.open(config1)
         assertNotNull(realm1)
 
@@ -223,7 +221,7 @@ class SyncedRealmTests {
                 schema = setOf(io.realm.entities.sync.bogus.ChildPk::class),
                 user = user,
                 partitionValue = DEFAULT_PARTITION_VALUE
-            ).path("$tmpDir/test2.realm")
+            ).directory(tmpDir).name("test2.realm")
                 .also { builder ->
                     builder.errorHandler(object : ErrorHandler {
                         override fun onError(session: SyncSession, error: SyncException) {
@@ -604,7 +602,7 @@ class SyncedRealmTests {
     private fun createSyncConfig(
         user: User,
         partitionValue: String = DEFAULT_PARTITION_VALUE,
-        path: String? = null,
+        directory: String? = null,
         name: String = DEFAULT_NAME,
         encryptionKey: ByteArray? = null,
         log: LogConfiguration? = null,
@@ -613,7 +611,7 @@ class SyncedRealmTests {
         schema = setOf(ParentPk::class, ChildPk::class),
         user = user,
         partitionValue = partitionValue
-    ).path(path)
+    ).directory(directory)
         .name(name)
         .let { builder ->
             if (encryptionKey != null) builder.encryptionKey(encryptionKey)


### PR DESCRIPTION
Closes #346 

This PR replaces `RealmConfiguration.Builder.path` with `RealmConfiguration.Builder.directory`. This fixes the problem that specifying both `path` and `name` was counter-intuitive and didn't work together as well as aligning the API with Realm Java.

Having both `name` and `directory` is also beneficial on multiplatform where specifying paths always have some platform dependant component. So now users only have to reason about `directory` as the platform dependant part of setting up a Realm. 

**Note for reviews**
Most of this PR is just updating tests. The most relevant files to review are `SystemUtils` for Jvm and Darwin + associated tests in `RealmConfigurationTests`