### PR TITLE
Reorganize and update README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to Realm Kotlin
+
+## CLA
+
+We welcomes all contributions! The only requirement we have is that, like many other projects, we need to have a [Contributor License Agreement](https://en.wikipedia.org/wiki/Contributor_License_Agreement) (CLA) in place before we can accept any external code. Our own CLA is a modified version of the Apache Software Foundation’s CLA.
+
+[Please submit your CLA electronically using our Google form](https://docs.google.com/forms/d/e/1FAIpQLSeQ9ROFaTu9pyrmPhXc-dEnLD84DbLuT_-tPNZDOL9J10tOKQ/viewform) so we can accept your submissions. The GitHub username you file there will need to match that of your Pull Requests. If you have any questions or cannot file the CLA electronically, you can email help@realm.io.
+
+
+# How to build locally:
+
+
+### Prerequisites
+
+- Swig. On Mac this can be installed using Homebrew: `brew install swig`.
+- CMake 3.18.1 or above. Can be installed through the Android SDK Manager.
+- Java 11.
+
+
+### Commands to build from source
+
+Checkout repo:
+```
+git clone --recursive  https://github.com/realm/realm-kotlin.git 
+```
+
+Build library:
+```
+git submodule update --init --recursive
+cd packages
+./gradlew assemble
+```
+
+Publish packages to `mavenLocal()`. Default location is `~/.m2` on Mac:
+```
+cd packages
+./gradlew publishToMavenLocal
+```
+
+In Android Studio open the `/test` project, which will open also all all required modules under `/packages`. 
+
+You can also run tests from the commandline:
+
+```
+cd test
+./gradlew connectedAndroidTest
+./gradlew macosTest
+```
+
+# Repository Guidelines
+
+## Branch Strategy
+
+We have three branches for shared development: `master`, `releases` and `next-major`. Tagged releases are only made from `releases`.
+
+`master`:
+* Target branch for new features.
+* Cotains the latest publishable state of the SDK.
+* [SNAPSHOT releases](#using-snapshots) are being created for every commit.
+
+`releases`:
+* All tagged releases are made from this branch.
+* Target branch for bug fixes.
+* Every commit should be merged back to master `master`.
+* Minor changes (e.g. to documentation, tests, and the build system) may not affect end users but should still be merged to `releases` to avoid diverging too far from `master` and to reduce the likelihood of merge conflicts.
+
+`next-major`:
+* Target branch for breaking changes that would result in a major version bump.
+
+
+## Code Style
+
+We use the offical [style guide](https://kotlinlang.org/docs/reference/coding-conventions.html) from Kotlin which is enforced using [ktlint](https://github.com/pinterest/ktlint) and [detekt](https://github.com/detekt/detekt).
+
+```sh
+# Call from root folder to check if code is compliant.
+./gradlew ktlintCheck
+./gradlew detekt
+
+# Call from root folder to automatically format all Kotlin code according to the code style rules.
+./gradlew ktlintFormat
+```
+
+Note: ktlint does not allow group imports using `.*`. You can configure IntelliJ to disallow this by going to preferences `Editor > Code Style > Kotlin > Imports` and select "Use single name imports".
+
+
+## Multiplatform source layout
+
+The multiplatform source hierarchy is structured like this:
+
+```
+- commonMain
+  ├── jvm
+  │   ├── androidMain
+  │   └── jvmMain
+  └── native
+      └── darwin
+          ├── ios
+          |   ├── iosArm64Main
+          |   └── iosX64Main
+          └── macosX64Main
+```
+
+All source sets ending with `Main` is platform specific source sets, while the others are intermediate source sets shared between multiple targets. Only exception is `commonMain` which is kept to follow the Kotlin MPP gradle convention.
+
+It is currently not possible to enable hierarchical setup due to various issues rendering the IDE unable to resolve common symbols, so for now we are just adding shared source sets to the individual platform specific targets they belong to. (Issues to track: https://youtrack.jetbrains.com/issue/KT-48153, https://youtrack.jetbrains.com/issue/KT-42466, https://youtrack.jetbrains.com/issue/KT-40975, see description of https://github.com/realm/realm-kotlin/pull/370 for details).
+
+All platform differentiated implementations are kept in `platform`-packages with their current package hierarchy, to make it easier to keep track of the level of platform differentiation.
+
+
+## Writing Tests
+
+Currently all unit tests should be place in the `test/` project instead of `packages/library-base`. The reason for this is that we need to apply the Realm Compiler Plugin to the tests and this introduces a circular dependency if the tests are in `library-base`.
+
+Inside `test/` there are 3 locations the files can be placed in:
+
+* `<base/sync>/src/commonTest`
+* `<base/sync>/src/androidTest`
+* `<base/sync>/src/macosTest`
+
+Ideally all shared tests should be in `commonTest` with specific platform tests in `androidTest`/`macosTest`. However IntelliJ does not yet allow you to run common tests on Android from within the IDE](https://youtrack.jetbrains.com/issue/KT-46452), so we
+are using the following work-around:
+
+1) All "common" tests should be placed in the `test/src/androidtest/kotlin/io/realm/shared` folder. They should be written using only common API's. I'e. use Kotlin Test, not JUnit. This `io.realm.shared` package should only contain tests we plan to eventually move to `commonTest`.
+
+
+2) The `macosTest` shared tests would automatically be picked up from the `androidTests` as it is symlinked to `test/src/androidtest/kotlin/io/realm/shared`.
+
+
+3) This allows us to run and debug unit tests on both macOS and Android. It is easier getting the imports correctly using the macOS sourceset as the Android code will default to using JUnit.
+ 
+
+All platform specific tests should be placed outside the `io.realm.shared` package, the default being `io.realm`.
+
+
+## Defining dependencies
+
+All dependency versions and other constants we might want to share between projects are defined inside the file 
+`buildSrc/src/main/kotlin/Config.kt`. Any new dependencies should be added to this file as well, so we only have one
+location for these.
+
+
+## Debugging Kotlin/Native Tests
+
+- Location of the kexe file that contains this test - make sure to compile the test beforehand:
+`test/build/bin/macos/debugTest/test.kexe`
+- Open:
+`lldb test/build/bin/macos/debugTest/test.kexe`
+- Set breakpoints, e.g.:
+`breakpoint set --file realm_coordinator.cpp --line 288`
+- Run ONLY the test you want:
+`r --gtest_filter="io.realm.MigrationTests.deleteOnMigration"`
+- Step into:
+`s`
+- Step over:
+`n`
+- Step out:
+`finish`
+
+

--- a/README.md
+++ b/README.md
@@ -7,21 +7,18 @@
 Realm is a mobile database that runs directly inside phones, tablets or wearables.
 This repository holds the source code for the Kotlin SDK for Realm, which runs on Kotlin Multiplatform and Android.
 
-# Examples 
+# Beta Notice
 
-https://github.com/realm/realm-kotlin-samples
+The Realm Kotlin SDK is in Beta for local database support, with [MongoDB Realm](https://www.mongodb.com/realm) and Sync API's in Alpha.
 
-## Kotlin Multiplatform Sample
 
-The folder `examples/kmm-sample` contains an example showing how to use Realm in a multiplatform
-project, sharing code for using Realm in the `shared` module. The project is based on
-`https://github.com/Kotlin/kmm-sample`.
+# Ressources
 
-# Documentation
+* Samples: https://github.com/realm/realm-kotlin-samples
+* Documentation: https://docs.mongodb.com/realm/sdk/kotlin-multiplatform/
 
-https://docs.mongodb.com/realm/sdk/kotlin-multiplatform/
 
-# Quick Start
+# Multiplatform Quick Start
 
 ## Prerequisite
 
@@ -79,12 +76,8 @@ Define a _RealmConfiguration_ with the database schema, then open the Realm usin
 
 ```Kotlin
 val configuration = RealmConfiguration.with(schema = setOf(Person::class, Dog::class))
-```
-
-```Kotlin
 val realm = Realm.open(configuration)
 ```
-
 
 ## Write
 
@@ -112,7 +105,7 @@ CoroutineScope(context).async {
 
 ## Query
 
-The query language supported by Realm is inspired by Apple’s [NSPredicate](https://developer.apple.com/documentation/foundation/nspredicate), see more examples [here](https://docs.mongodb.com/realm-legacy/docs/javascript/latest/index.html#queries)
+The query language supported by Realm is inspired by Apple’s [NSPredicate](https://developer.apple.com/documentation/foundation/nspredicate), see more examples [here](https://docs.mongodb.com/realm/sdk/kotlin/realm-database/query-language/)
 
 ```Kotlin
 // All persons
@@ -127,7 +120,7 @@ val filteredByName = personsByNameQuery.find()
 // Person having a dog aged more than 7 with a name starting with 'Fi'
 val filteredByDog = realm.query<Person>("dog.age > $0 AND dog.name BEGINSWITH $1", 7, "Fi").find()
 
-// Observing for changes with Kotlin Coroutine Flows
+// Observing for changes with Coroutine Flows
 CoroutineScope(context).async {
     personsByNameQuery.asFlow().collect { result: ResultsChange<Person> ->
         println("Realm updated: Number of persons is ${result.list.size}")
@@ -250,50 +243,8 @@ realm.query<Person>("name = $0", "Carlo").first().asFlow()
     }
 ```
 
-Next: head to the full KMM [example](./examples/kmm-sample).  
+Next: head to the full KMM [example](https://github.com/realm/realm-kotlin-samples/tree/main/Bookshelf).  
 
-### NOTE: The SDK doesn't currently support  `x86` - Please use an `x86_64` or `arm64` emulator/device
- 
-## The project is in Alpha. Features and API may change in future versions.
-
-## Kotlin Memory Model and Coroutine compatibility
-
-Realm Kotlin is implemented against Kotlin's default memory model (the old one), but still supports running with the new memory model if enabled in the consuming project. See https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md#switch-to-the-new-mm for details on enabled the new memory model.
-
-By default Realm Kotlin depends and requires to run with Kotlin Coroutines version `1.6.0-native-mt`. To use Realm Kotlin with the non-`native-mt` version of Coroutines you will have to enable the new memory model and also disables our internal freezing to accomodate the new freeze transparency for Coroutine 1.6.0. See https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md#unexpected-object-freezing for more details on that.
-
-## Design documents
-
-The public API of the SDK has not been finalized. Design discussions will happen in both Google Doc and this Github repository. Most bigger features will first undergo a design process that might not involve code. These design documents can be found using the following links:
-
-* [Intial Project Description](https://docs.google.com/document/d/10adRFquingm_JgyjDhUzcYXIDJsDG2A1ldFw53GSVJQ/edit)
-* [API Design Overview](https://docs.google.com/document/d/1RSPNO95wZAAojYlFwshSpLiuEu9ZqXptO58RDoPHKNc/edit)
-
-
-# How to build locally:
-
-## Prerequisites
-
-- Swig. On Mac this can be installed using Homebrew: `brew install swig`.
-- CMake 3.18.1 or above. Can be installed through the Android SDK Manager.
-- Java 11.
-
-## Commands to build from source
-
-```
-git submodule update --init --recursive
-cd packages
-./gradlew assemble
-```
-In Android Studio open the `test` project, which will open also the `realm-library` and the compiler projects
-
-You can also run tests from the commandline:
-
-```
-cd test
-./gradlew connectedAndroidTest
-./gradlew macosTest
-```
 
 # Using Snapshots
 
@@ -337,131 +288,29 @@ apply plugin: "io.realm.kotlin"
 See [Config.kt](buildSrc/src/main/kotlin/Config.kt#L2txt) for the latest version number.
 
 
-# Repository Guidelines
+## Kotlin Memory Model and Coroutine compatibility
 
-## Branch Strategy
+Realm Kotlin is implemented against Kotlin's default memory model (the old one), but still supports running with the new memory model if enabled in the consuming project. See https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md#switch-to-the-new-mm for details on enabled the new memory model.
 
-We have three branches for shared development: `master`, `releases` and `next-major`. Tagged releases are only made from `releases`.
+By default Realm Kotlin depends and requires to run with Kotlin Coroutines version `1.6.0-native-mt`. To use Realm Kotlin with the non-`native-mt` version of Coroutines you will have to enable the new memory model and also disables our internal freezing to accomodate the new freeze transparency for Coroutine 1.6.0. See https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md#unexpected-object-freezing for more details on that.
 
-`master`:
-
-* Target branch for new features.
-* Cotains the latest publishable state of the SDK.
-* [SNAPSHOT releases](#using-snapshots) are being created for every commit.
-
-`releases`:
-
-* All tagged releases are made from this branch.
-* Target branch for bug fixes.
-* Every commit should be merged back to master `master`.
-* Minor changes (e.g. to documentation, tests, and the build system) may not affect end users but should still be merged to `releases` to avoid diverging too far from `master` and to reduce the likelihood of merge conflicts.
-
-`next-major`:
-
-* Target branch for breaking changes that would result in a major version bump.
-
-
-Note: We currently only have the `master` branch, as no tagged releases have been made yet.
-
-## Code Style
-
-We use the offical [style guide](https://kotlinlang.org/docs/reference/coding-conventions.html) from Kotlin which is enforced using [ktlint](https://github.com/pinterest/ktlint) and [detekt](https://github.com/detekt/detekt).
-
-```sh
-# Call from root folder to check if code is compliant.
-./gradlew ktlintCheck
-./gradlew detekt
-
-# Call from root folder to automatically format all Kotlin code according to the code style rules.
-./gradlew ktlintFormat
-```
-
-Note: ktlint does not allow group imports using `.*`. You can configure IntelliJ to disallow this by going to preferences `Editor > Code Style > Kotlin > Imports` and select "Use single name imports".
-
-## Multiplatform source layout
-
-The multiplatform source hierarchy is structured like this:
-
-```
-- commonMain
-  ├── jvm
-  │   ├── androidMain
-  │   └── jvmMain
-  └── native
-      └── darwin
-          ├── ios
-          |   ├── iosArm64Main
-          |   └── iosX64Main
-          └── macosX64Main
-```
-
-All source sets ending with `Main` is platform specific source sets, while the others are intermediate source sets shared between multiple targets. Only exception is `commonMain` which is kept to follow the Kotlin MPP gradle convention.
-
-It is currently not possible to enable hierarchical setup due to various issues rendering the IDE unable to resolve common symbols, so for now we are just adding shared source sets to the individual platform specific targets they belong to. (Issues to track: https://youtrack.jetbrains.com/issue/KT-48153, https://youtrack.jetbrains.com/issue/KT-42466, https://youtrack.jetbrains.com/issue/KT-40975, see description of https://github.com/realm/realm-kotlin/pull/370 for details).
-
-All platform differentiated implementations are kept in `platform`-packages with their current package hierarchy, to make it easier to keep track of the level of platform differentiation.
-
-## Writing Tests
-
-Currently all unit tests should be place in the `test/` project instead of `packages/library`. The reason for this is that we need to apply the Realm Compiler Plugin to the tests and this introduces a circular dependency if the tests are in `library`.
-
-Inside `tests/` there are 3 locations the files can be placed in:
-
-* `test/src/commonTest`
-* `test/src/androidTest`
-* `test/src/macosTest`
-
-Ideally all shared tests should be in `commonTest` with specific platform tests in `androidTest`/`macosTest`. However IntelliJ does not yet allow you to run common tests on Android from within the IDE](https://youtrack.jetbrains.com/issue/KT-46452), so we
-are using the following work-around:
-
-1) All "common" tests should be placed in the `test/src/androidtest/kotlin/io/realm/shared` folder. They should be written using only common API's. I'e. use Kotlin Test, not JUnit. This `io.realm.shared` package should only contain tests we plan to eventually move to `commonTest`.
-
-
-2) The `macosTest` shared tests would automatically be picked up from the `androidTests` as it is symlinked to `test/src/androidtest/kotlin/io/realm/shared`.
-
-
-3) This allows us to run and debug unit tests on both macOS and Android. It is easier getting the imports correctly using the macOS sourceset as the Android code will default to using JUnit.
- 
-
-All platform specific tests should be placed outside the `io.realm.shared` package, the default being `io.realm`.
-
-## Defining dependencies
-
-All dependency versions and other constants we might want to share between projects are defined inside the file 
-`buildSrc/src/main/kotlin/Config.kt`. Any new dependencies should be added to this file as well, so we only have one
-location for these.
-
-## Debugging Kotlin/Native Tests
-
-- Location of the kexe file that contains this test - make sure to compile the test beforehand:
-`test/build/bin/macos/debugTest/test.kexe`
-- Open:
-`lldb test/build/bin/macos/debugTest/test.kexe`
-- Set breakpoints, e.g.:
-`breakpoint set --file realm_coordinator.cpp --line 288`
-- Run ONLY the test you want:
-`r --gtest_filter="io.realm.MigrationTests.deleteOnMigration"`
-- Step into:
-`s`
-- Step over:
-`n`
-- Step out:
-`finish`
 
 ## Contributing
 
-We love contributions to Realm! If you'd like to contribute code, documentation, or any other improvements, please [file a Pull Request](https://github.com/realm/realm-kotlin/pulls) on our GitHub repository. Make sure to accept our CLA:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more details!
 
-### CLA
-
-We welcomes all contributions! The only requirement we have is that, like many other projects, we need to have a [Contributor License Agreement](https://en.wikipedia.org/wiki/Contributor_License_Agreement) (CLA) in place before we can accept any external code. Our own CLA is a modified version of the Apache Software Foundation’s CLA.
-
-[Please submit your CLA electronically using our Google form](https://docs.google.com/forms/d/e/1FAIpQLSeQ9ROFaTu9pyrmPhXc-dEnLD84DbLuT_-tPNZDOL9J10tOKQ/viewform) so we can accept your submissions. The GitHub username you file there will need to match that of your Pull Requests. If you have any questions or cannot file the CLA electronically, you can email help@realm.io.
 
 ## Code of Conduct
 
 This project adheres to the [MongoDB Code of Conduct](https://www.mongodb.com/community-code-of-conduct).
 By participating, you are expected to uphold this code. Please report
 unacceptable behavior to [community-conduct@mongodb.com](mailto:community-conduct@mongodb.com).
+
+
+## License
+
+Realm Kotlin is published under the [Apache 2.0 license](LICENSE).
+
+This product is not being made available to any person located in Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, or to any other person that is not eligible to receive the product under U.S. law.
 
 <img style="width: 0px; height: 0px;" src="https://3eaz4mshcd.execute-api.us-east-1.amazonaws.com/prod?s=https://github.com/realm/realm-kotlin#README.md">

--- a/README.md
+++ b/README.md
@@ -292,7 +292,14 @@ See [Config.kt](buildSrc/src/main/kotlin/Config.kt#L2txt) for the latest version
 
 Realm Kotlin is implemented against Kotlin's default memory model (the old one), but still supports running with the new memory model if enabled in the consuming project. See https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md#switch-to-the-new-mm for details on enabled the new memory model.
 
-By default Realm Kotlin depends and requires to run with Kotlin Coroutines version `1.6.0-native-mt`. To use Realm Kotlin with the non-`native-mt` version of Coroutines you will have to enable the new memory model and also disables our internal freezing to accomodate the new freeze transparency for Coroutine 1.6.0. See https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md#unexpected-object-freezing for more details on that.
+By default Realm Kotlin depends and requires you to run with Kotlin Coroutines version `1.6.0-native-mt`. To use Realm Kotlin with the non-`native-mt` version of Coroutines you will have to enable the new memory model and also disables our internal freezing to accomodate the new freeze transparency for Coroutine 1.6.0. 
+
+```
+kotlin.native.binary.memoryModel=experimental
+kotlin.native.binary.freezing=disabled
+```
+
+See https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md#unexpected-object-freezing for more details.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository holds the source code for the Kotlin SDK for Realm, which runs o
 The Realm Kotlin SDK is in Beta for local database support, with [MongoDB Realm](https://www.mongodb.com/realm) and Sync API's in Alpha.
 
 
-# Ressources
+# Resources
 
 * Samples: https://github.com/realm/realm-kotlin-samples
 * Documentation: https://docs.mongodb.com/realm/sdk/kotlin-multiplatform/


### PR DESCRIPTION
Our README was getting a bit too large.

In order to improve readability, I reorganized into `README.md` and `CONTRIBUTING.md`, similar to how realm-core has done.

I also collapsed a few sections like examples/documentation, adjusted some references to docs and generally point people towards realm-kotlin-samples instead of the `kmm-sample` in this repo, since this is just for integration tests now.

I also moved the Beta notice to the top...but not 100% exactly what to write there.

I also removed the mention to our design documents. They did see a little bit of traffic, but not sure it is worth having references to them anymore since things quite a lot of things have changed. So I removed them to reduce the length of the doc.