### PR TITLE
Reducing binary size for Andorid dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* None.
+* Reducing the binary size for Android dependency . (Issue [#616](https://github.com/realm/realm-kotlin/issues/216)).
 
 ### Fixed
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* Reducing the binary size for Android dependency . (Issue [#616](https://github.com/realm/realm-kotlin/issues/216)).
+* Reducing the binary size for Android dependency . (Issue [#216](https://github.com/realm/realm-kotlin/issues/216)).
 
 ### Fixed
 * None.

--- a/packages/cinterop/src/jvm/CMakeLists.txt
+++ b/packages/cinterop/src/jvm/CMakeLists.txt
@@ -36,6 +36,12 @@ set(REALM_ENABLE_SYNC ON)
 set(REALM_BUILD_LIB_ONLY ON)
 add_subdirectory("${CMAKE_SOURCE_DIR}/../../../external/core" core EXCLUDE_FROM_ALL)
 
+if(ANDROID)
+    if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-gc-sections -Wl,--exclude-libs,ALL")
+    endif()
+endif()
+
 file(GLOB jni_SRC
         "${CINTEROP_JNI}/env_utils.cpp"
         "${CINTEROP_JNI}/utils.cpp"


### PR DESCRIPTION
- There's a difference of ~1MB on the overall AAR file when applying the linker `gc` flags
- `arm64` was `7.5MB` and now `7MB`
- This is also way below the size of a Java shared object with Sync which is around `9.2MB` for `arm64`
  
Most of the other flags set in Java are not necessary since they're set by the Android toolchain file 
