### PR TITLE
Adding support for Configuration.InitialData

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/Callback.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/Callback.kt
@@ -62,3 +62,7 @@ fun interface CompactOnLaunchCallback {
 fun interface MigrationCallback {
     fun migrate(oldRealm: NativePointer, newRealm: NativePointer, schema: NativePointer): Boolean
 }
+
+fun interface DataInitializationCallback {
+    fun invoke(realm: NativePointer): Boolean
+}

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -64,6 +64,7 @@ expect object RealmInterop {
     fun realm_config_get_encryption_key(config: NativePointer): ByteArray?
     fun realm_config_set_should_compact_on_launch_function(config: NativePointer, callback: CompactOnLaunchCallback)
     fun realm_config_set_migration_function(config: NativePointer, callback: MigrationCallback)
+    fun realm_config_set_data_initialization_function(config: NativePointer, callback: DataInitializationCallback)
 
     fun realm_schema_validate(schema: NativePointer, mode: SchemaValidationMode): Boolean
 

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -382,6 +382,21 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_config_set_data_initialization_function(config: NativePointer, callback: DataInitializationCallback) {
+        realm_wrapper.realm_config_set_data_initialization_function(
+            config.cptr(),
+            staticCFunction { userData, realm ->
+                safeUserData<DataInitializationCallback>(userData).invoke(
+                    // These realm/schema pointers are only valid for the duraction of the
+                    // migration so don't let ownership follow the NativePointer-objects
+                    CPointerWrapper(realm, false)
+                )
+            },
+            // Leaking - Await fix of https://github.com/realm/realm-core/issues/5222
+            StableRef.create(callback).asCPointer()
+        )
+    }
+
     actual fun realm_config_set_schema(config: NativePointer, schema: NativePointer) {
         realm_wrapper.realm_config_set_schema(config.cptr(), schema.cptr())
     }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -148,6 +148,10 @@ actual object RealmInterop {
         realmc.realm_config_set_migration_function(config.cptr(), callback)
     }
 
+    actual fun realm_config_set_data_initialization_function(config: NativePointer, callback: DataInitializationCallback) {
+        realmc.realm_config_set_data_initialization_function(config.cptr(), callback)
+    }
+
     actual fun realm_open(config: NativePointer, dispatcher: CoroutineDispatcher?): NativePointer {
         // create a custom Scheduler for JVM if a Coroutine Dispatcher is provided other wise pass null to use the generic one
 

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -140,6 +140,19 @@ std::string rlm_stdstr(realm_string_t val)
     $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
 }
 
+// Setup Data Initialization callback
+%typemap(jstype) (realm_data_initialization_func_t, void* userdata) "Object" ;
+%typemap(jtype) (realm_data_initialization_func_t, void* userdata) "Object" ;
+%typemap(javain) (realm_data_initialization_func_t, void* userdata) "$javainput";
+%typemap(jni) (realm_data_initialization_func_t, void* userdata) "jobject";
+%typemap(in) (realm_data_initialization_func_t, void* userdata) {
+    auto jenv = get_env(true);
+    $1 = reinterpret_cast<realm_data_initialization_func_t>(realm_data_initialization_callback);
+    // FIXME How to release this: https://github.com/realm/realm-core/issues/5222
+    //  When #5222 resolved, it might be possible to merge this type map with the above as their
+    //  signatures then follow the same pattern.
+    $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
+}
 // Primitive/built in type handling
 typedef jstring realm_string_t;
 // TODO OPTIMIZATION Optimize...maybe port JStringAccessor from realm-java

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -358,6 +358,16 @@ bool realm_should_compact_callback(void* userdata, uint64_t total_bytes, uint64_
     return result;
 }
 
+void realm_data_initialization_callback(void* userdata, realm_t* realm) {
+    auto env = get_env(true);
+    static JavaClass java_data_initialization_class(env, "io/realm/internal/interop/DataInitializationCallback");
+    static JavaMethod java_invoke_method(env, java_data_initialization_class, "invoke", "(Ljava/lang/Object;)V");
+
+    jobject callback = static_cast<jobject>(userdata);
+    env->CallVoidMethod(callback, java_invoke_method, wrap_pointer(env, reinterpret_cast<jlong>(realm), false));
+    jni_check_exception(env);
+}
+
 static void send_request_via_jvm_transport(JNIEnv *jenv, jobject network_transport, const realm_http_request_t request, jobject j_response_callback) {
     static JavaMethod m_send_request_method(jenv,
                                             JavaClassGlobalDef::network_transport_class(),

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -68,4 +68,7 @@ sync_set_error_handler(realm_sync_config_t* sync_config, jobject error_handler);
 void
 complete_http_request(void* request_context, jobject j_response);
 
+void
+realm_data_initialization_callback(void* user_data, realm_t* realm);
+
 #endif //TEST_REALM_API_HELPERS_H

--- a/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
@@ -44,6 +44,17 @@ public fun interface CompactOnLaunchCallback {
 }
 
 /**
+ * TODO
+ */
+public fun interface InitialDataCallback {
+
+    /**
+     * TODO
+     */
+    public fun writeData(block: MutableRealm.() -> Unit)
+}
+
+/**
  * Configuration for log events created by a Realm instance.
  */
 public data class LogConfiguration(
@@ -116,6 +127,11 @@ public interface Configuration {
     public val compactOnLaunchCallback: CompactOnLaunchCallback?
 
     /**
+     * TODO
+     */
+    public val initialDataCallback: InitialDataCallback?
+
+    /**
      * Base class for configuration builders that holds properties available to both
      * [RealmConfiguration] and [SyncConfiguration].
      *
@@ -140,6 +156,7 @@ public interface Configuration {
         protected var schemaVersion: Long = 0
         protected var encryptionKey: ByteArray? = null
         protected var compactOnLaunchCallback: CompactOnLaunchCallback? = null
+        protected var initialDataCallback: InitialDataCallback? = null
 
         /**
          * Creates the RealmConfiguration based on the builder properties.
@@ -305,6 +322,12 @@ public interface Configuration {
          */
         public fun compactOnLaunch(callback: CompactOnLaunchCallback = Realm.DEFAULT_COMPACT_ON_LAUNCH_CALLBACK): S =
             apply { this.compactOnLaunchCallback = callback } as S
+
+        /**
+         * TODO
+         */
+        public fun initialData(block: InitialDataCallback): S =
+            apply { this.initialDataCallback = block } as S
 
         /**
          * Removes the default system logger from being installed. If no custom loggers have

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -88,7 +88,8 @@ public interface RealmConfiguration : Configuration {
                 encryptionKey,
                 deleteRealmIfMigrationNeeded,
                 compactOnLaunchCallback,
-                migration
+                migration,
+                initialDataCallback
             )
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
@@ -17,6 +17,7 @@
 package io.realm.internal
 
 import io.realm.CompactOnLaunchCallback
+import io.realm.InitialDataCallback
 import io.realm.LogConfiguration
 import io.realm.RealmConfiguration
 import io.realm.RealmObject
@@ -38,7 +39,8 @@ internal class RealmConfigurationImpl(
     encryptionKey: ByteArray?,
     override val deleteRealmIfMigrationNeeded: Boolean,
     compactOnLaunchCallback: CompactOnLaunchCallback?,
-    migration: RealmMigration?
+    migration: RealmMigration?,
+    initialDataCallback: InitialDataCallback?
 ) : ConfigurationImpl(
     directory,
     name,
@@ -54,6 +56,7 @@ internal class RealmConfigurationImpl(
     },
     encryptionKey,
     compactOnLaunchCallback,
-    migration
+    migration,
+    initialDataCallback
 ),
     RealmConfiguration

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/SyncConfiguration.kt
@@ -151,7 +151,8 @@ public interface SyncConfiguration : Configuration {
                 SchemaMode.RLM_SCHEMA_MODE_ADDITIVE_DISCOVERED,
                 encryptionKey,
                 compactOnLaunchCallback,
-                null // migration is not relevant for sync
+                null, // migration is not relevant for sync
+                initialDataCallback
             )
 
             return SyncConfigurationImpl(


### PR DESCRIPTION
Closes #302
Closes #422 

Add support `Configuration.initialData()`, so it works for both `RealmConfiguration` and `SyncConfiguration`. Similar to how it works in Realm Java.

**TODO**
- [x] Figure out how to get a MutableRealm during initialization? Right now I have two options
           - 1. Refactor how MutableRealms are created. Right now it is pretty heavily intertwined with WriterRealm. Unclear how difficult this is.
           - 2. Only use the callback to set a flag we can react to after opening the Realm. This appears to be easier, but might also be problematic if the same configuration is used to open multiple Realms at the same time.
 - [x] Change to SchemaMode::HardReset
 - [x] Tests
 - [x] This approach means it will not work for `DynamicRealm`...This is also the case in Java where no-one has complained about the missing support...could be worked around by having a `MutableRealm.asDynamicRealm()` extension method (or something like that)



 