### PR TITLE
Fix assignments to RealmList properties on managed objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* Fix assignments to `RealmList`-properties on managed objects (Issue [#718](https://github.com/realm/realm-kotlin/issues/718))
 
 ### Compatibility
 * This release is compatible with:

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -329,7 +329,10 @@ internal object RealmObjectHelper {
     }
 
     @Suppress("UNUSED_PARAMETER")
-    internal fun setList(obj: RealmObjectInternal, col: String, list: RealmList<Any?>) {
-        TODO()
+    inline fun <reified T : Any> setList(obj: RealmObjectInternal, col: String, list: RealmList<Any?>) {
+        getList<T>(obj, col).also {
+            it.clear()
+            it.addAll(list)
+        }
     }
 }

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
@@ -351,6 +351,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                 modifyAccessor(
                     property = declaration,
                     getFunction = getList,
+                    setFunction = setList,
                     collectionType = CollectionType.LIST
                 )
             }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmListTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmListTests.kt
@@ -190,6 +190,13 @@ class RealmListTests {
     }
 
     @Test
+    fun add() {
+        for (tester in managedTesters) {
+            tester.add()
+        }
+    }
+
+    @Test
     fun addWithIndex() {
         for (tester in managedTesters) {
             tester.addWithIndex()
@@ -257,6 +264,13 @@ class RealmListTests {
     fun setFailsIfClosed() {
         // No need to be exhaustive
         managedTesters[0].setFailsIfClosed(getCloseableRealm())
+    }
+
+    @Test
+    fun reassign() {
+        for (tester in managedTesters) {
+            tester.reassign()
+        }
     }
 
     @Test
@@ -343,6 +357,7 @@ internal interface ListApiTester {
     fun copyToRealm()
     fun get()
     fun getFailsIfClosed(realm: Realm)
+    fun add()
     fun addWithIndex()
     fun addWithIndexFailsIfClosed(realm: Realm)
     fun addAllWithIndex()
@@ -353,6 +368,7 @@ internal interface ListApiTester {
     fun removeAtFailsIfClosed(realm: Realm)
     fun set()
     fun setFailsIfClosed(realm: Realm)
+    fun reassign()
 
     // All the other functions are not tested since we rely on implementations from parent classes.
 
@@ -375,7 +391,7 @@ internal interface ListApiTester {
         try {
             block()
         } catch (e: AssertionError) {
-            throw AssertionError("'${toString()}' failed - ${e.message}")
+            throw AssertionError("'${toString()}' failed - ${e.message}", e)
         }
     }
 }
@@ -518,6 +534,29 @@ internal abstract class ManagedListTester<T>(
             }
         }
 
+        assertContainerAndCleanup { container -> assertions(container) }
+    }
+
+    override fun add() {
+        val dataSet: List<T> = typeSafetyManager.getInitialDataSet()
+
+        val assertions = { container: RealmListContainer ->
+            val list = typeSafetyManager.getList(container)
+            dataSet.forEachIndexed { index, t ->
+                assertElementsAreEqual(t, list[index])
+            }
+        }
+
+        errorCatcher {
+            realm.writeBlocking {
+                val list = typeSafetyManager.createContainerAndGetList(this)
+                dataSet.forEachIndexed { index, e ->
+                    assertEquals(index, list.size)
+                    list.add(e)
+                    assertEquals(index + 1, list.size)
+                }
+            }
+        }
         assertContainerAndCleanup { container -> assertions(container) }
     }
 
@@ -817,6 +856,31 @@ internal abstract class ManagedListTester<T>(
                 }
             }
         }
+    }
+
+    override fun reassign() {
+        val dataSet = typeSafetyManager.getInitialDataSet()
+        val reassignedDataSet = listOf(dataSet[1])
+
+        val assertions = { list: RealmList<T> ->
+            assertEquals(1, list.size)
+            // We cannot assert equality on RealmObject lists as the object isn't equals to the
+            // unmanaged object from before the assignment
+            if (list[0] !is RealmObject) {
+                assertContentEquals(reassignedDataSet, list)
+            }
+        }
+        errorCatcher {
+            realm.writeBlocking {
+                val container = copyToRealm(RealmListContainer())
+                val list = typeSafetyManager.property.get(container)
+                list.addAll(dataSet)
+
+                val value = reassignedDataSet.toRealmList()
+                typeSafetyManager.property.set(container, value)
+            }
+        }
+        assertListAndCleanup { list -> assertions(list) }
     }
 
     // Retrieves the list again but this time from Realm to check the getter is called correctly


### PR DESCRIPTION
This adds support for assigning and importing unmanaged objects by assigning `RealmList` property on an already managed object.

Closes #718 