### PR TITLE
Refactor object internal 

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmObjectInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmObjectInterop.kt
@@ -27,5 +27,5 @@ interface RealmObjectInterop {
     // Names must match identifiers in compiler plugin (plugin-compiler/io.realm.compiler.Identifiers.kt)
 
     // Invariant: This is never null for managed objects!
-    var objectPointer: NativePointer
+    val objectPointer: NativePointer
 }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmObjectInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmObjectInterop.kt
@@ -27,5 +27,5 @@ interface RealmObjectInterop {
     // Names must match identifiers in compiler plugin (plugin-compiler/io.realm.compiler.Identifiers.kt)
 
     // Invariant: This is never null for managed objects!
-    var `$realm$ObjectPointer`: NativePointer?
+    var objectPointer: NativePointer
 }

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -862,7 +862,7 @@ actual object RealmInterop {
             is RealmObjectInterop -> {
                 cvalue.type = realm_value_type.RLM_TYPE_LINK
                 val nativePointer =
-                    value.`$realm$ObjectPointer` ?: error("Cannot set unmanaged object")
+                    value.objectPointer
                 realm_wrapper.realm_object_as_link(nativePointer?.cptr()).useContents {
                     cvalue.link.apply {
                         target_table = this@useContents.target_table

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -497,8 +497,7 @@ actual object RealmInterop {
                     }
                 }
                 is RealmObjectInterop -> {
-                    val nativePointer = (value as RealmObjectInterop).`$realm$ObjectPointer`
-                        ?: error("Cannot add unmanaged object")
+                    val nativePointer = (value as RealmObjectInterop).objectPointer
                     cvalue.link = realmc.realm_object_as_link(nativePointer.cptr())
                     cvalue.type = realm_value_type_e.RLM_TYPE_LINK
                 }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -501,7 +501,7 @@ actual object RealmInterop {
                     }
                 }
                 is RealmObjectInterop -> {
-                    val nativePointer = (value as RealmObjectInterop).objectPointer
+                    val nativePointer = value.objectPointer
                     cvalue.link = realmc.realm_object_as_link(nativePointer.cptr())
                     cvalue.type = realm_value_type_e.RLM_TYPE_LINK
                 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -21,6 +21,7 @@ import io.realm.internal.UnmanagedState
 import io.realm.internal.getObjectReference
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.runIfManaged
+import io.realm.internal.checkNotificationsAvailable
 import io.realm.migration.AutomaticSchemaMigration
 import io.realm.notifications.DeletedObject
 import io.realm.notifications.InitialObject
@@ -85,11 +86,3 @@ public fun <T : RealmObject> T.asFlow(): Flow<ObjectChange<T>> = runIfManaged {
     return owner.owner.registerObserver(this) as Flow<ObjectChange<T>>
 } ?: throw IllegalStateException("Changes cannot be observed on unmanaged objects.")
 
-private fun <T : RealmObject> RealmObjectReference<T>.checkNotificationsAvailable() {
-    if (RealmInterop.realm_is_closed(owner.dbPointer)) {
-        throw IllegalStateException("Changes cannot be observed when the Realm has been closed.")
-    }
-    if (!isValid()) {
-        throw IllegalStateException("Changes cannot be observed on objects that have been deleted from the Realm.")
-    }
-}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -60,27 +60,6 @@ public fun RealmObject.version(): VersionId =
 public fun RealmObject.isManaged(): Boolean = getObjectReference() != null
 
 /**
- * Checks whether [this] and [other] represent the same underlying object or not. It allows to check
- * if two object from different frozen realms share their object key, and thus represent the same
- * object at different points in time (= at two different frozen realm versions).
- */
-internal fun RealmObject.hasSameObjectKey(other: RealmObject?): Boolean {
-    if (other == null) return false
-
-    return runIfManaged {
-        val that = this
-        other.runIfManaged {
-            val thisKey =
-                RealmInterop.realm_object_get_key(this.objectPointer)
-            val otherKey =
-                RealmInterop.realm_object_get_key(that.objectPointer)
-
-            thisKey == otherKey
-        }
-    } ?: throw IllegalStateException("Cannot compare unmanaged objects.")
-}
-
-/**
  * Returns true if this object is still valid to use, i.e. the Realm is open and the underlying object has
  * not been deleted. Unmanaged objects are always valid.
  */

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -18,7 +18,7 @@ package io.realm
 
 import io.realm.internal.RealmObjectInternal
 import io.realm.internal.interop.RealmInterop
-import io.realm.internal.realmObjectInternal
+import io.realm.internal.asObjectReference
 import io.realm.migration.AutomaticSchemaMigration
 import io.realm.notifications.DeletedObject
 import io.realm.notifications.InitialObject
@@ -40,14 +40,14 @@ public interface RealmObject : Deleteable
  * @return true if the object is frozen, false otherwise.
  */
 public fun RealmObject.isFrozen(): Boolean {
-    return realmObjectInternal().isFrozen()
+    return asObjectReference()!!.isFrozen()
 }
 
 /**
  * Returns the Realm version of this object. This version number is tied to the transaction the object was read from.
  */
 public fun RealmObject.version(): VersionId {
-    return realmObjectInternal().version()
+    return asObjectReference()!!.version()
 }
 
 /**
@@ -58,7 +58,7 @@ public fun RealmObject.version(): VersionId {
  * Realm.
  */
 public fun RealmObject.isManaged(): Boolean {
-    return realmObjectInternal().`$realm$IsManaged`
+    return asObjectReference() != null
 }
 
 /**
@@ -74,9 +74,9 @@ internal fun RealmObject.hasSameObjectKey(other: RealmObject?): Boolean {
     }
 
     val thisKey =
-        RealmInterop.realm_object_get_key(this.realmObjectInternal().`$realm$ObjectPointer`!!)
+        RealmInterop.realm_object_get_key(this.asObjectReference()!!.`$realm$ObjectPointer`!!)
     val otherKey =
-        RealmInterop.realm_object_get_key(other.realmObjectInternal().`$realm$ObjectPointer`!!)
+        RealmInterop.realm_object_get_key(other.asObjectReference()!!.`$realm$ObjectPointer`!!)
 
     return thisKey == otherKey
 }
@@ -88,7 +88,7 @@ internal fun RealmObject.hasSameObjectKey(other: RealmObject?): Boolean {
 public fun RealmObject.isValid(): Boolean {
     return if (isManaged()) {
         val internalObject = this as RealmObjectInternal
-        val ptr = internalObject.`$realm$ObjectPointer`
+        val ptr = internalObject.`$realm$objectReference`!!.`$realm$ObjectPointer`
         return if (ptr != null) {
             RealmInterop.realm_object_is_valid(ptr)
         } else {
@@ -117,12 +117,12 @@ public fun <T : RealmObject, C : ObjectChange<T>> T.asFlow(): Flow<ObjectChange<
     checkNotificationsAvailable()
     val internalObject = this as RealmObjectInternal
     @Suppress("UNCHECKED_CAST")
-    return (internalObject.`$realm$Owner`!!).owner.registerObserver(this) as Flow<ObjectChange<T>>
+    return (internalObject.`$realm$objectReference`!!.`$realm$Owner`!!).owner.registerObserver(internalObject.`$realm$objectReference`!!) as Flow<ObjectChange<T>>
 }
 
 private fun RealmObject.checkNotificationsAvailable() {
     val internalObject = this as RealmObjectInternal
-    val realm = internalObject.`$realm$Owner`
+    val realm = internalObject.`$realm$objectReference`!!.`$realm$Owner`
     if (!isManaged()) {
         throw IllegalStateException("Changes cannot be observed on unmanaged objects.")
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -18,8 +18,8 @@ package io.realm
 
 import io.realm.internal.UnmanagedState
 import io.realm.internal.checkNotificationsAvailable
-import io.realm.internal.getObjectReference
 import io.realm.internal.interop.RealmInterop
+import io.realm.internal.realmObjectReference
 import io.realm.internal.runIfManaged
 import io.realm.migration.AutomaticSchemaMigration
 import io.realm.notifications.DeletedObject
@@ -42,13 +42,13 @@ public interface RealmObject : Deleteable
  * @return true if the object is frozen, false otherwise.
  */
 public fun RealmObject.isFrozen(): Boolean =
-    (getObjectReference() ?: UnmanagedState).isFrozen()
+    (realmObjectReference ?: UnmanagedState).isFrozen()
 
 /**
  * Returns the Realm version of this object. This version number is tied to the transaction the object was read from.
  */
 public fun RealmObject.version(): VersionId =
-    (getObjectReference() ?: UnmanagedState).version()
+    (realmObjectReference ?: UnmanagedState).version()
 
 /**
  * Returns whether or not this object is managed by Realm.
@@ -57,7 +57,7 @@ public fun RealmObject.version(): VersionId =
  * queries or change listeners. Unmanaged objects behave like normal Kotlin objects and are completely separate from
  * Realm.
  */
-public fun RealmObject.isManaged(): Boolean = getObjectReference() != null
+public fun RealmObject.isManaged(): Boolean = realmObjectReference != null
 
 /**
  * Returns true if this object is still valid to use, i.e. the Realm is open and the underlying object has

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -18,7 +18,7 @@ package io.realm
 
 import io.realm.internal.RealmObjectInternal
 import io.realm.internal.UnmanagedState
-import io.realm.internal.asObjectReference
+import io.realm.internal.getObjectReference
 import io.realm.internal.interop.RealmInterop
 import io.realm.migration.AutomaticSchemaMigration
 import io.realm.notifications.DeletedObject
@@ -41,13 +41,13 @@ public interface RealmObject : Deleteable
  * @return true if the object is frozen, false otherwise.
  */
 public fun RealmObject.isFrozen(): Boolean =
-    (asObjectReference() ?: UnmanagedState).isFrozen()
+    (getObjectReference() ?: UnmanagedState).isFrozen()
 
 /**
  * Returns the Realm version of this object. This version number is tied to the transaction the object was read from.
  */
 public fun RealmObject.version(): VersionId =
-    (asObjectReference() ?: UnmanagedState).version()
+    (getObjectReference() ?: UnmanagedState).version()
 
 /**
  * Returns whether or not this object is managed by Realm.
@@ -56,7 +56,7 @@ public fun RealmObject.version(): VersionId =
  * queries or change listeners. Unmanaged objects behave like normal Kotlin objects and are completely separate from
  * Realm.
  */
-public fun RealmObject.isManaged(): Boolean = asObjectReference() != null
+public fun RealmObject.isManaged(): Boolean = getObjectReference() != null
 
 /**
  * Checks whether [this] and [other] represent the same underlying object or not. It allows to check
@@ -66,8 +66,8 @@ public fun RealmObject.isManaged(): Boolean = asObjectReference() != null
 internal fun RealmObject.hasSameObjectKey(other: RealmObject?): Boolean {
     if ((other == null) || (other !is RealmObjectInternal)) return false
 
-    return asObjectReference()?.let { ref1 ->
-        other.asObjectReference()?.let { ref2 ->
+    return getObjectReference()?.let { ref1 ->
+        other.getObjectReference()?.let { ref2 ->
             val thisKey =
                 RealmInterop.realm_object_get_key(ref1.objectPointer)
             val otherKey =
@@ -83,7 +83,7 @@ internal fun RealmObject.hasSameObjectKey(other: RealmObject?): Boolean {
  * not been deleted. Unmanaged objects are always valid.
  */
 public fun RealmObject.isValid(): Boolean =
-    asObjectReference()?.run {
+    getObjectReference()?.run {
         return RealmInterop.realm_object_is_valid(objectPointer)
     } ?: true
 
@@ -108,7 +108,7 @@ public fun <T : RealmObject> T.asFlow(): Flow<ObjectChange<T>> {
 }
 
 private fun RealmObject.checkNotificationsAvailable() {
-    asObjectReference()?.run {
+    getObjectReference()?.run {
         if (RealmInterop.realm_is_closed(owner.dbPointer)) {
             throw IllegalStateException("Changes cannot be observed when the Realm has been closed.")
         }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmObject.kt
@@ -16,12 +16,11 @@
 
 package io.realm
 
-import io.realm.internal.RealmObjectReference
 import io.realm.internal.UnmanagedState
+import io.realm.internal.checkNotificationsAvailable
 import io.realm.internal.getObjectReference
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.runIfManaged
-import io.realm.internal.checkNotificationsAvailable
 import io.realm.migration.AutomaticSchemaMigration
 import io.realm.notifications.DeletedObject
 import io.realm.notifications.InitialObject
@@ -85,4 +84,3 @@ public fun <T : RealmObject> T.asFlow(): Flow<ObjectChange<T>> = runIfManaged {
     checkNotificationsAvailable()
     return owner.owner.registerObserver(this) as Flow<ObjectChange<T>>
 } ?: throw IllegalStateException("Changes cannot be observed on unmanaged objects.")
-

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
@@ -24,13 +24,15 @@ public interface InternalDeleteable : Deleteable {
 }
 
 internal fun Deleteable.asInternalDeleteable(): InternalDeleteable {
-    // This line is needed because the classes that are marked with Deleteable and InternalDeleteable are not
-    // the same for RealmObjects.
-    val deleteable = if (this is RealmObjectInternal) { this.getObjectReference() } else { this }
-    if (deleteable !is InternalDeleteable) {
-        // This should only happen if users implements Deleteable and pass their non-Realm objects
-        // to delete
-        throw IllegalArgumentException("Cannot delete custom Deleteable objects: ${this::class.simpleName}")
+    return when (this) {
+        // InternalDeleteable is not on RealmObjects but on the RealmObjectReference
+        is RealmObjectInternal ->
+            this.realmObjectReference
+                ?: throw IllegalArgumentException("Cannot delete unmanaged object")
+        is InternalDeleteable -> this
+        else ->
+            // This should only happen if users implements Deleteable and pass their non-Realm objects
+            // to delete
+            throw IllegalArgumentException("Cannot delete custom Deleteable objects: ${this::class.simpleName}")
     }
-    return deleteable
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
@@ -24,7 +24,7 @@ public interface InternalDeleteable : Deleteable {
 }
 
 internal fun Deleteable.asInternalDeleteable(): InternalDeleteable {
-    val deleteable = if (this is RealmObjectInternal) { this.asObjectReference() } else { this }
+    val deleteable = if (this is RealmObjectInternal) { this.getObjectReference() } else { this }
     if (deleteable !is InternalDeleteable) {
         // This should only happen if users implements Deleteable and pass their non-Realm objects
         // to delete

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
@@ -24,6 +24,8 @@ public interface InternalDeleteable : Deleteable {
 }
 
 internal fun Deleteable.asInternalDeleteable(): InternalDeleteable {
+    // This line is needed because the classes that are marked with Deleteable and InternalDeleteable are not
+    // the same for RealmObjects.
     val deleteable = if (this is RealmObjectInternal) { this.getObjectReference() } else { this }
     if (deleteable !is InternalDeleteable) {
         // This should only happen if users implements Deleteable and pass their non-Realm objects

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
@@ -24,10 +24,11 @@ public interface InternalDeleteable : Deleteable {
 }
 
 internal fun Deleteable.asInternalDeleteable(): InternalDeleteable {
-    if (this !is InternalDeleteable) {
+    val deleteable = if (this is RealmObjectInternal) { this.asObjectReference() } else { this }
+    if (deleteable !is InternalDeleteable) {
         // This should only happen if users implements Deleteable and pass their non-Realm objects
         // to delete
         throw IllegalArgumentException("Cannot delete custom Deleteable objects: ${this::class.simpleName}")
     }
-    return this
+    return deleteable
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalDeleteable.kt
@@ -28,7 +28,7 @@ internal fun Deleteable.asInternalDeleteable(): InternalDeleteable {
         // InternalDeleteable is not on RealmObjects but on the RealmObjectReference
         is RealmObjectInternal ->
             this.realmObjectReference
-                ?: throw IllegalArgumentException("Cannot delete unmanaged object")
+                ?: throw IllegalArgumentException("Cannot delete unmanaged objects.")
         is InternalDeleteable -> this
         else ->
             // This should only happen if users implements Deleteable and pass their non-Realm objects

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
@@ -36,7 +36,7 @@ internal interface InternalMutableRealm : MutableRealm {
                     // up to date, just return input
                     obj
                 } else {
-                    return obj.thaw(realmReference) as T?
+                    return thaw(realmReference)?.toRealmObject() as T?
                 }
             } ?: throw IllegalArgumentException(
                 "Unmanaged objects must be part of the Realm, before " +

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
@@ -36,7 +36,7 @@ internal interface InternalMutableRealm : MutableRealm {
                     "they can be queried this way. Use `MutableRealm.copyToRealm()` to turn it into " +
                     "a managed object."
             )
-        } else if ((obj as RealmObjectInternal).`$realm$Owner` == realmReference) {
+        } else if (obj.asObjectReference()?.`$realm$Owner` == realmReference) {
             // If already valid, managed and not frozen, it must be live, and thus already
             // up to date, just return input
             obj

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
@@ -30,7 +30,7 @@ internal interface InternalMutableRealm : MutableRealm {
         return if (!obj.isValid()) {
             null
         } else {
-            obj.getObjectReference()?.run {
+            obj.runIfManaged {
                 if (owner == realmReference) {
                     // If already valid, managed and not frozen, it must be live, and thus already
                     // up to date, just return input

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
@@ -36,7 +36,7 @@ internal interface InternalMutableRealm : MutableRealm {
                     // up to date, just return input
                     obj
                 } else {
-                    return (obj as RealmObjectInternal).thaw(realmReference) as T?
+                    return obj.thaw(realmReference) as T?
                 }
             } ?: throw IllegalArgumentException(
                 "Unmanaged objects must be part of the Realm, before " +

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
@@ -30,7 +30,7 @@ internal interface InternalMutableRealm : MutableRealm {
         return if (!obj.isValid()) {
             null
         } else {
-            obj.asObjectReference()?.run {
+            obj.getObjectReference()?.run {
                 if (owner == realmReference) {
                     // If already valid, managed and not frozen, it must be live, and thus already
                     // up to date, just return input

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalMutableRealm.kt
@@ -36,7 +36,7 @@ internal interface InternalMutableRealm : MutableRealm {
                     "they can be queried this way. Use `MutableRealm.copyToRealm()` to turn it into " +
                     "a managed object."
             )
-        } else if (obj.asObjectReference()?.`$realm$Owner` == realmReference) {
+        } else if (obj.asObjectReference()?.owner == realmReference) {
             // If already valid, managed and not frozen, it must be live, and thus already
             // up to date, just return input
             obj

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
@@ -33,9 +33,13 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
-public class ObjectReference<T : RealmObject>
-// This internal constructor is for Testing purposes see io.realm.test.InstrumentedTests
-internal constructor(
+/**
+ * A ObjectReference that links a specific Kotlin RealmObjectInternal instance with an underlying C++
+ * Realm Object.
+ *
+ * It contains the reference to the object and it is the main entry point to access any Realm object feature.
+ */
+public class ObjectReference<T : RealmObject>(
     public val className: String,
     internal val type: KClass<T>,
     public val owner: RealmReference,
@@ -54,8 +58,7 @@ internal constructor(
     // the compiler plugin, see "RealmObjectInternal overrides" in RealmModelLowering.lower
     public fun propertyInfoOrThrow(
         propertyName: String
-    ): PropertyInfo =
-        this.metadata.getOrThrow(propertyName)
+    ): PropertyInfo = this.metadata.getOrThrow(propertyName)
 
     override fun realmState(): RealmState {
         return owner

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
@@ -7,6 +7,7 @@ import io.realm.internal.interop.PropertyInfo
 import io.realm.internal.interop.PropertyKey
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.schema.ClassMetadata
+import io.realm.isValid
 import io.realm.notifications.ObjectChange
 import io.realm.notifications.internal.DeletedObjectImpl
 import io.realm.notifications.internal.InitialObjectImpl
@@ -145,6 +146,12 @@ public class ObjectReference<T : RealmObject>(internal val type: KClass<T>) :
             RealmInterop.realm_object_is_valid(ptr)
         } else {
             false
+        }
+    }
+
+    internal fun checkValid() {
+        if (!this.isValid()) {
+            throw IllegalStateException("Cannot perform this operation on an invalid/deleted object")
         }
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
@@ -1,0 +1,156 @@
+package io.realm.internal
+
+import io.realm.RealmObject
+import io.realm.internal.schema.ClassMetadata
+import io.realm.internal.util.Validation
+import io.realm.notifications.ObjectChange
+import io.realm.internal.interop.Callback
+import io.realm.internal.interop.NativePointer
+import io.realm.internal.interop.PropertyInfo
+import io.realm.internal.interop.PropertyKey
+import io.realm.internal.interop.RealmInterop
+import io.realm.notifications.internal.DeletedObjectImpl
+import io.realm.notifications.internal.InitialObjectImpl
+import io.realm.notifications.internal.UpdatedObjectImpl
+import kotlinx.coroutines.channels.ChannelResult
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.Flow
+import kotlin.reflect.KClass
+
+public class ObjectReference<T : RealmObject>(private val type: KClass<T>) :
+    RealmStateHolder,
+    io.realm.internal.interop.RealmObjectInterop,
+    InternalDeleteable,
+    Observable<ObjectReference<T>, ObjectChange<T>>,
+    Flowable<ObjectChange<T>> {
+
+    public lateinit var `$realm$Owner`: RealmReference
+    public lateinit var `$realm$ClassName`: String
+    public lateinit var `$realm$Mediator`: Mediator
+
+    // Could be subclassed for DynamicClassMetadata that would query the realm on each lookup
+    public lateinit var `$realm$metadata`: ClassMetadata
+    public override var `$realm$ObjectPointer`: NativePointer? = null
+
+    // Any methods added to this interface, needs to be fake overridden on the user classes by
+    // the compiler plugin, see "RealmObjectInternal overrides" in RealmModelLowering.lower
+    public fun propertyInfoOrThrow(
+        propertyName: String
+    ): PropertyInfo =
+        this.`$realm$metadata`?.getOrThrow(propertyName)
+        // TODO Error could be eliminated if we only reached here on a ManagedRealmObject (or something like that)
+            ?: Validation.sdkError("Class meta data should never be null for managed objects")
+
+    override fun realmState(): RealmState {
+        return `$realm$Owner` ?: UnmanagedState
+    }
+
+    private fun clone(pointer: NativePointer) = ObjectReference(type).apply {
+        `$realm$Owner` = this@ObjectReference.`$realm$Owner`
+        `$realm$ClassName` = this@ObjectReference.`$realm$ClassName`
+        `$realm$Mediator` = this@ObjectReference.`$realm$Mediator`
+        `$realm$metadata` = this@ObjectReference.`$realm$metadata`
+        `$realm$ObjectPointer` = pointer
+    }
+
+    override fun freeze(
+        frozenRealm: RealmReference
+    ): ObjectReference<T>? {
+        return RealmInterop.realm_object_resolve_in(
+            `$realm$ObjectPointer`!!,
+            frozenRealm.dbPointer
+        )?.let { it: NativePointer ->
+            clone(it)
+        }
+    }
+
+    override fun thaw(liveRealm: RealmReference): ObjectReference<T>? {
+        val dbPointer = liveRealm.dbPointer
+        return RealmInterop.realm_object_resolve_in(`$realm$ObjectPointer`!!, dbPointer)
+            ?.let { it: NativePointer ->
+                clone(it)
+            }
+    }
+
+    override fun registerForNotification(callback: Callback): NativePointer {
+        // We should never get here unless it is a managed object as unmanaged doesn't support observing
+        return RealmInterop.realm_object_add_notification_callback(
+            this.`$realm$ObjectPointer`!!,
+            callback
+        )
+    }
+
+    override fun emitFrozenUpdate(
+        frozenRealm: RealmReference,
+        change: NativePointer,
+        channel: SendChannel<ObjectChange<T>>
+    ): ChannelResult<Unit>? {
+        val frozenObject: ObjectReference<T>? = this.freeze(frozenRealm)
+
+        return if (frozenObject == null) {
+            channel
+                .trySend(DeletedObjectImpl())
+                .also {
+                    channel.close()
+                }
+        } else {
+            val obj: T = frozenObject.asRealmObject()
+            val changedFieldNames = getChangedFieldNames(frozenRealm, change)
+
+            // We can identify the initial ObjectChange event emitted by core because it has no changed fields.
+            if (changedFieldNames.isEmpty()) {
+                channel.trySend(InitialObjectImpl(obj))
+            } else {
+                channel.trySend(UpdatedObjectImpl(obj, changedFieldNames))
+            }
+        }
+    }
+
+    internal fun <T: RealmObject> asRealmObject(): T {
+        val mediator = `$realm$Mediator`
+        val managedModel: RealmObjectInternal = mediator.createInstanceOf(type)
+        managedModel.manage(
+            type,
+            this
+        )
+        @Suppress("UNCHECKED_CAST")
+        return managedModel as T
+    }
+
+    private fun getChangedFieldNames(
+        frozenRealm: RealmReference,
+        change: NativePointer
+    ): Array<String> {
+        return RealmInterop.realm_object_changes_get_modified_properties(
+            change
+        ).map { propertyKey: PropertyKey ->
+            `$realm$metadata`?.get(propertyKey)?.name ?: ""
+        }.toTypedArray()
+    }
+
+    override fun asFlow(): Flow<ObjectChange<T>> {
+        return this.`$realm$Owner`.owner.registerObserver(this)
+    }
+
+    override fun delete() {
+        if (isFrozen()) {
+            throw IllegalArgumentException(
+                "Frozen objects cannot be deleted. They must be converted to live objects first " +
+                    "by using `MutableRealm/DynamicMutableRealm.findLatest(frozenObject)`."
+            )
+        }
+        if (!isValid()) {
+            throw IllegalArgumentException("Cannot perform this operation on an invalid/deleted object")
+        }
+        `$realm$ObjectPointer`?.let { RealmInterop.realm_object_delete(it) }
+    }
+
+    private fun isValid(): Boolean {
+        val ptr = `$realm$ObjectPointer`
+        return if (ptr != null) {
+            RealmInterop.realm_object_is_valid(ptr)
+        } else {
+            false
+        }
+    }
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
@@ -37,7 +37,7 @@ import kotlin.reflect.KClass
  * A ObjectReference that links a specific Kotlin RealmObjectInternal instance with an underlying C++
  * Realm Object.
  *
- * It contains the reference to the object and it is the main entry point to access any Realm object feature.
+ * It contains a pointer to the object and it is the main entry point to the Realm object features.
  */
 public class ObjectReference<T : RealmObject>(
     public val className: String,
@@ -142,7 +142,7 @@ public class ObjectReference<T : RealmObject>(
         return RealmInterop.realm_object_changes_get_modified_properties(
             change
         ).map { propertyKey: PropertyKey ->
-            metadata.get(propertyKey)?.name ?: ""
+            metadata[propertyKey]?.name ?: ""
         }.toTypedArray()
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/ObjectReference.kt
@@ -42,7 +42,7 @@ public class ObjectReference<T : RealmObject>(private val type: KClass<T>) :
         return owner
     }
 
-    private fun clone(
+    private fun newObjectReference(
         owner: RealmReference,
         pointer: NativePointer,
         clazz: KClass<out RealmObject> = type
@@ -59,7 +59,7 @@ public class ObjectReference<T : RealmObject>(private val type: KClass<T>) :
             objectPointer,
             frozenRealm.dbPointer
         )?.let { pointer: NativePointer ->
-            clone(frozenRealm, pointer)
+            newObjectReference(frozenRealm, pointer)
         }
     }
 
@@ -74,7 +74,7 @@ public class ObjectReference<T : RealmObject>(private val type: KClass<T>) :
         val dbPointer = liveRealm.dbPointer
         return RealmInterop.realm_object_resolve_in(objectPointer, dbPointer)
             ?.let { pointer: NativePointer ->
-                clone(liveRealm, pointer, clazz)
+                newObjectReference(liveRealm, pointer, clazz)
             }
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
@@ -80,6 +80,7 @@ internal class ManagedRealmList<E>(
             RealmInterop.realm_list_add(
                 nativePointer,
                 index.toLong(),
+                // FIXME: https://github.com/realm/realm-kotlin/issues/728
                 copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
                     when (value) {
                         is RealmObjectInternal -> value.getObjectReference()
@@ -126,6 +127,7 @@ internal class ManagedRealmList<E>(
                 RealmInterop.realm_list_set(
                     nativePointer,
                     index.toLong(),
+                    // FIXME: https://github.com/realm/realm-kotlin/issues/728
                     copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
                         when (value) {
                             is RealmObjectInternal -> value.getObjectReference()

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
@@ -80,7 +80,12 @@ internal class ManagedRealmList<E>(
             RealmInterop.realm_list_add(
                 nativePointer,
                 index.toLong(),
-                copyToRealm(metadata.mediator, metadata.realm, element)
+                copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
+                    when (value) {
+                        is RealmObjectInternal -> value.asObjectReference()
+                        else -> value
+                    }
+                }
             )
         } catch (exception: RealmCoreException) {
             throw genericRealmCoreExceptionHandler(
@@ -121,7 +126,12 @@ internal class ManagedRealmList<E>(
                 RealmInterop.realm_list_set(
                     nativePointer,
                     index.toLong(),
-                    copyToRealm(metadata.mediator, metadata.realm, element)
+                    copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
+                        when (value) {
+                            is RealmObjectInternal -> value.asObjectReference()
+                            else -> value
+                        }
+                    }
                 )
             )
         } catch (exception: RealmCoreException) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
@@ -80,7 +80,7 @@ internal class ManagedRealmList<E>(
             RealmInterop.realm_list_add(
                 nativePointer,
                 index.toLong(),
-                // FIXME: https://github.com/realm/realm-kotlin/issues/728
+                // FIXME https://github.com/realm/realm-kotlin/issues/728
                 copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
                     when (value) {
                         is RealmObjectInternal -> value.getObjectReference()
@@ -127,7 +127,7 @@ internal class ManagedRealmList<E>(
                 RealmInterop.realm_list_set(
                     nativePointer,
                     index.toLong(),
-                    // FIXME: https://github.com/realm/realm-kotlin/issues/728
+                    // FIXME https://github.com/realm/realm-kotlin/issues/728
                     copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
                         when (value) {
                             is RealmObjectInternal -> value.getObjectReference()

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
@@ -80,10 +80,12 @@ internal class ManagedRealmList<E>(
             RealmInterop.realm_list_add(
                 nativePointer,
                 index.toLong(),
-                // FIXME https://github.com/realm/realm-kotlin/issues/728
                 copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
+                    // TODO Not ideal. We should make inbound value conversion part of
+                    //  ElementConverter or another pattern as part of
+                    //  https://github.com/realm/realm-kotlin/issues/728
                     when (value) {
-                        is RealmObjectInternal -> value.getObjectReference()
+                        is RealmObjectInternal -> value.realmObjectReference!! // Just copied object should never be null
                         else -> value
                     }
                 }
@@ -127,10 +129,12 @@ internal class ManagedRealmList<E>(
                 RealmInterop.realm_list_set(
                     nativePointer,
                     index.toLong(),
-                    // FIXME https://github.com/realm/realm-kotlin/issues/728
+                    // TODO Not ideal. We should make inbound value conversion part of
+                    //  ElementConverter or another pattern as part of
+                    //  https://github.com/realm/realm-kotlin/issues/728
                     copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
                         when (value) {
-                            is RealmObjectInternal -> value.getObjectReference()
+                            is RealmObjectInternal -> value.realmObjectReference!! // Just copied object should never be null
                             else -> value
                         }
                     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmListInternal.kt
@@ -82,7 +82,7 @@ internal class ManagedRealmList<E>(
                 index.toLong(),
                 copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
                     when (value) {
-                        is RealmObjectInternal -> value.asObjectReference()
+                        is RealmObjectInternal -> value.getObjectReference()
                         else -> value
                     }
                 }
@@ -128,7 +128,7 @@ internal class ManagedRealmList<E>(
                     index.toLong(),
                     copyToRealm(metadata.mediator, metadata.realm, element).let { value ->
                         when (value) {
-                            is RealmObjectInternal -> value.asObjectReference()
+                            is RealmObjectInternal -> value.getObjectReference()
                             else -> value
                         }
                     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -230,7 +230,7 @@ internal object RealmObjectHelper {
         value: R?
     ) {
         obj.checkValid()
-        val newValue = value?.getObjectReference()?.run {
+        val newValue = value?.runIfManaged {
             if (obj.owner != owner) {
                 copyToRealm(obj.mediator, obj.owner, value)
             } else {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -87,17 +87,11 @@ internal object RealmObjectHelper {
         key: io.realm.internal.interop.PropertyKey,
     ): Any? {
         val o = obj.getObjectPointer()
-        val link = RealmInterop.realm_get_value<Link?>(o, key)
-        if (link != null) {
-            val value = obj.getMediator().createInstanceOf(R::class)
-            return value.link(
-                obj.getOwner(),
-                obj.getMediator(),
-                R::class,
-                link
-            )
-        }
-        return null
+        return RealmInterop.realm_get_value<Link?>(o, key)?.toRealmObject(
+            clazz = R::class,
+            mediator = obj.getMediator(),
+            realm = obj.getOwner()
+        )
     }
 
     // Return type should be RealmList<R?> but causes compilation errors for native

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -222,7 +222,7 @@ internal object RealmObjectHelper {
             if (obj.owner == owner) value else null
         } ?: copyToRealm(obj.mediator, obj.owner, value)
 
-        setValueByKey(obj, obj.propertyInfoOrThrow(propertyName).key, newValue?.getObjectReference())
+        setValueByKey(obj, obj.propertyInfoOrThrow(propertyName).key, newValue?.realmObjectReference)
     }
 
     /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -224,7 +224,7 @@ internal object RealmObjectHelper {
     }
 
     @Suppress("unused") // Called from generated code
-    internal inline fun <reified R : RealmObjectInternal> setObject(
+    internal inline fun <reified R : RealmObject> setObject(
         obj: RealmObjectReference<out RealmObject>,
         propertyName: String,
         value: R?

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -230,14 +230,14 @@ internal object RealmObjectHelper {
         value: R?
     ) {
         obj.checkValid()
-        val newValue = if (
-            value != null &&
-            (!value.isManaged() || obj.owner != (value as RealmObjectInternal).asObjectReference()!!.owner)
-        ) {
-            copyToRealm(obj.mediator, obj.owner, value)
-        } else {
-            value
-        }
+        val newValue = value?.asObjectReference()?.run {
+            if (obj.owner != owner) {
+                copyToRealm(obj.mediator, obj.owner, value)
+            } else {
+                value
+            }
+        } ?: copyToRealm(obj.mediator, obj.owner, value)
+
         setValueByKey(obj, obj.propertyInfoOrThrow(propertyName).key, newValue?.asObjectReference())
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -51,13 +51,13 @@ internal object RealmObjectHelper {
 
     // Consider inlining
     @Suppress("unused") // Called from generated code
-    internal fun <R> getValue(obj: ObjectReference<out RealmObject>, propertyName: String): Any? {
+    internal fun <R> getValue(obj: RealmObjectReference<out RealmObject>, propertyName: String): Any? {
         obj.checkValid()
         return getValueByKey<R>(obj, obj.propertyInfoOrThrow(propertyName).key)
     }
 
     internal fun <R> getValueByKey(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         key: io.realm.internal.interop.PropertyKey
     ): Any? {
         val o = obj.objectPointer
@@ -65,7 +65,7 @@ internal object RealmObjectHelper {
     }
 
     @Suppress("unused") // Called from generated code
-    internal fun <R> getTimestamp(obj: ObjectReference<out RealmObject>, propertyName: String): RealmInstant? {
+    internal fun <R> getTimestamp(obj: RealmObjectReference<out RealmObject>, propertyName: String): RealmInstant? {
         obj.checkValid()
         val o = obj.objectPointer
         val res = RealmInterop.realm_get_value<Timestamp?>(o, obj.propertyInfoOrThrow(propertyName).key)
@@ -75,7 +75,7 @@ internal object RealmObjectHelper {
     // Return type should be R? but causes compilation errors for native
     @Suppress("unused") // Called from generated code
     internal inline fun <reified R : RealmObject> getObject(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         propertyName: String,
     ): Any? {
         obj.checkValid()
@@ -83,7 +83,7 @@ internal object RealmObjectHelper {
     }
 
     internal inline fun <reified R : RealmObject> getObjectByKey(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         key: io.realm.internal.interop.PropertyKey,
     ): Any? {
         val o = obj.objectPointer
@@ -96,14 +96,14 @@ internal object RealmObjectHelper {
 
     // Return type should be RealmList<R?> but causes compilation errors for native
     internal inline fun <reified R : Any> getList(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         propertyName: String
     ): ManagedRealmList<Any?> {
         return getList(obj, propertyName, R::class)
     }
 
     internal fun <R : Any> getList(
-        obj: ObjectReference<out io.realm.RealmObject>,
+        obj: RealmObjectReference<out io.realm.RealmObject>,
         propertyName: String,
         elementType: KClass<R>,
     ): ManagedRealmList<Any?> {
@@ -111,7 +111,7 @@ internal object RealmObjectHelper {
     }
 
     internal fun <R : Any> getListByKey(
-        obj: ObjectReference<out io.realm.RealmObject>,
+        obj: RealmObjectReference<out io.realm.RealmObject>,
         key: io.realm.internal.interop.PropertyKey,
         elementType: KClass<R>,
     ): ManagedRealmList<Any?> {
@@ -147,7 +147,7 @@ internal object RealmObjectHelper {
 
     // Consider inlining
     @Suppress("unused") // Called from generated code
-    internal fun <R> setValue(obj: ObjectReference<out RealmObject>, propertyName: String, value: R) {
+    internal fun <R> setValue(obj: RealmObjectReference<out RealmObject>, propertyName: String, value: R) {
         obj.checkValid()
         val key = obj.propertyInfoOrThrow(propertyName).key
         // TODO OPTIMIZE We are currently only doing this check for typed access so could consider
@@ -168,7 +168,7 @@ internal object RealmObjectHelper {
     // Consider inlining
     @Suppress("unused") // Called from generated code
     internal fun <R> setTimestamp(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         propertyName: String,
         value: RealmInstant?
     ) {
@@ -196,7 +196,7 @@ internal object RealmObjectHelper {
 
     @Suppress("unused") // Called from generated code
     internal fun <R> setValueByKey(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         key: io.realm.internal.interop.PropertyKey,
         value: R
     ) {
@@ -225,7 +225,7 @@ internal object RealmObjectHelper {
 
     @Suppress("unused") // Called from generated code
     internal inline fun <reified R : RealmObjectInternal> setObject(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         propertyName: String,
         value: R?
     ) {
@@ -248,7 +248,7 @@ internal object RealmObjectHelper {
      * properties in the schema.
      */
     internal fun <R : Any> dynamicGet(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         propertyName: String,
         clazz: KClass<R>,
         nullable: Boolean
@@ -275,7 +275,7 @@ internal object RealmObjectHelper {
     }
 
     internal fun <R : Any> dynamicGetList(
-        obj: ObjectReference<out RealmObject>,
+        obj: RealmObjectReference<out RealmObject>,
         propertyName: String,
         clazz: KClass<R>,
         nullable: Boolean
@@ -286,7 +286,7 @@ internal object RealmObjectHelper {
         return getListByKey(obj, propertyInfo.key, clazz) as RealmList<R?>
     }
 
-    private fun checkPropertyType(obj: ObjectReference<out RealmObject>, propertyName: String, collectionType: CollectionType, elementType: KClass<*>, nullable: Boolean): PropertyInfo {
+    private fun checkPropertyType(obj: RealmObjectReference<out RealmObject>, propertyName: String, collectionType: CollectionType, elementType: KClass<*>, nullable: Boolean): PropertyInfo {
         val realElementType = when (elementType) {
             DynamicRealmObject::class,
             DynamicMutableRealmObject::class ->
@@ -305,7 +305,7 @@ internal object RealmObjectHelper {
         }
     }
 
-    internal fun <R> dynamicSetValue(obj: ObjectReference<out RealmObject>, propertyName: String, value: R) {
+    internal fun <R> dynamicSetValue(obj: RealmObjectReference<out RealmObject>, propertyName: String, value: R) {
         obj.checkValid()
         setValueByKey<R>(obj, obj.propertyInfoOrThrow(propertyName).key, value)
     }
@@ -320,7 +320,7 @@ internal object RealmObjectHelper {
     }
 
     @Suppress("unused") // Called from generated code
-    inline fun <reified T : Any> setList(obj: ObjectReference<out RealmObject>, col: String, list: RealmList<Any?>) {
+    inline fun <reified T : Any> setList(obj: RealmObjectReference<out RealmObject>, col: String, list: RealmList<Any?>) {
         val existingList = getList<T>(obj, col)
         if (list !is ManagedRealmList || !RealmInterop.realm_equals(existingList.nativePointer, list.nativePointer)) {
             existingList.also {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -230,7 +230,7 @@ internal object RealmObjectHelper {
         value: R?
     ) {
         obj.checkValid()
-        val newValue = value?.asObjectReference()?.run {
+        val newValue = value?.getObjectReference()?.run {
             if (obj.owner != owner) {
                 copyToRealm(obj.mediator, obj.owner, value)
             } else {
@@ -238,7 +238,7 @@ internal object RealmObjectHelper {
             }
         } ?: copyToRealm(obj.mediator, obj.owner, value)
 
-        setValueByKey(obj, obj.propertyInfoOrThrow(propertyName).key, newValue?.asObjectReference())
+        setValueByKey(obj, obj.propertyInfoOrThrow(propertyName).key, newValue?.getObjectReference())
     }
 
     /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -86,10 +86,10 @@ internal object RealmObjectHelper {
         obj: RealmObjectReference<out RealmObject>,
         key: io.realm.internal.interop.PropertyKey,
     ): Any? = RealmInterop.realm_get_value<Link?>(obj.objectPointer, key)?.toRealmObject(
-            clazz = R::class,
-            mediator = obj.mediator,
-            realm = obj.owner
-        )
+        clazz = R::class,
+        mediator = obj.mediator,
+        realm = obj.owner
+    )
 
     // Return type should be RealmList<R?> but causes compilation errors for native
     internal inline fun <reified R : Any> getList(
@@ -101,7 +101,8 @@ internal object RealmObjectHelper {
         obj: RealmObjectReference<out io.realm.RealmObject>,
         propertyName: String,
         elementType: KClass<R>,
-    ): ManagedRealmList<Any?> =  getListByKey(obj, obj.propertyInfoOrThrow(propertyName).key, elementType)
+    ): ManagedRealmList<Any?> =
+        getListByKey(obj, obj.propertyInfoOrThrow(propertyName).key, elementType)
 
     // Cannot call managedRealmList directly from an inline function
     internal fun <R : Any> getListByKey(
@@ -126,13 +127,13 @@ internal object RealmObjectHelper {
         mediator: Mediator,
         realm: RealmReference
     ): ManagedRealmList<R> = managedRealmList(
-            listPtr,
-            ListOperatorMetadata(
-                mediator = mediator,
-                realm = realm,
-                converter(mediator, realm, clazz),
-            )
+        listPtr,
+        ListOperatorMetadata(
+            mediator = mediator,
+            realm = realm,
+            converter(mediator, realm, clazz),
         )
+    )
 
     // Consider inlining
     @Suppress("unused") // Called from generated code
@@ -216,12 +217,9 @@ internal object RealmObjectHelper {
         value: R?
     ) {
         obj.checkValid()
+
         val newValue = value?.runIfManaged {
-            if (obj.owner != owner) {
-                copyToRealm(obj.mediator, obj.owner, value)
-            } else {
-                value
-            }
+            if (obj.owner == owner) value else null
         } ?: copyToRealm(obj.mediator, obj.owner, value)
 
         setValueByKey(obj, obj.propertyInfoOrThrow(propertyName).key, newValue?.getObjectReference())

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectHelper.kt
@@ -158,7 +158,7 @@ internal object RealmObjectHelper {
         obj.metadata.let { classMetaData ->
             val primaryKeyPropertyKey: PropertyKey? = classMetaData.primaryKeyPropertyKey
             if (primaryKeyPropertyKey != null && key == primaryKeyPropertyKey) {
-                val name = classMetaData.get(primaryKeyPropertyKey)!!.name
+                val name = classMetaData[primaryKeyPropertyKey]!!.name
                 throw IllegalArgumentException("Cannot update primary key property '${obj.className}.$name'")
             }
         }
@@ -212,12 +212,12 @@ internal object RealmObjectHelper {
             // Core exceptions meaning might differ depending on the context, by rethrowing we can add some context related
             // info that might help users to understand the exception.
         } catch (exception: RealmCorePropertyNotNullableException) {
-            throw IllegalArgumentException("Required property `${obj.className}.${obj.metadata.get(key)!!.name}` cannot be null")
+            throw IllegalArgumentException("Required property `${obj.className}.${obj.metadata[key]!!.name}` cannot be null")
         } catch (exception: RealmCorePropertyTypeMismatchException) {
-            throw IllegalArgumentException("Property `${obj.className}.${obj.metadata.get(key)!!.name}` cannot be assigned with value '$value' of wrong type")
+            throw IllegalArgumentException("Property `${obj.className}.${obj.metadata[key]!!.name}` cannot be assigned with value '$value' of wrong type")
         } catch (exception: RealmCoreException) {
             throw IllegalStateException(
-                "Cannot set `${obj.className}.$${obj.metadata.get(key)!!.name}` to `$value`: changing Realm data can only be done on a live object from inside a write transaction. Frozen objects can be turned into live using the 'MutableRealm.findLatest(obj)' API.",
+                "Cannot set `${obj.className}.$${obj.metadata[key]!!.name}` to `$value`: changing Realm data can only be done on a live object from inside a write transaction. Frozen objects can be turned into live using the 'MutableRealm.findLatest(obj)' API.",
                 exception
             )
         }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -17,12 +17,10 @@
 package io.realm.internal
 
 import io.realm.RealmObject
-import io.realm.internal.interop.PropertyInfo
 import io.realm.internal.interop.NativePointer
+import io.realm.internal.interop.PropertyInfo
 import io.realm.internal.schema.ClassMetadata
-import io.realm.internal.util.Validation
 import io.realm.isValid
-import kotlin.reflect.KClass
 
 /**
  * Internal interface for Realm objects.
@@ -55,12 +53,14 @@ internal fun RealmObjectInternal.propertyInfoOrThrow(
     propertyName: String
 ): PropertyInfo = asObjectReference()!!.propertyInfoOrThrow(propertyName)
 
-internal fun RealmObjectInternal.getObjectPointer(): NativePointer? = asObjectReference()!!.`$realm$ObjectPointer`
+internal fun RealmObjectInternal.getObjectPointer(): NativePointer =
+    asObjectReference()!!.objectPointer
 
-internal fun RealmObjectInternal.getOwner(): RealmReference = asObjectReference()!!.`$realm$Owner`
+internal fun RealmObjectInternal.getOwner(): RealmReference = asObjectReference()!!.owner
 
-internal fun RealmObjectInternal.getMediator(): Mediator = asObjectReference()!!.`$realm$Mediator`
+internal fun RealmObjectInternal.getMediator(): Mediator = asObjectReference()!!.mediator
 
-internal fun RealmObjectInternal.getMetadata(): ClassMetadata = asObjectReference()!!.`$realm$metadata`
+internal fun RealmObjectInternal.getMetadata(): ClassMetadata =
+    asObjectReference()!!.metadata
 
-internal fun RealmObjectInternal.getClassName(): String = asObjectReference()!!.`$realm$ClassName`
+internal fun RealmObjectInternal.getClassName(): String = asObjectReference()!!.className

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -34,11 +34,3 @@ public interface RealmObjectInternal : RealmObject {
 internal fun RealmObject.asObjectReference(): ObjectReference<out RealmObject>? {
     return (this as RealmObjectInternal).`$realm$objectReference`
 }
-
-internal fun RealmObject.isManaged(): Boolean {
-    return asObjectReference() != null
-}
-
-internal fun RealmObjectInternal.getOwner(): RealmReference = asObjectReference()!!.owner
-
-internal fun RealmObjectInternal.getClassName(): String = asObjectReference()!!.className

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -17,10 +17,6 @@
 package io.realm.internal
 
 import io.realm.RealmObject
-import io.realm.internal.interop.NativePointer
-import io.realm.internal.interop.PropertyInfo
-import io.realm.internal.schema.ClassMetadata
-import io.realm.isValid
 
 /**
  * Internal interface for Realm objects.
@@ -43,24 +39,6 @@ internal fun RealmObject.isManaged(): Boolean {
     return asObjectReference() != null
 }
 
-internal fun RealmObjectInternal.checkValid() {
-    if (!this.isValid()) {
-        throw IllegalStateException("Cannot perform this operation on an invalid/deleted object")
-    }
-}
-
-internal fun RealmObjectInternal.propertyInfoOrThrow(
-    propertyName: String
-): PropertyInfo = asObjectReference()!!.propertyInfoOrThrow(propertyName)
-
-internal fun RealmObjectInternal.getObjectPointer(): NativePointer =
-    asObjectReference()!!.objectPointer
-
 internal fun RealmObjectInternal.getOwner(): RealmReference = asObjectReference()!!.owner
-
-internal fun RealmObjectInternal.getMediator(): Mediator = asObjectReference()!!.mediator
-
-internal fun RealmObjectInternal.getMetadata(): ClassMetadata =
-    asObjectReference()!!.metadata
 
 internal fun RealmObjectInternal.getClassName(): String = asObjectReference()!!.className

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -31,9 +31,16 @@ public interface RealmObjectInternal : RealmObject {
     public var `$realm$objectReference`: RealmObjectReference<out RealmObject>? // RealmObjectReference ?
 }
 
+/**
+ * If the Realm object is managed returns its Realm Object reference, otherwise returns null.
+ */
 internal fun RealmObject.getObjectReference(): RealmObjectReference<out RealmObject>? {
     return (this as RealmObjectInternal).`$realm$objectReference`
 }
 
+/**
+ * If the Realm Object is managed it calls the specified function block and returns its result,
+ * otherwise returns null.
+ */
 internal inline fun <R> RealmObject.runIfManaged(block: RealmObjectReference<out RealmObject>.() -> R?): R? =
     getObjectReference()?.run(block)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -25,7 +25,7 @@ import io.realm.RealmObject
  * exposing our internal API and compiler plugin additions without leaking it to the public
  * [RealmObject].
  */
-// TODO Public due to being a transative dependency of Mediator
+// TODO Public due to being a transitive dependency of Mediator
 @Suppress("VariableNaming")
 public interface RealmObjectInternal : RealmObject {
     public var `$realm$objectReference`: RealmObjectReference<out RealmObject>?

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -28,9 +28,9 @@ import io.realm.RealmObject
 // TODO Public due to being a transative dependency of Mediator
 @Suppress("VariableNaming")
 public interface RealmObjectInternal : RealmObject {
-    public var `$realm$objectReference`: ObjectReference<out RealmObject>? // RealmObjectReference ?
+    public var `$realm$objectReference`: RealmObjectReference<out RealmObject>? // RealmObjectReference ?
 }
 
-internal fun RealmObject.asObjectReference(): ObjectReference<out RealmObject>? {
+internal fun RealmObject.asObjectReference(): RealmObjectReference<out RealmObject>? {
     return (this as RealmObjectInternal).`$realm$objectReference`
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -30,17 +30,3 @@ import io.realm.RealmObject
 public interface RealmObjectInternal : RealmObject {
     public var `$realm$objectReference`: RealmObjectReference<out RealmObject>? // RealmObjectReference ?
 }
-
-/**
- * If the Realm object is managed returns its Realm Object reference, otherwise returns null.
- */
-internal fun RealmObject.getObjectReference(): RealmObjectReference<out RealmObject>? {
-    return (this as RealmObjectInternal).`$realm$objectReference`
-}
-
-/**
- * If the Realm Object is managed it calls the specified function block and returns its result,
- * otherwise returns null.
- */
-internal inline fun <R> RealmObject.runIfManaged(block: RealmObjectReference<out RealmObject>.() -> R?): R? =
-    getObjectReference()?.run(block)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -17,21 +17,11 @@
 package io.realm.internal
 
 import io.realm.RealmObject
-import io.realm.internal.interop.Callback
-import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.PropertyInfo
-import io.realm.internal.interop.PropertyKey
-import io.realm.internal.interop.RealmInterop
+import io.realm.internal.interop.NativePointer
 import io.realm.internal.schema.ClassMetadata
-import io.realm.internal.util.Validation.sdkError
+import io.realm.internal.util.Validation
 import io.realm.isValid
-import io.realm.notifications.ObjectChange
-import io.realm.notifications.internal.DeletedObjectImpl
-import io.realm.notifications.internal.InitialObjectImpl
-import io.realm.notifications.internal.UpdatedObjectImpl
-import kotlinx.coroutines.channels.ChannelResult
-import kotlinx.coroutines.channels.SendChannel
-import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
 /**
@@ -43,126 +33,16 @@ import kotlin.reflect.KClass
  */
 // TODO Public due to being a transative dependency of Mediator
 @Suppress("VariableNaming")
-public interface RealmObjectInternal : RealmObject, RealmStateHolder, io.realm.internal.interop.RealmObjectInterop, InternalDeleteable, Observable<RealmObjectInternal, ObjectChange<RealmObjectInternal>>, Flowable<ObjectChange<RealmObjectInternal>> {
-    // Names must match identifiers in compiler plugin (plugin-compiler/io.realm.compiler.Identifiers.kt)
-
-    // Reference to the public Realm instance and internal transaction to which the object belongs.
-    public var `$realm$IsManaged`: Boolean
-    // Invariant: None of the below will be null for managed objects!
-    public var `$realm$Owner`: RealmReference?
-    public var `$realm$ClassName`: String?
-    public var `$realm$Mediator`: Mediator?
-    // Could be subclassed for DynamicClassMetadata that would query the realm on each lookup
-    public var `$realm$metadata`: ClassMetadata?
-
-    // Any methods added to this interface, needs to be fake overridden on the user classes by
-    // the compiler plugin, see "RealmObjectInternal overrides" in RealmModelLowering.lower
-    public fun propertyInfoOrThrow(propertyName: String): PropertyInfo = this.`$realm$metadata`?.getOrThrow(propertyName)
-        // TODO Error could be eliminated if we only reached here on a ManagedRealmObject (or something like that)
-        ?: sdkError("Class meta data should never be null for managed objects")
-
-    override fun realmState(): RealmState {
-        return `$realm$Owner` ?: UnmanagedState
-    }
-
-    override fun freeze(frozenRealm: RealmReference): RealmObjectInternal? {
-        @Suppress("UNCHECKED_CAST")
-        val type: KClass<RealmObjectInternal> = this::class as KClass<RealmObjectInternal>
-        val mediator = `$realm$Mediator`!!
-        val managedModel = mediator.createInstanceOf(type)
-        return RealmInterop.realm_object_resolve_in(
-            `$realm$ObjectPointer`!!,
-            frozenRealm.dbPointer
-        )?.let {
-            managedModel.manage(
-                frozenRealm,
-                mediator,
-                type,
-                it
-            )
-        }
-    }
-
-    override fun thaw(liveRealm: RealmReference): RealmObjectInternal? {
-        return thaw(liveRealm, this::class)
-    }
-
-    public fun thaw(liveRealm: RealmReference, clazz: KClass<out RealmObject>): RealmObjectInternal? {
-        val mediator = `$realm$Mediator`!!
-        val managedModel = mediator.createInstanceOf(clazz)
-        val dbPointer = liveRealm.dbPointer
-        return RealmInterop.realm_object_resolve_in(`$realm$ObjectPointer`!!, dbPointer)?.let {
-            @Suppress("UNCHECKED_CAST")
-            managedModel.manage(
-                liveRealm,
-                mediator,
-                clazz as KClass<RealmObjectInternal>,
-                it
-            )
-        }
-    }
-
-    override fun registerForNotification(callback: Callback): NativePointer {
-        // We should never get here unless it is a managed object as unmanaged doesn't support observing
-        return RealmInterop.realm_object_add_notification_callback(this.`$realm$ObjectPointer`!!, callback)
-    }
-
-    override fun emitFrozenUpdate(
-        frozenRealm: RealmReference,
-        change: NativePointer,
-        channel: SendChannel<ObjectChange<RealmObjectInternal>>
-    ): ChannelResult<Unit>? {
-        val frozenObject: RealmObjectInternal? = this.freeze(frozenRealm)
-
-        return if (frozenObject == null) {
-            channel
-                .trySend(DeletedObjectImpl())
-                .also {
-                    channel.close()
-                }
-        } else {
-            val changedFieldNames = getChangedFieldNames(frozenRealm, change)
-
-            // We can identify the initial ObjectChange event emitted by core because it has no changed fields.
-            if (changedFieldNames.isEmpty()) {
-                channel.trySend(InitialObjectImpl(frozenObject))
-            } else {
-                channel.trySend(UpdatedObjectImpl(frozenObject, changedFieldNames))
-            }
-        }
-    }
-
-    private fun getChangedFieldNames(
-        frozenRealm: RealmReference,
-        change: NativePointer
-    ): Array<String> {
-        return RealmInterop.realm_object_changes_get_modified_properties(
-            change
-        ).map { propertyKey: PropertyKey ->
-            `$realm$metadata`?.get(propertyKey)?.name ?: ""
-        }.toTypedArray()
-    }
-
-    override fun asFlow(): Flow<ObjectChange<RealmObjectInternal>> {
-        return this.`$realm$Owner`!!.owner.registerObserver(this)
-    }
-
-    override fun delete() {
-        if (isFrozen()) {
-            throw IllegalArgumentException(
-                "Frozen objects cannot be deleted. They must be converted to live objects first " +
-                    "by using `MutableRealm/DynamicMutableRealm.findLatest(frozenObject)`."
-            )
-        }
-        if (!isValid()) {
-            throw IllegalArgumentException("Cannot perform this operation on an invalid/deleted object")
-        }
-        `$realm$ObjectPointer`?.let { RealmInterop.realm_object_delete(it) }
-    }
+public interface RealmObjectInternal : RealmObject {
+    public var `$realm$objectReference`: ObjectReference<out RealmObject>? // RealmObjectReference ?
 }
 
-internal fun RealmObject.realmObjectInternal(): RealmObjectInternal {
-    return this as RealmObjectInternal
+internal fun RealmObject.asObjectReference(): ObjectReference<out RealmObject>? {
+    return (this as RealmObjectInternal).`$realm$objectReference`
+}
+
+internal fun RealmObject.isManaged(): Boolean {
+    return asObjectReference() != null
 }
 
 internal fun RealmObjectInternal.checkValid() {
@@ -170,3 +50,17 @@ internal fun RealmObjectInternal.checkValid() {
         throw IllegalStateException("Cannot perform this operation on an invalid/deleted object")
     }
 }
+
+internal fun RealmObjectInternal.propertyInfoOrThrow(
+    propertyName: String
+): PropertyInfo = asObjectReference()!!.propertyInfoOrThrow(propertyName)
+
+internal fun RealmObjectInternal.getObjectPointer(): NativePointer? = asObjectReference()!!.`$realm$ObjectPointer`
+
+internal fun RealmObjectInternal.getOwner(): RealmReference = asObjectReference()!!.`$realm$Owner`
+
+internal fun RealmObjectInternal.getMediator(): Mediator = asObjectReference()!!.`$realm$Mediator`
+
+internal fun RealmObjectInternal.getMetadata(): ClassMetadata = asObjectReference()!!.`$realm$metadata`
+
+internal fun RealmObjectInternal.getClassName(): String = asObjectReference()!!.`$realm$ClassName`

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -34,3 +34,6 @@ public interface RealmObjectInternal : RealmObject {
 internal fun RealmObject.getObjectReference(): RealmObjectReference<out RealmObject>? {
     return (this as RealmObjectInternal).`$realm$objectReference`
 }
+
+internal inline fun <R> RealmObject.runIfManaged(block: RealmObjectReference<out RealmObject>.() -> R?): R? =
+    getObjectReference()?.run(block)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -31,6 +31,6 @@ public interface RealmObjectInternal : RealmObject {
     public var `$realm$objectReference`: RealmObjectReference<out RealmObject>? // RealmObjectReference ?
 }
 
-internal fun RealmObject.asObjectReference(): RealmObjectReference<out RealmObject>? {
+internal fun RealmObject.getObjectReference(): RealmObjectReference<out RealmObject>? {
     return (this as RealmObjectInternal).`$realm$objectReference`
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectInternal.kt
@@ -28,5 +28,5 @@ import io.realm.RealmObject
 // TODO Public due to being a transative dependency of Mediator
 @Suppress("VariableNaming")
 public interface RealmObjectInternal : RealmObject {
-    public var `$realm$objectReference`: RealmObjectReference<out RealmObject>? // RealmObjectReference ?
+    public var `$realm$objectReference`: RealmObjectReference<out RealmObject>?
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
@@ -23,7 +23,6 @@ import io.realm.internal.interop.PropertyInfo
 import io.realm.internal.interop.PropertyKey
 import io.realm.internal.interop.RealmInterop
 import io.realm.internal.schema.ClassMetadata
-import io.realm.isValid
 import io.realm.notifications.ObjectChange
 import io.realm.notifications.internal.DeletedObjectImpl
 import io.realm.notifications.internal.InitialObjectImpl
@@ -34,12 +33,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
 /**
- * A ObjectReference that links a specific Kotlin RealmObjectInternal instance with an underlying C++
+ * A RealmObjectReference that links a specific Kotlin RealmObjectInternal instance with an underlying C++
  * Realm Object.
  *
  * It contains a pointer to the object and it is the main entry point to the Realm object features.
  */
-public class ObjectReference<T : RealmObject>(
+public class RealmObjectReference<T : RealmObject>(
     public val className: String,
     internal val type: KClass<T>,
     public val owner: RealmReference,
@@ -49,7 +48,7 @@ public class ObjectReference<T : RealmObject>(
     RealmStateHolder,
     io.realm.internal.interop.RealmObjectInterop,
     InternalDeleteable,
-    Observable<ObjectReference<out RealmObject>, ObjectChange<out RealmObject>>,
+    Observable<RealmObjectReference<out RealmObject>, ObjectChange<out RealmObject>>,
     Flowable<ObjectChange<out RealmObject>> {
 
     public val metadata: ClassMetadata = owner.schemaMetadata[className]!!
@@ -68,7 +67,7 @@ public class ObjectReference<T : RealmObject>(
         owner: RealmReference,
         pointer: NativePointer,
         clazz: KClass<out RealmObject> = type
-    ): ObjectReference<out RealmObject> = ObjectReference(
+    ): RealmObjectReference<out RealmObject> = RealmObjectReference(
         type = clazz,
         owner = owner,
         mediator = mediator,
@@ -78,7 +77,7 @@ public class ObjectReference<T : RealmObject>(
 
     override fun freeze(
         frozenRealm: RealmReference
-    ): ObjectReference<out RealmObject>? {
+    ): RealmObjectReference<out RealmObject>? {
         return RealmInterop.realm_object_resolve_in(
             objectPointer,
             frozenRealm.dbPointer
@@ -87,14 +86,14 @@ public class ObjectReference<T : RealmObject>(
         }
     }
 
-    override fun thaw(liveRealm: RealmReference): ObjectReference<out RealmObject>? {
+    override fun thaw(liveRealm: RealmReference): RealmObjectReference<out RealmObject>? {
         return thaw(liveRealm, type)
     }
 
     public fun thaw(
         liveRealm: RealmReference,
         clazz: KClass<out RealmObject>
-    ): ObjectReference<out RealmObject>? {
+    ): RealmObjectReference<out RealmObject>? {
         val dbPointer = liveRealm.dbPointer
         return RealmInterop.realm_object_resolve_in(objectPointer, dbPointer)
             ?.let { pointer: NativePointer ->
@@ -115,7 +114,7 @@ public class ObjectReference<T : RealmObject>(
         change: NativePointer,
         channel: SendChannel<ObjectChange<out RealmObject>>
     ): ChannelResult<Unit>? {
-        val frozenObject: ObjectReference<out RealmObject>? = this.freeze(frozenRealm)
+        val frozenObject: RealmObjectReference<out RealmObject>? = this.freeze(frozenRealm)
 
         return if (frozenObject == null) {
             channel

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
@@ -124,7 +124,7 @@ public class RealmObjectReference<T : RealmObject>(
                 }
         } else {
             val obj: RealmObject = frozenObject.toRealmObject()
-            val changedFieldNames = obj.asObjectReference()!!.getChangedFieldNames(change)
+            val changedFieldNames = obj.getObjectReference()!!.getChangedFieldNames(change)
 
             // We can identify the initial ObjectChange event emitted by core because it has no changed fields.
             if (changedFieldNames.isEmpty()) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
@@ -123,8 +123,8 @@ public class RealmObjectReference<T : RealmObject>(
                     channel.close()
                 }
         } else {
+            val changedFieldNames = frozenObject.getChangedFieldNames(change)
             val obj: RealmObject = frozenObject.toRealmObject()
-            val changedFieldNames = obj.getObjectReference()!!.getChangedFieldNames(change)
 
             // We can identify the initial ObjectChange event emitted by core because it has no changed fields.
             if (changedFieldNames.isEmpty()) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
@@ -177,3 +177,12 @@ public class RealmObjectReference<T : RealmObject>(
         }
     }
 }
+
+internal fun <T : RealmObject> RealmObjectReference<T>.checkNotificationsAvailable() {
+    if (RealmInterop.realm_is_closed(owner.dbPointer)) {
+        throw IllegalStateException("Changes cannot be observed when the Realm has been closed.")
+    }
+    if (!isValid()) {
+        throw IllegalStateException("Changes cannot be observed on objects that have been deleted from the Realm.")
+    }
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectReference.kt
@@ -162,7 +162,7 @@ public class RealmObjectReference<T : RealmObject>(
         objectPointer.let { RealmInterop.realm_object_delete(it) }
     }
 
-    private fun isValid(): Boolean {
+    internal fun isValid(): Boolean {
         val ptr = objectPointer
         return if (ptr != null) {
             RealmInterop.realm_object_is_valid(ptr)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -114,18 +114,19 @@ internal inline fun <reified T : RealmObject> KClass<T>.realmObjectCompanionOrTh
 }
 
 /**
- * If the Realm object is managed returns its Realm Object reference, otherwise returns null.
+ * Convenience property to get easy access to the RealmObjectReference of a RealmObject.
+ *
+ * This will be `null` for unmanaged objects.
  */
-internal fun RealmObject.getObjectReference(): RealmObjectReference<out RealmObject>? {
-    return (this as RealmObjectInternal).`$realm$objectReference`
-}
+internal val RealmObject.realmObjectReference: RealmObjectReference<out RealmObject>?
+    get() = (this as RealmObjectInternal).`$realm$objectReference`
 
 /**
  * If the Realm Object is managed it calls the specified function block and returns its result,
  * otherwise returns null.
  */
-internal inline fun <R> RealmObject.runIfManaged(block: RealmObjectReference<out RealmObject>.() -> R?): R? =
-    getObjectReference()?.run(block)
+internal inline fun <R> RealmObject.runIfManaged(block: RealmObjectReference<out RealmObject>.() -> R): R? =
+    realmObjectReference?.run(block)
 
 /**
  * Checks whether [this] and [other] represent the same underlying object or not. It allows to check
@@ -138,10 +139,8 @@ internal fun RealmObject.hasSameObjectKey(other: RealmObject?): Boolean {
     return runIfManaged {
         val otherObjectPointer = this.objectPointer
         other.runIfManaged {
-            val thisKey =
-                RealmInterop.realm_object_get_key(this.objectPointer)
-            val otherKey =
-                RealmInterop.realm_object_get_key(otherObjectPointer)
+            val thisKey = RealmInterop.realm_object_get_key(this.objectPointer)
+            val otherKey = RealmInterop.realm_object_get_key(otherObjectPointer)
 
             thisKey == otherKey
         }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -65,7 +65,7 @@ internal fun <T : RealmObject> RealmObjectInternal.link(
  * @param frozenRealm Pointer to frozen Realm to which the frozen copy should belong.
  */
 internal fun <T : RealmObject> RealmObjectInternal.freeze(frozenRealm: RealmReference): T =
-    asObjectReference()?.freeze(frozenRealm)?.toRealmObject()!! as T
+    getObjectReference()?.freeze(frozenRealm)?.toRealmObject()!! as T
 
 /**
  * Creates a live copy of this object.
@@ -73,7 +73,7 @@ internal fun <T : RealmObject> RealmObjectInternal.freeze(frozenRealm: RealmRefe
  * @param liveRealm Reference to the Live Realm that should own the thawed object.
  */
 internal fun <T : RealmObject> RealmObjectInternal.thaw(liveRealm: LiveRealmReference): T? =
-    asObjectReference()?.thaw(liveRealm)?.toRealmObject() as T?
+    getObjectReference()?.thaw(liveRealm)?.toRealmObject() as T?
 
 /**
  * Instantiates a [RealmObject] from its Core [Link] representation. For internal use only.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -65,7 +65,7 @@ internal fun <T : RealmObject> RealmObjectInternal.link(
  * @param frozenRealm Pointer to frozen Realm to which the frozen copy should belong.
  */
 @Suppress("UNCHECKED_CAST")
-internal fun <T : RealmObject> RealmObjectInternal.freeze(frozenRealm: RealmReference): T =
+internal fun <T : RealmObject> RealmObject.freeze(frozenRealm: RealmReference): T =
     getObjectReference()?.freeze(frozenRealm)?.toRealmObject() as T
 
 /**
@@ -74,7 +74,7 @@ internal fun <T : RealmObject> RealmObjectInternal.freeze(frozenRealm: RealmRefe
  * @param liveRealm Reference to the Live Realm that should own the thawed object.
  */
 @Suppress("UNCHECKED_CAST")
-internal fun <T : RealmObject> RealmObjectInternal.thaw(liveRealm: LiveRealmReference): T? =
+internal fun <T : RealmObject> RealmObject.thaw(liveRealm: LiveRealmReference): T? =
     getObjectReference()?.thaw(liveRealm)?.toRealmObject() as T?
 
 /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -60,24 +60,6 @@ internal fun <T : RealmObject> RealmObjectInternal.link(
 }
 
 /**
- * Creates a frozen copy of this object.
- *
- * @param frozenRealm Pointer to frozen Realm to which the frozen copy should belong.
- */
-@Suppress("UNCHECKED_CAST")
-internal fun <T : RealmObject> RealmObject.freeze(frozenRealm: RealmReference): T =
-    getObjectReference()?.freeze(frozenRealm)?.toRealmObject() as T
-
-/**
- * Creates a live copy of this object.
- *
- * @param liveRealm Reference to the Live Realm that should own the thawed object.
- */
-@Suppress("UNCHECKED_CAST")
-internal fun <T : RealmObject> RealmObject.thaw(liveRealm: LiveRealmReference): T? =
-    getObjectReference()?.thaw(liveRealm)?.toRealmObject() as T?
-
-/**
  * Instantiates a [RealmObject] from its Core [Link] representation. For internal use only.
  */
 internal fun <T : RealmObject> Link.toRealmObject(
@@ -154,12 +136,12 @@ internal fun RealmObject.hasSameObjectKey(other: RealmObject?): Boolean {
     if (other == null) return false
 
     return runIfManaged {
-        val that = this
+        val otherObjectPointer = this.objectPointer
         other.runIfManaged {
             val thisKey =
                 RealmInterop.realm_object_get_key(this.objectPointer)
             val otherKey =
-                RealmInterop.realm_object_get_key(that.objectPointer)
+                RealmInterop.realm_object_get_key(otherObjectPointer)
 
             thisKey == otherKey
         }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -31,20 +31,20 @@ internal fun <T : RealmObject> RealmObjectInternal.manage(
     type: KClass<T>,
     objectPointer: NativePointer
 ): T {
-    this.`$realm$objectReference` = ObjectReference(type).apply {
-        this.owner = realm
-        this.mediator = mediator
-        this.objectPointer = objectPointer
-        this.className = if (this@manage is DynamicRealmObject) {
+    this.`$realm$objectReference` = ObjectReference(
+        type = type,
+        owner = realm,
+        mediator = mediator,
+        objectPointer = objectPointer,
+        className = if (this@manage is DynamicRealmObject) {
             RealmInterop.realm_get_class(
-                owner.dbPointer,
+                realm.dbPointer,
                 RealmInterop.realm_object_get_table(objectPointer)
             ).name
         } else {
             realmObjectCompanionOrThrow(type).`$realm$className`
         }
-        this.metadata = realm.schemaMetadata[this.className]!!
-    }
+    )
 
     @Suppress("UNCHECKED_CAST")
     return this as T

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -31,7 +31,7 @@ internal fun <T : RealmObject> RealmObjectInternal.manage(
     type: KClass<T>,
     objectPointer: NativePointer
 ): T {
-    this.`$realm$objectReference` = ObjectReference(
+    this.`$realm$objectReference` = RealmObjectReference(
         type = type,
         owner = realm,
         mediator = mediator,
@@ -104,9 +104,9 @@ internal fun <T : RealmObject> NativePointer.toRealmObject(
 )
 
 /**
- * Instantiates a [RealmObject] from its Core [ObjectReference] representation. For internal use only.
+ * Instantiates a [RealmObject] from its Core [RealmObjectReference] representation. For internal use only.
  */
-internal fun <T : RealmObject> ObjectReference<T>.toRealmObject(): T =
+internal fun <T : RealmObject> RealmObjectReference<T>.toRealmObject(): T =
     mediator.createInstanceOf(type)
         .manage(
             realm = owner,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmObjectUtil.kt
@@ -64,14 +64,16 @@ internal fun <T : RealmObject> RealmObjectInternal.link(
  *
  * @param frozenRealm Pointer to frozen Realm to which the frozen copy should belong.
  */
+@Suppress("UNCHECKED_CAST")
 internal fun <T : RealmObject> RealmObjectInternal.freeze(frozenRealm: RealmReference): T =
-    getObjectReference()?.freeze(frozenRealm)?.toRealmObject()!! as T
+    getObjectReference()?.freeze(frozenRealm)?.toRealmObject() as T
 
 /**
  * Creates a live copy of this object.
  *
  * @param liveRealm Reference to the Live Realm that should own the thawed object.
  */
+@Suppress("UNCHECKED_CAST")
 internal fun <T : RealmObject> RealmObjectInternal.thaw(liveRealm: LiveRealmReference): T? =
     getObjectReference()?.thaw(liveRealm)?.toRealmObject() as T?
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmResultsImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmResultsImpl.kt
@@ -37,6 +37,7 @@ import kotlin.reflect.KClass
  */
 // TODO OPTIMIZE Perhaps we should map the output of dictionary.values to a RealmList so that
 //  primitive typed results are never ever exposed publicly.
+// TODO OPTIMIZE We create the same type every time, so don't have to perform map/distinction every time
 internal class RealmResultsImpl<E : RealmObject> constructor(
     private val realm: RealmReference,
     internal val nativePointer: NativePointer,
@@ -55,13 +56,12 @@ internal class RealmResultsImpl<E : RealmObject> constructor(
     override val size: Int
         get() = RealmInterop.realm_results_count(nativePointer).toInt()
 
-    override fun get(index: Int): E {
-        return RealmInterop.realm_results_get(nativePointer, index.toLong()).toRealmObject(
+    override fun get(index: Int): E =
+        RealmInterop.realm_results_get(nativePointer, index.toLong()).toRealmObject(
             clazz = clazz,
             mediator = mediator,
             realm = realm
         )
-    }
 
     @Suppress("SpreadOperator")
     override fun query(query: String, vararg args: Any?): RealmResultsImpl<E> {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmResultsImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmResultsImpl.kt
@@ -56,12 +56,11 @@ internal class RealmResultsImpl<E : RealmObject> constructor(
         get() = RealmInterop.realm_results_count(nativePointer).toInt()
 
     override fun get(index: Int): E {
-        val link = RealmInterop.realm_results_get(nativePointer, index.toLong())
-        // TODO OPTIMIZE We create the same type every time, so don't have to perform map/distinction every time
-        val model = mediator.createInstanceOf(clazz)
-        model.link(realm, mediator, clazz, link)
-        @Suppress("UNCHECKED_CAST")
-        return model as E
+        return RealmInterop.realm_results_get(nativePointer, index.toLong()).toRealmObject(
+            clazz = clazz,
+            mediator = mediator,
+            realm = realm
+        )
     }
 
     @Suppress("SpreadOperator")

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmState.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmState.kt
@@ -44,7 +44,7 @@ internal object UnmanagedState : RealmState {
 }
 
 // Default implementation for all objects that can provide a RealmState instance
-// TODO Public due to being a transitive dependency to RealmObjectInternal
+// TODO Public due to being a transitive dependency to RealmObjectReference
 public interface RealmStateHolder : RealmState {
     public fun realmState(): RealmState
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -171,7 +171,7 @@ internal fun <T> copyToRealm(
             throw IllegalArgumentException("Cannot copy an invalid managed object to Realm.")
         }
 
-        element.asObjectReference()?.run {
+        element.getObjectReference()?.run {
             if (owner == realmReference) {
                 element
             } else {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -172,7 +172,7 @@ internal fun <T> copyToRealm(
         }
 
         if (element.isManaged()) {
-            if (element.`$realm$Owner` == realmReference) {
+            if (element.getOwner() == realmReference) {
                 element
             } else {
                 throw IllegalArgumentException("Cannot set/copyToRealm an outdated object. User findLatest(object) to find the version of the object required in the given context.")
@@ -206,7 +206,7 @@ internal fun <T> copyToRealm(
                 val targetValue = member.get(instance).let { sourceObject ->
                     // Check whether the source is a RealmObject, a primitive or a list
                     // In case of list ensure the values from the source are passed to the native list
-                    if (sourceObject is RealmObjectInternal && !sourceObject.`$realm$IsManaged`) {
+                    if (sourceObject is RealmObjectInternal && !sourceObject.isManaged()) {
                         cache.getOrPut(sourceObject) {
                             copyToRealm(mediator, realmReference, sourceObject, updatePolicy, cache)
                         }
@@ -251,7 +251,7 @@ private fun <T : RealmObject> processListMember(
     val list = member.get(target) as RealmList<Any?>
     for (item in sourceObject) {
         // Same as in copyToRealm, check whether we are working with a primitive or a RealmObject
-        if (item is RealmObjectInternal && !item.`$realm$IsManaged`) {
+        if (item is RealmObjectInternal && !item.isManaged()) {
             val value = cache.getOrPut(item) {
                 copyToRealm(mediator, realmPointer, item, MutableRealm.UpdatePolicy.ERROR, cache)
             }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -171,7 +171,7 @@ internal fun <T> copyToRealm(
             throw IllegalArgumentException("Cannot copy an invalid managed object to Realm.")
         }
 
-        element.getObjectReference()?.run {
+        element.runIfManaged {
             if (owner == realmReference) {
                 element
             } else {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmUtils.kt
@@ -171,13 +171,13 @@ internal fun <T> copyToRealm(
             throw IllegalArgumentException("Cannot copy an invalid managed object to Realm.")
         }
 
-        if (element.isManaged()) {
-            if (element.getOwner() == realmReference) {
+        element.asObjectReference()?.run {
+            if (owner == realmReference) {
                 element
             } else {
                 throw IllegalArgumentException("Cannot set/copyToRealm an outdated object. User findLatest(object) to find the version of the object required in the given context.")
             }
-        } else {
+        } ?: run {
             // Copy object if it is not managed
             val instance: RealmObjectInternal = element
             val companion = mediator.companionOf(instance::class)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
@@ -23,6 +23,7 @@ import io.realm.internal.platform.runBlocking
 import io.realm.internal.platform.threadId
 import io.realm.internal.schema.RealmClassImpl
 import io.realm.internal.schema.RealmSchemaImpl
+import io.realm.isManaged
 import io.realm.query.RealmQuery
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ensureActive
@@ -151,7 +152,7 @@ internal class SuspendableWriter(private val owner: RealmImpl, val dispatcher: C
         // How to test for managed results?
         return when (result) {
             // is RealmResults<*> -> return result.owner != null
-            is RealmObject -> return result.getObjectReference() != null
+            is RealmObject -> return result.isManaged()
             else -> false
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
@@ -149,7 +149,7 @@ internal class SuspendableWriter(private val owner: RealmImpl, val dispatcher: C
         // How to test for managed results?
         return when (result) {
             // is RealmResults<*> -> return result.owner != null
-            is RealmObject -> return result is RealmObjectInternal && result.`$realm$IsManaged`
+            is RealmObject -> return result is RealmObjectInternal && result.isManaged()
             else -> false
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
@@ -139,7 +139,7 @@ internal class SuspendableWriter(private val owner: RealmImpl, val dispatcher: C
             is RealmObject -> {
                 // FIXME If we could transfer ownership (the owning Realm) in Realm instead then we
                 //  could completely eliminate the need for the external owner in here!?
-                (result as RealmObjectInternal).freezeTyped(reference)
+                result.freezeTyped(reference)
             }
             else -> throw IllegalArgumentException("Did not recognize type to be frozen: $result")
         }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
@@ -149,7 +149,7 @@ internal class SuspendableWriter(private val owner: RealmImpl, val dispatcher: C
         // How to test for managed results?
         return when (result) {
             // is RealmResults<*> -> return result.owner != null
-            is RealmObject -> return result.asObjectReference() != null
+            is RealmObject -> return result.getObjectReference() != null
             else -> false
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/SuspendableWriter.kt
@@ -149,7 +149,7 @@ internal class SuspendableWriter(private val owner: RealmImpl, val dispatcher: C
         // How to test for managed results?
         return when (result) {
             // is RealmResults<*> -> return result.owner != null
-            is RealmObject -> return result is RealmObjectInternal && result.isManaged()
+            is RealmObject -> return result.asObjectReference() != null
             else -> false
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -27,6 +27,7 @@ import io.realm.internal.LiveRealmReference
 import io.realm.internal.RealmObjectInternal
 import io.realm.internal.WriteTransactionManager
 import io.realm.internal.asInternalDeleteable
+import io.realm.internal.asObjectReference
 import io.realm.internal.create
 import io.realm.internal.getOwner
 import io.realm.internal.interop.NativePointer
@@ -83,10 +84,7 @@ internal open class DynamicMutableRealmImpl(
         } else if ((obj as RealmObjectInternal).getOwner() == realmReference) {
             obj as DynamicMutableRealmObject?
         } else {
-            null
-            // TODO
-            // obj.`$realm$objectReference`!!.thaw(realmReference, DynamicMutableRealmObject::class)
-            // obj.thaw(realmReference, DynamicMutableRealmObject::class) as DynamicMutableRealmObject?
+            obj.asObjectReference()!!.thaw(realmReference, DynamicMutableRealmObject::class)?.asRealmObject()
         }
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -30,6 +30,7 @@ import io.realm.internal.getObjectReference
 import io.realm.internal.create
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.query.ObjectQuery
+import io.realm.internal.runIfManaged
 import io.realm.internal.toRealmObject
 import io.realm.isValid
 import io.realm.query.RealmQuery
@@ -78,7 +79,7 @@ internal open class DynamicMutableRealmImpl(
         return if (!obj.isValid()) {
             null
         } else {
-            obj.getObjectReference()?.run {
+            obj.runIfManaged {
                 if (owner == realmReference) {
                     obj as DynamicMutableRealmObject?
                 } else {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -28,6 +28,7 @@ import io.realm.internal.RealmObjectInternal
 import io.realm.internal.WriteTransactionManager
 import io.realm.internal.asInternalDeleteable
 import io.realm.internal.create
+import io.realm.internal.getOwner
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.query.ObjectQuery
 import io.realm.isManaged
@@ -79,10 +80,13 @@ internal open class DynamicMutableRealmImpl(
             null
         } else if (!obj.isManaged()) {
             throw IllegalArgumentException("Cannot lookup unmanaged object")
-        } else if ((obj as RealmObjectInternal).`$realm$Owner` == realmReference) {
+        } else if ((obj as RealmObjectInternal).getOwner() == realmReference) {
             obj as DynamicMutableRealmObject?
         } else {
-            obj.thaw(realmReference, DynamicMutableRealmObject::class) as DynamicMutableRealmObject?
+            null
+            // TODO
+            // obj.`$realm$objectReference`!!.thaw(realmReference, DynamicMutableRealmObject::class)
+            // obj.thaw(realmReference, DynamicMutableRealmObject::class) as DynamicMutableRealmObject?
         }
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -83,8 +83,7 @@ internal open class DynamicMutableRealmImpl(
                 if (owner == realmReference) {
                     obj as DynamicMutableRealmObject?
                 } else {
-                    return obj.getObjectReference()!!
-                        .thaw(realmReference, DynamicMutableRealmObject::class)
+                    return thaw(realmReference, DynamicMutableRealmObject::class)
                         ?.toRealmObject() as DynamicMutableRealmObject?
                 }
             } ?: throw IllegalArgumentException("Cannot lookup unmanaged object")

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -27,7 +27,6 @@ import io.realm.internal.LiveRealmReference
 import io.realm.internal.WriteTransactionManager
 import io.realm.internal.asInternalDeleteable
 import io.realm.internal.create
-import io.realm.internal.getObjectReference
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.query.ObjectQuery
 import io.realm.internal.runIfManaged

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -26,7 +26,7 @@ import io.realm.internal.InternalConfiguration
 import io.realm.internal.LiveRealmReference
 import io.realm.internal.WriteTransactionManager
 import io.realm.internal.asInternalDeleteable
-import io.realm.internal.asObjectReference
+import io.realm.internal.getObjectReference
 import io.realm.internal.create
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.query.ObjectQuery
@@ -78,11 +78,11 @@ internal open class DynamicMutableRealmImpl(
         return if (!obj.isValid()) {
             null
         } else {
-            obj.asObjectReference()?.run {
+            obj.getObjectReference()?.run {
                 if (owner == realmReference) {
                     obj as DynamicMutableRealmObject?
                 } else {
-                    return obj.asObjectReference()!!
+                    return obj.getObjectReference()!!
                         .thaw(realmReference, DynamicMutableRealmObject::class)
                         ?.toRealmObject() as DynamicMutableRealmObject?
                 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -26,8 +26,8 @@ import io.realm.internal.InternalConfiguration
 import io.realm.internal.LiveRealmReference
 import io.realm.internal.WriteTransactionManager
 import io.realm.internal.asInternalDeleteable
-import io.realm.internal.getObjectReference
 import io.realm.internal.create
+import io.realm.internal.getObjectReference
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.query.ObjectQuery
 import io.realm.internal.runIfManaged

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -32,6 +32,7 @@ import io.realm.internal.create
 import io.realm.internal.getOwner
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.query.ObjectQuery
+import io.realm.internal.toRealmObject
 import io.realm.isManaged
 import io.realm.isValid
 import io.realm.query.RealmQuery
@@ -84,7 +85,7 @@ internal open class DynamicMutableRealmImpl(
         } else if ((obj as RealmObjectInternal).getOwner() == realmReference) {
             obj as DynamicMutableRealmObject?
         } else {
-            obj.asObjectReference()!!.thaw(realmReference, DynamicMutableRealmObject::class)?.asRealmObject()
+            obj.asObjectReference()!!.thaw(realmReference, DynamicMutableRealmObject::class)?.toRealmObject() as DynamicMutableRealmObject?
         }
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmObjectImpl.kt
@@ -35,11 +35,11 @@ internal class DynamicMutableRealmObjectImpl : DynamicMutableRealmObject, Dynami
     override fun <T> set(propertyName: String, value: T): DynamicMutableRealmObject {
         when (value) {
             is RealmObject -> RealmObjectHelper.setObject(
-                this,
+                this.`$realm$objectReference`!!,
                 propertyName,
                 value as RealmObjectInternal
             )
-            else -> RealmObjectHelper.dynamicSetValue(this, propertyName, value)
+            else -> RealmObjectHelper.dynamicSetValue(this.`$realm$objectReference`!!, propertyName, value)
         }
         return this
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmObjectImpl.kt
@@ -32,13 +32,12 @@ internal class DynamicMutableRealmObjectImpl : DynamicMutableRealmObject, Dynami
     }
 
     override fun <T> set(propertyName: String, value: T): DynamicMutableRealmObject {
+        // `$realm$objectReference` is not null, as DynamicMutableRealmObject are always managed
+        val reference = this.`$realm$objectReference`!!
+
         when (value) {
-            is RealmObject -> RealmObjectHelper.setObject(
-                this.`$realm$objectReference`!!,
-                propertyName,
-                value
-            )
-            else -> RealmObjectHelper.dynamicSetValue(this.`$realm$objectReference`!!, propertyName, value)
+            is RealmObject -> RealmObjectHelper.setObject(reference, propertyName, value)
+            else -> RealmObjectHelper.dynamicSetValue(reference, propertyName, value)
         }
         return this
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmObjectImpl.kt
@@ -20,7 +20,6 @@ import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.dynamic.DynamicMutableRealmObject
 import io.realm.internal.RealmObjectHelper
-import io.realm.internal.RealmObjectInternal
 
 internal class DynamicMutableRealmObjectImpl : DynamicMutableRealmObject, DynamicRealmObjectImpl() {
 
@@ -37,7 +36,7 @@ internal class DynamicMutableRealmObjectImpl : DynamicMutableRealmObject, Dynami
             is RealmObject -> RealmObjectHelper.setObject(
                 this.`$realm$objectReference`!!,
                 propertyName,
-                value as RealmObjectInternal
+                value
             )
             else -> RealmObjectHelper.dynamicSetValue(this.`$realm$objectReference`!!, propertyName, value)
         }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -22,23 +22,23 @@ import io.realm.dynamic.DynamicRealmObject
 import io.realm.internal.RealmObjectHelper
 import io.realm.internal.RealmObjectInternal
 import io.realm.internal.RealmObjectReference
-import io.realm.internal.getObjectReference
 import kotlin.reflect.KClass
 
 public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectInternal {
     override val type: String
-        get() = this.getObjectReference()!!.className
+        get() = this.`$realm$objectReference`!!.className
 
+    // This should never be null after initialization of a dynamic object, but we currently cannot
+    // represent that in the type system as we one some code paths construct the Kotlin object
+    // before having the realm object reference
     override var `$realm$objectReference`: RealmObjectReference<out RealmObject>? = null
 
     override fun <T : Any> getValue(propertyName: String, clazz: KClass<T>): T {
         // dynamicGetSingle checks nullability of property, so null pointer check raises appropriate NPE
-        // `$realm$objectReference` is not null, as DynamicRealmObject are always managed
-        return RealmObjectHelper.dynamicGet(`$realm$objectReference`!!, propertyName, clazz, false)!!
+        return RealmObjectHelper.dynamicGet(this.`$realm$objectReference`!!, propertyName, clazz, false)!!
     }
 
     override fun <T : Any> getNullableValue(propertyName: String, clazz: KClass<T>): T? {
-        // `$realm$objectReference` is not null, as DynamicRealmObject are always managed
         return RealmObjectHelper.dynamicGet(`$realm$objectReference`!!, propertyName, clazz, true)
     }
 
@@ -47,12 +47,10 @@ public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectIntern
     }
 
     override fun <T : Any> getValueList(propertyName: String, clazz: KClass<T>): RealmList<T> {
-        // `$realm$objectReference` is not null, as DynamicRealmObject are always managed
         return RealmObjectHelper.dynamicGetList(`$realm$objectReference`!!, propertyName, clazz, false) as RealmList<T>
     }
 
     override fun <T : Any> getNullableValueList(propertyName: String, clazz: KClass<T>): RealmList<T?> {
-        // `$realm$objectReference` is not null, as DynamicRealmObject are always managed
         return RealmObjectHelper.dynamicGetList(`$realm$objectReference`!!, propertyName, clazz, true)
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -33,10 +33,12 @@ public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectIntern
 
     override fun <T : Any> getValue(propertyName: String, clazz: KClass<T>): T {
         // dynamicGetSingle checks nullability of property, so null pointer check raises appropriate NPE
+        // `$realm$objectReference` is not null, as DynamicRealmObject are always managed
         return RealmObjectHelper.dynamicGet(`$realm$objectReference`!!, propertyName, clazz, false)!!
     }
 
     override fun <T : Any> getNullableValue(propertyName: String, clazz: KClass<T>): T? {
+        // `$realm$objectReference` is not null, as DynamicRealmObject are always managed
         return RealmObjectHelper.dynamicGet(`$realm$objectReference`!!, propertyName, clazz, true)
     }
 
@@ -45,10 +47,12 @@ public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectIntern
     }
 
     override fun <T : Any> getValueList(propertyName: String, clazz: KClass<T>): RealmList<T> {
+        // `$realm$objectReference` is not null, as DynamicRealmObject are always managed
         return RealmObjectHelper.dynamicGetList(`$realm$objectReference`!!, propertyName, clazz, false) as RealmList<T>
     }
 
     override fun <T : Any> getNullableValueList(propertyName: String, clazz: KClass<T>): RealmList<T?> {
+        // `$realm$objectReference` is not null, as DynamicRealmObject are always managed
         return RealmObjectHelper.dynamicGetList(`$realm$objectReference`!!, propertyName, clazz, true)
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -19,9 +19,9 @@ package io.realm.internal.dynamic
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.dynamic.DynamicRealmObject
-import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmObjectHelper
 import io.realm.internal.RealmObjectInternal
+import io.realm.internal.RealmObjectReference
 import io.realm.internal.getObjectReference
 import kotlin.reflect.KClass
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -33,11 +33,11 @@ public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectIntern
 
     override fun <T : Any> getValue(propertyName: String, clazz: KClass<T>): T {
         // dynamicGetSingle checks nullability of property, so null pointer check raises appropriate NPE
-        return RealmObjectHelper.dynamicGet(this, propertyName, clazz, false)!!
+        return RealmObjectHelper.dynamicGet(`$realm$objectReference`!!, propertyName, clazz, false)!!
     }
 
     override fun <T : Any> getNullableValue(propertyName: String, clazz: KClass<T>): T? {
-        return RealmObjectHelper.dynamicGet(this, propertyName, clazz, true)
+        return RealmObjectHelper.dynamicGet(`$realm$objectReference`!!, propertyName, clazz, true)
     }
 
     override fun getObject(propertyName: String): DynamicRealmObject? {
@@ -45,11 +45,11 @@ public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectIntern
     }
 
     override fun <T : Any> getValueList(propertyName: String, clazz: KClass<T>): RealmList<T> {
-        return RealmObjectHelper.dynamicGetList(this, propertyName, clazz, false) as RealmList<T>
+        return RealmObjectHelper.dynamicGetList(`$realm$objectReference`!!, propertyName, clazz, false) as RealmList<T>
     }
 
     override fun <T : Any> getNullableValueList(propertyName: String, clazz: KClass<T>): RealmList<T?> {
-        return RealmObjectHelper.dynamicGetList(this, propertyName, clazz, true)
+        return RealmObjectHelper.dynamicGetList(`$realm$objectReference`!!, propertyName, clazz, true)
     }
 
     override fun getObjectList(propertyName: String): RealmList<out DynamicRealmObject> {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -22,12 +22,12 @@ import io.realm.dynamic.DynamicRealmObject
 import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmObjectHelper
 import io.realm.internal.RealmObjectInternal
-import io.realm.internal.asObjectReference
+import io.realm.internal.getObjectReference
 import kotlin.reflect.KClass
 
 public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectInternal {
     override val type: String
-        get() = this.asObjectReference()!!.className
+        get() = this.getObjectReference()!!.className
 
     override var `$realm$objectReference`: RealmObjectReference<out RealmObject>? = null
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -17,24 +17,19 @@
 package io.realm.internal.dynamic
 
 import io.realm.RealmList
+import io.realm.RealmObject
 import io.realm.dynamic.DynamicRealmObject
-import io.realm.internal.Mediator
+import io.realm.internal.ObjectReference
 import io.realm.internal.RealmObjectHelper
 import io.realm.internal.RealmObjectInternal
-import io.realm.internal.RealmReference
-import io.realm.internal.interop.NativePointer
-import io.realm.internal.schema.ClassMetadata
+import io.realm.internal.getClassName
 import kotlin.reflect.KClass
 
 public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectInternal {
     override val type: String
-        get() = this.`$realm$ClassName` ?: throw IllegalArgumentException("Cannot get class name of unmanaged dynamic object")
-    override var `$realm$ObjectPointer`: NativePointer? = null
-    override var `$realm$IsManaged`: Boolean = false
-    override var `$realm$Owner`: RealmReference? = null
-    override var `$realm$ClassName`: String? = null
-    override var `$realm$Mediator`: Mediator? = null
-    override var `$realm$metadata`: ClassMetadata? = null
+        get() = this.getClassName()
+
+    override var `$realm$objectReference`: ObjectReference<out RealmObject>? = null
 
     override fun <T : Any> getValue(propertyName: String, clazz: KClass<T>): T {
         // dynamicGetSingle checks nullability of property, so null pointer check raises appropriate NPE

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -19,7 +19,7 @@ package io.realm.internal.dynamic
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.dynamic.DynamicRealmObject
-import io.realm.internal.ObjectReference
+import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmObjectHelper
 import io.realm.internal.RealmObjectInternal
 import io.realm.internal.asObjectReference
@@ -29,7 +29,7 @@ public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectIntern
     override val type: String
         get() = this.asObjectReference()!!.className
 
-    override var `$realm$objectReference`: ObjectReference<out RealmObject>? = null
+    override var `$realm$objectReference`: RealmObjectReference<out RealmObject>? = null
 
     override fun <T : Any> getValue(propertyName: String, clazz: KClass<T>): T {
         // dynamicGetSingle checks nullability of property, so null pointer check raises appropriate NPE

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -22,12 +22,12 @@ import io.realm.dynamic.DynamicRealmObject
 import io.realm.internal.ObjectReference
 import io.realm.internal.RealmObjectHelper
 import io.realm.internal.RealmObjectInternal
-import io.realm.internal.getClassName
+import io.realm.internal.asObjectReference
 import kotlin.reflect.KClass
 
 public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectInternal {
     override val type: String
-        get() = this.getClassName()
+        get() = this.asObjectReference()!!.className
 
     override var `$realm$objectReference`: ObjectReference<out RealmObject>? = null
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -2,13 +2,13 @@ package io.realm.internal.query
 
 import io.realm.RealmObject
 import io.realm.asFlow
-import io.realm.hasSameObjectKey
 import io.realm.internal.InternalDeleteable
 import io.realm.internal.Mediator
 import io.realm.internal.Observable
 import io.realm.internal.RealmReference
 import io.realm.internal.RealmResultsImpl
 import io.realm.internal.Thawable
+import io.realm.internal.hasSameObjectKey
 import io.realm.internal.interop.ClassKey
 import io.realm.internal.interop.Link
 import io.realm.internal.interop.NativePointer

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -10,6 +10,7 @@ import io.realm.internal.RealmReference
 import io.realm.internal.RealmResultsImpl
 import io.realm.internal.Thawable
 import io.realm.internal.asInternalDeleteable
+import io.realm.internal.asObjectReference
 import io.realm.internal.interop.ClassKey
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
@@ -100,6 +101,6 @@ internal class SingleQuery<E : RealmObject> constructor(
     override fun delete() {
         // TODO C-API doesn't implement realm_query_delete_all so just fetch the result and delete
         //  that
-        find()?.asInternalDeleteable()?.delete()
+        find()?.asObjectReference()?.asInternalDeleteable()?.delete()
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -9,7 +9,6 @@ import io.realm.internal.Observable
 import io.realm.internal.RealmReference
 import io.realm.internal.RealmResultsImpl
 import io.realm.internal.Thawable
-import io.realm.internal.asInternalDeleteable
 import io.realm.internal.asObjectReference
 import io.realm.internal.interop.ClassKey
 import io.realm.internal.interop.Link

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -12,9 +12,10 @@ import io.realm.internal.Thawable
 import io.realm.internal.asInternalDeleteable
 import io.realm.internal.asObjectReference
 import io.realm.internal.interop.ClassKey
+import io.realm.internal.interop.Link
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
-import io.realm.internal.link
+import io.realm.internal.toRealmObject
 import io.realm.notifications.InitialResults
 import io.realm.notifications.ResultsChange
 import io.realm.notifications.SingleQueryChange
@@ -37,11 +38,12 @@ internal class SingleQuery<E : RealmObject> constructor(
 ) : RealmSingleQuery<E>, InternalDeleteable, Thawable<Observable<RealmResultsImpl<E>, ResultsChange<E>>> {
 
     override fun find(): E? {
-        val link = RealmInterop.realm_query_find_first(queryPointer) ?: return null
-        val model = mediator.createInstanceOf(clazz)
-        model.link(realmReference, mediator, clazz, link)
-        @Suppress("UNCHECKED_CAST")
-        return model as E
+        val link: Link = RealmInterop.realm_query_find_first(queryPointer) ?: return null
+        return link.toRealmObject(
+            clazz = clazz,
+            mediator = mediator,
+            realm = realmReference
+        )
     }
 
     /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -9,7 +9,7 @@ import io.realm.internal.Observable
 import io.realm.internal.RealmReference
 import io.realm.internal.RealmResultsImpl
 import io.realm.internal.Thawable
-import io.realm.internal.asObjectReference
+import io.realm.internal.getObjectReference
 import io.realm.internal.interop.ClassKey
 import io.realm.internal.interop.Link
 import io.realm.internal.interop.NativePointer
@@ -102,6 +102,6 @@ internal class SingleQuery<E : RealmObject> constructor(
     override fun delete() {
         // TODO C-API doesn't implement realm_query_delete_all so just fetch the result and delete
         //  that
-        find()?.asObjectReference()?.delete()
+        find()?.getObjectReference()?.delete()
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -103,6 +103,6 @@ internal class SingleQuery<E : RealmObject> constructor(
     override fun delete() {
         // TODO C-API doesn't implement realm_query_delete_all so just fetch the result and delete
         //  that
-        find()?.asObjectReference()?.asInternalDeleteable()?.delete()
+        find()?.asObjectReference()?.delete()
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -9,7 +9,6 @@ import io.realm.internal.Observable
 import io.realm.internal.RealmReference
 import io.realm.internal.RealmResultsImpl
 import io.realm.internal.Thawable
-import io.realm.internal.getObjectReference
 import io.realm.internal.interop.ClassKey
 import io.realm.internal.interop.Link
 import io.realm.internal.interop.NativePointer

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -102,6 +102,6 @@ internal class SingleQuery<E : RealmObject> constructor(
     override fun delete() {
         // TODO C-API doesn't implement realm_query_delete_all so just fetch the result and delete
         //  that
-        find()?.runIfManaged { delete() }
+        find()?.runIfManaged { delete() } // We can never have an unmanaged object as result of a query
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/query/SingleQuery.kt
@@ -14,6 +14,7 @@ import io.realm.internal.interop.ClassKey
 import io.realm.internal.interop.Link
 import io.realm.internal.interop.NativePointer
 import io.realm.internal.interop.RealmInterop
+import io.realm.internal.runIfManaged
 import io.realm.internal.toRealmObject
 import io.realm.notifications.InitialResults
 import io.realm.notifications.ResultsChange
@@ -102,6 +103,6 @@ internal class SingleQuery<E : RealmObject> constructor(
     override fun delete() {
         // TODO C-API doesn't implement realm_query_delete_all so just fetch the result and delete
         //  that
-        find()?.getObjectReference()?.delete()
+        find()?.runIfManaged { delete() }
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/CachedClassKeyMap.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/schema/CachedClassKeyMap.kt
@@ -27,7 +27,7 @@ import io.realm.internal.interop.RealmInterop
  */
 public interface SchemaMetadata {
     public operator fun get(className: String): ClassMetadata?
-    public fun getOrThrow(className: String): ClassMetadata = get(className)
+    public fun getOrThrow(className: String): ClassMetadata = this[className]
         ?: throw IllegalArgumentException("Schema does not contain a class named '$className'")
 }
 
@@ -40,7 +40,7 @@ public interface ClassMetadata {
     public val primaryKeyPropertyKey: PropertyKey?
     public operator fun get(propertyName: String): PropertyInfo?
     public operator fun get(propertyKey: PropertyKey): PropertyInfo?
-    public fun getOrThrow(propertyName: String): PropertyInfo = get(propertyName)
+    public fun getOrThrow(propertyName: String): PropertyInfo = this[propertyName]
         ?: throw IllegalArgumentException("Schema for type '$className' doesn't contain a property named '$propertyName'")
 }
 

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
@@ -35,7 +35,6 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
-import org.jetbrains.kotlin.ir.builders.IrStatementsBuilder
 import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irBlockBody
@@ -48,14 +47,12 @@ import org.jetbrains.kotlin.ir.builders.irLetS
 import org.jetbrains.kotlin.ir.builders.irNull
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irString
-import org.jetbrains.kotlin.ir.builders.irTemporary
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
-import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/AccessorModifierIrGeneration.kt
@@ -384,7 +384,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
              * Transform the getter to whether access the managed object or the backing field
              * ```
              * get() {
-             *      this.`$realm$objectReference`?.let { it.getValue("propertyName") } ?: backingField
+             *      return this.`$realm$objectReference`?.let { it.getValue("propertyName") } ?: backingField
              * }
              * ```
              */
@@ -455,7 +455,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                  * Transform the setter to whether access the managed object or the backing field
                  * ```
                  * set(value) {
-                 *      this.`$realm$objectReference`?.let { it.setValue("propertyName", value) } ?: backingField
+                 *      this.`$realm$objectReference`?.let { it.setValue("propertyName", value) } ?: run { backingField = value }
                  * }
                  * ```
                  */

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
@@ -34,15 +34,8 @@ internal object Names {
 
     val SET = Name.special("<set-?>")
 
-    // names must match `RealmObjectInterop` properties
-    val OBJECT_POINTER = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}ObjectPointer")
-
     // names must match `RealmObjectInternal` properties
-    val REALM_OWNER = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}Owner")
-    val OBJECT_CLASS_NAME = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}ClassName")
-    val OBJECT_IS_MANAGED = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}IsManaged")
-    val MEDIATOR = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}Mediator")
-    val METADATA = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}metadata")
+    val OBJECT_REFERENCE = Name.identifier("${REALM_SYNTHETIC_PROPERTY_PREFIX}objectReference")
 
     // C-interop methods
     val REALM_OBJECT_HELPER_GET_VALUE = Name.identifier("getValue")
@@ -60,19 +53,6 @@ internal object Names {
     val PROPERTY_TYPE_OBJECT = Name.identifier("RLM_PROPERTY_TYPE_OBJECT")
     val PROPERTY_COLLECTION_TYPE_NONE = Name.identifier("RLM_COLLECTION_TYPE_NONE")
     val PROPERTY_COLLECTION_TYPE_LIST = Name.identifier("RLM_COLLECTION_TYPE_LIST")
-
-    // Function names
-    val REALM_CONFIGURATION_BUILDER_BUILD = Name.identifier("build")
-    val REALM_CONFIGURATION_WITH = Name.identifier("with")
-    val REALM_OBJECT_INTERNAL_DELETE = Name.identifier("delete")
-    val REALM_OBJECT_INTERNAL_FREEZE = Name.identifier("freeze")
-    val REALM_OBJECT_INTERNAL_THAW = Name.identifier("thaw")
-    val REALM_OBJECT_INTERNAL_REGISTER_FOR_NOTIFICATION = Name.identifier("registerForNotification")
-    val REALM_OBJECT_INTERNAL_EMIT_FROZEN_UPDATE = Name.identifier("emitFrozenUpdate")
-    val REALM_OBJECT_INTERNAL_IS_FROZEN = Name.identifier("isFrozen")
-    val REALM_OBJECT_INTERNAL_REALM_STATE = Name.identifier("realmState")
-    val REALM_OBJECT_INTERNAL_VERSION = Name.identifier("version")
-    val REALM_OBJECT_INTERNAL_PROPERTY_KEY = Name.identifier("propertyInfoOrThrow")
 }
 
 internal object FqNames {
@@ -83,10 +63,8 @@ internal object FqNames {
     val REALM_MODEL_INTERFACE = FqName("io.realm.RealmObject")
     val REALM_MODEL_COMPANION = FqName("io.realm.internal.RealmObjectCompanion")
     val REALM_OBJECT_HELPER = FqName("io.realm.internal.RealmObjectHelper")
-    val REALM_REFERENCE = FqName("io.realm.internal.RealmReference")
-    val REALM_MEDIATOR_INTERFACE = FqName("io.realm.internal.Mediator")
     val REALM_CLASS_IMPL = FqName("io.realm.internal.schema.RealmClassImpl")
-    val CLASS_METADATA_CLASS = FqName("io.realm.internal.schema.ClassMetadata")
+    val OBJECT_REFERENCE_CLASS = FqName("io.realm.internal.ObjectReference")
 
     // External visible interface of Realm objects
     val KOTLIN_COLLECTIONS_SET = FqName("kotlin.collections.Set")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/Identifiers.kt
@@ -64,7 +64,7 @@ internal object FqNames {
     val REALM_MODEL_COMPANION = FqName("io.realm.internal.RealmObjectCompanion")
     val REALM_OBJECT_HELPER = FqName("io.realm.internal.RealmObjectHelper")
     val REALM_CLASS_IMPL = FqName("io.realm.internal.schema.RealmClassImpl")
-    val OBJECT_REFERENCE_CLASS = FqName("io.realm.internal.ObjectReference")
+    val OBJECT_REFERENCE_CLASS = FqName("io.realm.internal.RealmObjectReference")
 
     // External visible interface of Realm objects
     val KOTLIN_COLLECTIONS_SET = FqName("kotlin.collections.Set")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelLoweringExtension.kt
@@ -19,15 +19,6 @@ package io.realm.compiler
 import io.realm.compiler.FqNames.MODEL_OBJECT_ANNOTATION
 import io.realm.compiler.FqNames.REALM_MODEL_COMPANION
 import io.realm.compiler.FqNames.REALM_OBJECT_INTERNAL_INTERFACE
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_DELETE
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_EMIT_FROZEN_UPDATE
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_FREEZE
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_IS_FROZEN
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_PROPERTY_KEY
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_REALM_STATE
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_REGISTER_FOR_NOTIFICATION
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_THAW
-import io.realm.compiler.Names.REALM_OBJECT_INTERNAL_VERSION
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.checkDeclarationParents
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
@@ -47,18 +38,6 @@ import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.platform.konan.isNative
-
-private val realmObjectInternalOverrides = setOf(
-    REALM_OBJECT_INTERNAL_DELETE,
-    REALM_OBJECT_INTERNAL_FREEZE,
-    REALM_OBJECT_INTERNAL_THAW,
-    REALM_OBJECT_INTERNAL_REGISTER_FOR_NOTIFICATION,
-    REALM_OBJECT_INTERNAL_EMIT_FROZEN_UPDATE,
-    REALM_OBJECT_INTERNAL_IS_FROZEN,
-    REALM_OBJECT_INTERNAL_REALM_STATE,
-    REALM_OBJECT_INTERNAL_VERSION,
-    REALM_OBJECT_INTERNAL_PROPERTY_KEY
-)
 
 class RealmModelLoweringExtension : IrGenerationExtension {
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
@@ -116,9 +95,6 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
 
             // Modify properties accessor to generate custom getter/setter
             AccessorModifierIrGeneration(pluginContext).modifyPropertiesAndCollectSchema(irClass)
-
-            // RealmObjectInternal overrides
-            irClass.addFakeOverrides(realmObjectInternalInterface, realmObjectInternalOverrides)
 
             // Add body for synthetic companion methods
             val companion = irClass.companionObject() ?: fatalError("RealmObject without companion")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -17,24 +17,18 @@
 package io.realm.compiler
 
 import io.realm.compiler.FqNames.CLASS_INFO
-import io.realm.compiler.FqNames.CLASS_METADATA_CLASS
 import io.realm.compiler.FqNames.COLLECTION_TYPE
 import io.realm.compiler.FqNames.INDEX_ANNOTATION
+import io.realm.compiler.FqNames.OBJECT_REFERENCE_CLASS
 import io.realm.compiler.FqNames.PRIMARY_KEY_ANNOTATION
 import io.realm.compiler.FqNames.PROPERTY_INFO
 import io.realm.compiler.FqNames.PROPERTY_TYPE
 import io.realm.compiler.FqNames.REALM_INSTANT
-import io.realm.compiler.FqNames.REALM_MEDIATOR_INTERFACE
 import io.realm.compiler.FqNames.REALM_MODEL_COMPANION
 import io.realm.compiler.FqNames.REALM_NATIVE_POINTER
 import io.realm.compiler.FqNames.REALM_OBJECT_INTERNAL_INTERFACE
-import io.realm.compiler.FqNames.REALM_REFERENCE
 import io.realm.compiler.Names.CLASS_INFO_CREATE
-import io.realm.compiler.Names.MEDIATOR
-import io.realm.compiler.Names.METADATA
-import io.realm.compiler.Names.OBJECT_CLASS_NAME
-import io.realm.compiler.Names.OBJECT_IS_MANAGED
-import io.realm.compiler.Names.OBJECT_POINTER
+import io.realm.compiler.Names.OBJECT_REFERENCE
 import io.realm.compiler.Names.PROPERTY_COLLECTION_TYPE_LIST
 import io.realm.compiler.Names.PROPERTY_COLLECTION_TYPE_NONE
 import io.realm.compiler.Names.PROPERTY_INFO_CREATE
@@ -44,7 +38,6 @@ import io.realm.compiler.Names.REALM_OBJECT_COMPANION_FIELDS_MEMBER
 import io.realm.compiler.Names.REALM_OBJECT_COMPANION_NEW_INSTANCE_METHOD
 import io.realm.compiler.Names.REALM_OBJECT_COMPANION_PRIMARY_KEY_MEMBER
 import io.realm.compiler.Names.REALM_OBJECT_COMPANION_SCHEMA_METHOD
-import io.realm.compiler.Names.REALM_OWNER
 import io.realm.compiler.Names.SET
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.ir.copyTo
@@ -124,9 +117,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
     private val collectionTypes =
         collectionType.declarations.filterIsInstance<IrEnumEntry>()
 
-    private val realmReferenceClass = pluginContext.lookupClassOrThrow(REALM_REFERENCE)
-    private val mediatorInterface = pluginContext.lookupClassOrThrow(REALM_MEDIATOR_INTERFACE)
-    private val classMetadataClass = pluginContext.lookupClassOrThrow(CLASS_METADATA_CLASS)
+    private val objectReferenceClass = pluginContext.lookupClassOrThrow(OBJECT_REFERENCE_CLASS)
     private val realmInstantType: IrType = pluginContext.lookupClassOrThrow(REALM_INSTANT).defaultType
 
     private val listIrClass: IrClass =
@@ -142,35 +133,10 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         irClass.apply {
             addVariableProperty(
                 realmModelInternalInterface,
-                OBJECT_POINTER,
-                nullableNativePointerInterface,
+                OBJECT_REFERENCE,
+                objectReferenceClass.defaultType.makeNullable(),
                 ::irNull
             )
-            addVariableProperty(
-                realmModelInternalInterface,
-                REALM_OWNER,
-                realmReferenceClass.defaultType.makeNullable(),
-                ::irNull
-            )
-            addVariableProperty(
-                realmModelInternalInterface,
-                OBJECT_CLASS_NAME,
-                pluginContext.irBuiltIns.stringType.makeNullable(),
-                ::irNull
-            )
-            addVariableProperty(
-                realmModelInternalInterface,
-                OBJECT_IS_MANAGED,
-                pluginContext.irBuiltIns.booleanType,
-                ::irFalse
-            )
-            addVariableProperty(
-                realmModelInternalInterface,
-                MEDIATOR,
-                mediatorInterface.defaultType.makeNullable(),
-                ::irNull
-            )
-            addVariableProperty(realmModelInternalInterface, METADATA, classMetadataClass.defaultType.makeNullable(), ::irNull)
         }
 
     @Suppress("LongMethod")

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
@@ -152,23 +152,18 @@ class GenerationExtensionTest {
         assertTrue(sampleModel is io.realm.internal.RealmObjectInternal)
 
         assertNull(sampleModel.`$realm$objectReference`)
-        // Accessing getters/setters
-        @Suppress("UNCHECKED_CAST")
-        sampleModel.`$realm$objectReference` = RealmObjectReference(
+
+        val realmObjectReference = RealmObjectReference(
             type = RealmObject::class,
             objectPointer = LongPointer(0xCAFEBABE),
-            // Cannot initialize a RealmReference without a model, so skipping this from the test
-            // sampleModel.owner = LongPointer(0XCAFED00D)
             className = "Sample",
             owner = dummyRealmReference,
             mediator = dummyMediator
         )
 
-        assertNotNull(sampleModel.`$realm$objectReference`)
-        assertEquals(0xCAFEBABE, (sampleModel.`$realm$objectReference`!!.objectPointer as LongPointer).ptr)
-        // Cannot initialize a RealmReference without a model, so skipping this from the test
-        // assertEquals(0XCAFED00D, (sampleModel.owner as LongPointer).ptr)
-        assertEquals("Sample", sampleModel.`$realm$objectReference`!!.className)
+        // Accessing getters/setters
+        sampleModel.`$realm$objectReference` = realmObjectReference
+        assertEquals(realmObjectReference, sampleModel.`$realm$objectReference`)
 
         inputs.assertGeneratedIR()
     }

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
@@ -45,42 +45,6 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class GenerationExtensionTest {
-    private val dummyRealmReference = object : RealmReference {
-        override val dbPointer: NativePointer
-            get() = TODO("Not yet implemented")
-        override val owner: BaseRealmImpl
-            get() = TODO("Not yet implemented")
-        override val schemaMetadata: SchemaMetadata
-            get() = object : SchemaMetadata {
-                override fun get(className: String): ClassMetadata = object : ClassMetadata {
-                    override val classKey: ClassKey
-                        get() = TODO("Not yet implemented")
-                    override val className: String
-                        get() = TODO("Not yet implemented")
-                    override val primaryKeyPropertyKey: PropertyKey?
-                        get() = TODO("Not yet implemented")
-
-                    override fun get(propertyKey: PropertyKey): PropertyInfo? {
-                        TODO("Not yet implemented")
-                    }
-
-                    override fun get(propertyName: String): PropertyInfo? {
-                        TODO("Not yet implemented")
-                    }
-                }
-            }
-    }
-
-    private val dummyMediator = object : Mediator {
-        override fun companionOf(clazz: KClass<out RealmObject>): RealmObjectCompanion {
-            TODO("Not yet implemented")
-        }
-
-        override fun createInstanceOf(clazz: KClass<out RealmObject>): RealmObjectInternal {
-            TODO("Not yet implemented")
-        }
-    }
-
     /**
      * Wrapping conventions around test cases.
      *
@@ -155,10 +119,10 @@ class GenerationExtensionTest {
 
         val realmObjectReference = RealmObjectReference(
             type = RealmObject::class,
-            objectPointer = LongPointer(0xCAFEBABE),
+            objectPointer = DummyLongPointer(0xCAFEBABE),
             className = "Sample",
-            owner = dummyRealmReference,
-            mediator = dummyMediator
+            owner = MockRealmReference(),
+            mediator = MockMediator()
         )
 
         // Accessing getters/setters
@@ -276,12 +240,12 @@ class GenerationExtensionTest {
         @Suppress("UNCHECKED_CAST")
         sampleModel.`$realm$objectReference` = RealmObjectReference(
             type = RealmObject::class,
-            objectPointer = LongPointer(0xCAFEBABE), // If we don't specify a pointer the cinerop call will NPE
+            objectPointer = DummyLongPointer(0xCAFEBABE), // If we don't specify a pointer the cinerop call will NPE
             // Cannot initialize a RealmReference without a model, so skipping this from the test
             // sampleModel.owner = LongPointer(0XCAFED00D)
             className = "Sample",
-            owner = dummyRealmReference,
-            mediator = dummyMediator
+            owner = MockRealmReference(),
+            mediator = MockMediator()
         )
 
         // FIXME Bypass actual setter/getter invocation as it requires actual JNI compilation of
@@ -335,5 +299,36 @@ class GenerationExtensionTest {
         }
     }
 
-    class LongPointer(val ptr: Long) : NativePointer
+    class DummyLongPointer(val ptr: Long) : NativePointer
+    class MockRealmReference : RealmReference {
+        override val dbPointer: NativePointer
+            get() = TODO("Not yet implemented")
+        override val owner: BaseRealmImpl
+            get() = TODO("Not yet implemented")
+        override val schemaMetadata: SchemaMetadata
+            get() = object : SchemaMetadata {
+                override fun get(className: String): ClassMetadata = object : ClassMetadata {
+                    override val classKey: ClassKey
+                        get() = TODO("Not yet implemented")
+                    override val className: String
+                        get() = TODO("Not yet implemented")
+                    override val primaryKeyPropertyKey: PropertyKey?
+                        get() = TODO("Not yet implemented")
+                    override fun get(propertyKey: PropertyKey): PropertyInfo? {
+                        TODO("Not yet implemented")
+                    }
+                    override fun get(propertyName: String): PropertyInfo? {
+                        TODO("Not yet implemented")
+                    }
+                }
+            }
+    }
+    class MockMediator : Mediator {
+        override fun companionOf(clazz: KClass<out RealmObject>): RealmObjectCompanion {
+            TODO("Not yet implemented")
+        }
+        override fun createInstanceOf(clazz: KClass<out RealmObject>): RealmObjectInternal {
+            TODO("Not yet implemented")
+        }
+    }
 }

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
@@ -21,9 +21,9 @@ import com.tschuchort.compiletesting.SourceFile
 import io.realm.RealmObject
 import io.realm.internal.BaseRealmImpl
 import io.realm.internal.Mediator
-import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmObjectCompanion
 import io.realm.internal.RealmObjectInternal
+import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmReference
 import io.realm.internal.interop.ClassKey
 import io.realm.internal.interop.NativePointer

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/compiler/GenerationExtensionTest.kt
@@ -21,7 +21,7 @@ import com.tschuchort.compiletesting.SourceFile
 import io.realm.RealmObject
 import io.realm.internal.BaseRealmImpl
 import io.realm.internal.Mediator
-import io.realm.internal.ObjectReference
+import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmObjectCompanion
 import io.realm.internal.RealmObjectInternal
 import io.realm.internal.RealmReference
@@ -154,7 +154,7 @@ class GenerationExtensionTest {
         assertNull(sampleModel.`$realm$objectReference`)
         // Accessing getters/setters
         @Suppress("UNCHECKED_CAST")
-        sampleModel.`$realm$objectReference` = ObjectReference(
+        sampleModel.`$realm$objectReference` = RealmObjectReference(
             type = RealmObject::class,
             objectPointer = LongPointer(0xCAFEBABE),
             // Cannot initialize a RealmReference without a model, so skipping this from the test
@@ -279,7 +279,7 @@ class GenerationExtensionTest {
         assertEquals("Realm", nameProperty.call(sampleModel))
 
         @Suppress("UNCHECKED_CAST")
-        sampleModel.`$realm$objectReference` = ObjectReference(
+        sampleModel.`$realm$objectReference` = RealmObjectReference(
             type = RealmObject::class,
             objectPointer = LongPointer(0xCAFEBABE), // If we don't specify a pointer the cinerop call will NPE
             // Cannot initialize a RealmReference without a model, so skipping this from the test

--- a/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
@@ -20,45 +20,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-id> (): kotlin.Long declared in sample.input.Sample'
               BLOCK type=kotlin.Long origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Long origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Long origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Long
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="id"
         FUN name:<set-id> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Long) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:id visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Long
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="id"
                   value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
       PROPERTY name:ignoredString visibility:public modality:FINAL [var]
@@ -115,45 +115,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-stringField> (): kotlin.String? declared in sample.input.Sample'
               BLOCK type=kotlin.String? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.String? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.String? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="stringField"
         FUN name:<set-stringField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.String?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:stringField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.String?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="stringField"
                   value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
       PROPERTY name:byteField visibility:public modality:FINAL [var]
@@ -166,13 +166,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-byteField> (): kotlin.Byte? declared in sample.input.Sample'
               BLOCK type=kotlin.Byte? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Byte? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Byte? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
@@ -181,10 +181,10 @@ MODULE_FRAGMENT name:<main>
                     then: BLOCK type=kotlin.Byte? origin=null
                       BLOCK type=kotlin.Byte? origin=SAFE_CALL
                         VAR IR_TEMPORARY_VARIABLE name:tmp1_coreValue type:kotlin.Any? [val]
-                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                             <R>: kotlin.Byte?
                             $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                             propertyName: CONST String type=kotlin.String value="byteField"
                         WHEN type=kotlin.Byte? origin=null
                           BRANCH
@@ -201,23 +201,23 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Byte?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Byte?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="byteField"
                   value: WHEN type=kotlin.Long? origin=null
                     BRANCH
@@ -239,13 +239,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-charField> (): kotlin.Char? declared in sample.input.Sample'
               BLOCK type=kotlin.Char? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Char? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Char? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
@@ -254,10 +254,10 @@ MODULE_FRAGMENT name:<main>
                     then: BLOCK type=kotlin.Char? origin=null
                       BLOCK type=kotlin.Char? origin=SAFE_CALL
                         VAR IR_TEMPORARY_VARIABLE name:tmp1_coreValue type:kotlin.Any? [val]
-                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                             <R>: kotlin.Char?
                             $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                             propertyName: CONST String type=kotlin.String value="charField"
                         WHEN type=kotlin.Char? origin=null
                           BRANCH
@@ -274,23 +274,23 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Char?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Char?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="charField"
                   value: WHEN type=kotlin.Long? origin=null
                     BRANCH
@@ -312,13 +312,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-shortField> (): kotlin.Short? declared in sample.input.Sample'
               BLOCK type=kotlin.Short? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Short? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Short? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
@@ -327,10 +327,10 @@ MODULE_FRAGMENT name:<main>
                     then: BLOCK type=kotlin.Short? origin=null
                       BLOCK type=kotlin.Short? origin=SAFE_CALL
                         VAR IR_TEMPORARY_VARIABLE name:tmp1_coreValue type:kotlin.Any? [val]
-                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                             <R>: kotlin.Short?
                             $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                             propertyName: CONST String type=kotlin.String value="shortField"
                         WHEN type=kotlin.Short? origin=null
                           BRANCH
@@ -347,23 +347,23 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Short?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Short?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="shortField"
                   value: WHEN type=kotlin.Long? origin=null
                     BRANCH
@@ -387,13 +387,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-intField> (): kotlin.Int? declared in sample.input.Sample'
               BLOCK type=kotlin.Int? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Int? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Int? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
@@ -402,10 +402,10 @@ MODULE_FRAGMENT name:<main>
                     then: BLOCK type=kotlin.Int? origin=null
                       BLOCK type=kotlin.Int? origin=SAFE_CALL
                         VAR IR_TEMPORARY_VARIABLE name:tmp1_coreValue type:kotlin.Any? [val]
-                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                             <R>: kotlin.Int?
                             $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                             propertyName: CONST String type=kotlin.String value="intField"
                         WHEN type=kotlin.Int? origin=null
                           BRANCH
@@ -422,23 +422,23 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Int?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="intField"
                   value: WHEN type=kotlin.Long? origin=null
                     BRANCH
@@ -460,45 +460,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-longField> (): kotlin.Long? declared in sample.input.Sample'
               BLOCK type=kotlin.Long? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Long? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Long? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Long?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="longField"
         FUN name:<set-longField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Long?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:longField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Long?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="longField"
                   value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
       PROPERTY name:booleanField visibility:public modality:FINAL [var]
@@ -511,45 +511,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-booleanField> (): kotlin.Boolean? declared in sample.input.Sample'
               BLOCK type=kotlin.Boolean? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Boolean? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Boolean? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Boolean?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="booleanField"
         FUN name:<set-booleanField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Boolean?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:booleanField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Boolean?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="booleanField"
                   value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
       PROPERTY name:floatField visibility:public modality:FINAL [var]
@@ -562,45 +562,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-floatField> (): kotlin.Float? declared in sample.input.Sample'
               BLOCK type=kotlin.Float? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Float? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Float? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Float?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="floatField"
         FUN name:<set-floatField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Float?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:floatField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Float?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Float?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="floatField"
                   value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
       PROPERTY name:doubleField visibility:public modality:FINAL [var]
@@ -613,45 +613,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-doubleField> (): kotlin.Double? declared in sample.input.Sample'
               BLOCK type=kotlin.Double? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Double? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Double? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Double?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="doubleField"
         FUN name:<set-doubleField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Double?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:doubleField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Double?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.Double?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="doubleField"
                   value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
       PROPERTY name:timestampField visibility:public modality:FINAL [var]
@@ -667,45 +667,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-timestampField> (): io.realm.RealmInstant? declared in sample.input.Sample'
               BLOCK type=io.realm.RealmInstant? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmInstant? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private' type=io.realm.RealmInstant? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getTimestamp <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.RealmInstant? declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmInstant? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getTimestamp <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.RealmInstant? declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmInstant? origin=GET_PROPERTY
                       <R>: io.realm.RealmInstant?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="timestampField"
         FUN name:<set-timestampField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmInstant?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:timestampField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmInstant?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setTimestamp <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: io.realm.RealmInstant?): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setTimestamp <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: io.realm.RealmInstant?): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: io.realm.RealmInstant?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="timestampField"
                   value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
       PROPERTY name:child visibility:public modality:FINAL [var]
@@ -718,45 +718,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-child> (): sample.input.Child? declared in sample.input.Sample'
               BLOCK type=sample.input.Child? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
                 WHEN type=sample.input.Child? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=sample.input.Child? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getObject <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getObject <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: sample.input.Child?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="child"
         FUN name:<set-child> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:sample.input.Child?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:child visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:sample.input.Child?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setObject <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setObject?): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setObject <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setObject?): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: sample.input.Child?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="child"
                   value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
       PROPERTY name:stringListField visibility:public modality:FINAL [var]
@@ -770,45 +770,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-stringListField> (): io.realm.RealmList<kotlin.String> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.String> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.String> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private' type=io.realm.RealmList<kotlin.String> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.String
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="stringListField"
         FUN name:<set-stringListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.String>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:stringListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.String>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.String
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="stringListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
       PROPERTY name:byteListField visibility:public modality:FINAL [var]
@@ -822,45 +822,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-byteListField> (): io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Byte> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Byte> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private' type=io.realm.RealmList<kotlin.Byte> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Byte
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="byteListField"
         FUN name:<set-byteListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Byte>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:byteListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Byte>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Byte
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="byteListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
       PROPERTY name:charListField visibility:public modality:FINAL [var]
@@ -874,45 +874,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-charListField> (): io.realm.RealmList<kotlin.Char> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Char> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Char> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private' type=io.realm.RealmList<kotlin.Char> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Char
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="charListField"
         FUN name:<set-charListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Char>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:charListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Char>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Char
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="charListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
       PROPERTY name:shortListField visibility:public modality:FINAL [var]
@@ -926,45 +926,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-shortListField> (): io.realm.RealmList<kotlin.Short> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Short> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Short> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private' type=io.realm.RealmList<kotlin.Short> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Short
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="shortListField"
         FUN name:<set-shortListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Short>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:shortListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Short>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Short
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="shortListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
       PROPERTY name:intListField visibility:public modality:FINAL [var]
@@ -978,45 +978,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-intListField> (): io.realm.RealmList<kotlin.Int> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Int> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Int> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private' type=io.realm.RealmList<kotlin.Int> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Int
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="intListField"
         FUN name:<set-intListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Int>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:intListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Int>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Int
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="intListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
       PROPERTY name:longListField visibility:public modality:FINAL [var]
@@ -1030,45 +1030,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-longListField> (): io.realm.RealmList<kotlin.Long> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Long> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Long> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private' type=io.realm.RealmList<kotlin.Long> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Long
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="longListField"
         FUN name:<set-longListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Long>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:longListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Long>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Long
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="longListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
       PROPERTY name:booleanListField visibility:public modality:FINAL [var]
@@ -1082,45 +1082,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-booleanListField> (): io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Boolean> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Boolean> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private' type=io.realm.RealmList<kotlin.Boolean> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Boolean
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="booleanListField"
         FUN name:<set-booleanListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Boolean>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:booleanListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Boolean>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Boolean
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="booleanListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
       PROPERTY name:floatListField visibility:public modality:FINAL [var]
@@ -1134,45 +1134,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-floatListField> (): io.realm.RealmList<kotlin.Float> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Float> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Float> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private' type=io.realm.RealmList<kotlin.Float> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Float
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="floatListField"
         FUN name:<set-floatListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Float>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:floatListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Float>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Float
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="floatListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
       PROPERTY name:doubleListField visibility:public modality:FINAL [var]
@@ -1186,45 +1186,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-doubleListField> (): io.realm.RealmList<kotlin.Double> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Double> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Double> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private' type=io.realm.RealmList<kotlin.Double> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Double
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="doubleListField"
         FUN name:<set-doubleListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Double>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:doubleListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Double>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Double
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="doubleListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
       PROPERTY name:timestampListField visibility:public modality:FINAL [var]
@@ -1238,45 +1238,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-timestampListField> (): io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<io.realm.RealmInstant> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<io.realm.RealmInstant> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: io.realm.RealmInstant
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="timestampListField"
         FUN name:<set-timestampListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<io.realm.RealmInstant>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:timestampListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<io.realm.RealmInstant>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: io.realm.RealmInstant
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="timestampListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
       PROPERTY name:objectListField visibility:public modality:FINAL [var]
@@ -1290,45 +1290,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-objectListField> (): io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<sample.input.Sample> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<sample.input.Sample> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private' type=io.realm.RealmList<sample.input.Sample> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: sample.input.Sample
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="objectListField"
         FUN name:<set-objectListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<sample.input.Sample>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:objectListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<sample.input.Sample>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: sample.input.Sample
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="objectListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
       PROPERTY name:nullableStringListField visibility:public modality:FINAL [var]
@@ -1342,45 +1342,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableStringListField> (): io.realm.RealmList<kotlin.String?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.String?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.String?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private' type=io.realm.RealmList<kotlin.String?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableStringListField"
         FUN name:<set-nullableStringListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.String?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableStringListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.String?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.String?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableStringListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
       PROPERTY name:nullableByteListField visibility:public modality:FINAL [var]
@@ -1394,45 +1394,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableByteListField> (): io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Byte?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Byte?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private' type=io.realm.RealmList<kotlin.Byte?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Byte?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableByteListField"
         FUN name:<set-nullableByteListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Byte?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableByteListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Byte?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Byte?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableByteListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
       PROPERTY name:nullableCharListField visibility:public modality:FINAL [var]
@@ -1446,45 +1446,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableCharListField> (): io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Char?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Char?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private' type=io.realm.RealmList<kotlin.Char?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Char?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableCharListField"
         FUN name:<set-nullableCharListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Char?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableCharListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Char?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Char?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableCharListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
       PROPERTY name:nullableShortListField visibility:public modality:FINAL [var]
@@ -1498,45 +1498,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableShortListField> (): io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Short?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Short?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private' type=io.realm.RealmList<kotlin.Short?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Short?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableShortListField"
         FUN name:<set-nullableShortListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Short?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableShortListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Short?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Short?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableShortListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
       PROPERTY name:nullableIntListField visibility:public modality:FINAL [var]
@@ -1550,45 +1550,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableIntListField> (): io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Int?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Int?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private' type=io.realm.RealmList<kotlin.Int?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Int?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableIntListField"
         FUN name:<set-nullableIntListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Int?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableIntListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Int?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Int?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableIntListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
       PROPERTY name:nullableLongListField visibility:public modality:FINAL [var]
@@ -1602,45 +1602,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableLongListField> (): io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Long?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Long?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private' type=io.realm.RealmList<kotlin.Long?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Long?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableLongListField"
         FUN name:<set-nullableLongListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Long?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableLongListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Long?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Long?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableLongListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
       PROPERTY name:nullableBooleanListField visibility:public modality:FINAL [var]
@@ -1654,45 +1654,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableBooleanListField> (): io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Boolean?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Boolean?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private' type=io.realm.RealmList<kotlin.Boolean?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Boolean?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableBooleanListField"
         FUN name:<set-nullableBooleanListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Boolean?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableBooleanListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Boolean?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Boolean?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableBooleanListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
       PROPERTY name:nullableFloatListField visibility:public modality:FINAL [var]
@@ -1706,45 +1706,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableFloatListField> (): io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Float?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Float?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private' type=io.realm.RealmList<kotlin.Float?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Float?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableFloatListField"
         FUN name:<set-nullableFloatListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Float?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableFloatListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Float?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Float?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableFloatListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
       PROPERTY name:nullableDoubleListField visibility:public modality:FINAL [var]
@@ -1758,45 +1758,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableDoubleListField> (): io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<kotlin.Double?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<kotlin.Double?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private' type=io.realm.RealmList<kotlin.Double?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Double?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableDoubleListField"
         FUN name:<set-nullableDoubleListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Double?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableDoubleListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Double?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: kotlin.Double?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableDoubleListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
       PROPERTY name:nullableTimestampListField visibility:public modality:FINAL [var]
@@ -1810,45 +1810,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableTimestampListField> (): io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample'
               BLOCK type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: io.realm.RealmInstant?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableTimestampListField"
         FUN name:<set-nullableTimestampListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<io.realm.RealmInstant?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableTimestampListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<io.realm.RealmInstant?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
                   value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <T>: io.realm.RealmInstant?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   col: CONST String type=kotlin.String value="nullableTimestampListField"
                   list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
       FUN name:dumpSchema visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:kotlin.String
@@ -2350,28 +2350,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                 receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-$realm$objectReference>' type=sample.input.Sample origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-$realm$objectReference>' type=sample.input.Sample origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample.<set-$realm$objectReference>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
     CLASS CLASS name:Child modality:OPEN visibility:public superTypes:[io.realm.RealmObject; io.realm.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
       CONSTRUCTOR visibility:public <> () returnType:sample.input.Child [primary]
@@ -2388,45 +2388,45 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String? declared in sample.input.Child'
               BLOCK type=kotlin.String? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Child' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
                 WHEN type=kotlin.String? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Child.<get-name>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Child.<get-name>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.String? origin=null
                       receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
                   BRANCH
                     if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Child.<get-name>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Child.<get-name>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                       propertyName: CONST String type=kotlin.String value="name"
         FUN name:<set-name> visibility:public modality:FINAL <> ($this:sample.input.Child, <set-?>:kotlin.String?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Child
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Child' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
                 $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
             WHEN type=kotlin.Unit origin=null
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   arg1: CONST Null type=kotlin.Nothing? value=null
                 then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
                   receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
                   value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                   <R>: kotlin.String?
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                   propertyName: CONST String type=kotlin.String value="name"
                   value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
       CLASS OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any; io.realm.internal.RealmObjectCompanion]
@@ -2537,25 +2537,25 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Child'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                 receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-$realm$objectReference>' type=sample.input.Child origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-$realm$objectReference>' type=sample.input.Child origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Child.<set-$realm$objectReference>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null

--- a/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
@@ -42,25 +42,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Long
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="id"
-                  value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Long
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="id"
+                    value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
       PROPERTY name:ignoredString visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:ignoredString type:kotlin.String visibility:private
           annotations:
@@ -137,25 +138,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.String?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="stringField"
-                  value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.String?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="stringField"
+                    value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
       PROPERTY name:byteField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private
           EXPRESSION_BODY
@@ -201,34 +203,35 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Byte?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Byte?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="byteField"
-                  value: WHEN type=kotlin.Long? origin=null
-                    BRANCH
-                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                        arg0: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
-                        arg1: CONST Null type=kotlin.Nothing? value=null
-                      then: CONST Null type=kotlin.Nothing? value=null
-                    BRANCH
-                      if: CONST Boolean type=kotlin.Boolean value=true
-                      then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Byte' type=kotlin.Long origin=null
-                        $this: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Byte?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="byteField"
+                    value: WHEN type=kotlin.Long? origin=null
+                      BRANCH
+                        if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                          arg0: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
+                          arg1: CONST Null type=kotlin.Nothing? value=null
+                        then: CONST Null type=kotlin.Nothing? value=null
+                      BRANCH
+                        if: CONST Boolean type=kotlin.Boolean value=true
+                        then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Byte' type=kotlin.Long origin=null
+                          $this: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
       PROPERTY name:charField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private
           EXPRESSION_BODY
@@ -274,34 +277,35 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Char?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Char?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="charField"
-                  value: WHEN type=kotlin.Long? origin=null
-                    BRANCH
-                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                        arg0: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
-                        arg1: CONST Null type=kotlin.Nothing? value=null
-                      then: CONST Null type=kotlin.Nothing? value=null
-                    BRANCH
-                      if: CONST Boolean type=kotlin.Boolean value=true
-                      then: CALL 'public final fun toLong (): kotlin.Long declared in kotlin.Char' type=kotlin.Long origin=null
-                        $this: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Char?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="charField"
+                    value: WHEN type=kotlin.Long? origin=null
+                      BRANCH
+                        if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                          arg0: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
+                          arg1: CONST Null type=kotlin.Nothing? value=null
+                        then: CONST Null type=kotlin.Nothing? value=null
+                      BRANCH
+                        if: CONST Boolean type=kotlin.Boolean value=true
+                        then: CALL 'public final fun toLong (): kotlin.Long declared in kotlin.Char' type=kotlin.Long origin=null
+                          $this: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
       PROPERTY name:shortField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private
           EXPRESSION_BODY
@@ -347,34 +351,35 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Short?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Short?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="shortField"
-                  value: WHEN type=kotlin.Long? origin=null
-                    BRANCH
-                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                        arg0: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
-                        arg1: CONST Null type=kotlin.Nothing? value=null
-                      then: CONST Null type=kotlin.Nothing? value=null
-                    BRANCH
-                      if: CONST Boolean type=kotlin.Boolean value=true
-                      then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Short' type=kotlin.Long origin=null
-                        $this: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Short?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="shortField"
+                    value: WHEN type=kotlin.Long? origin=null
+                      BRANCH
+                        if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                          arg0: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
+                          arg1: CONST Null type=kotlin.Nothing? value=null
+                        then: CONST Null type=kotlin.Nothing? value=null
+                      BRANCH
+                        if: CONST Boolean type=kotlin.Boolean value=true
+                        then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Short' type=kotlin.Long origin=null
+                          $this: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
       PROPERTY name:intField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private
           annotations:
@@ -422,34 +427,35 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Int?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="intField"
-                  value: WHEN type=kotlin.Long? origin=null
-                    BRANCH
-                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                        arg0: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
-                        arg1: CONST Null type=kotlin.Nothing? value=null
-                      then: CONST Null type=kotlin.Nothing? value=null
-                    BRANCH
-                      if: CONST Boolean type=kotlin.Boolean value=true
-                      then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Int' type=kotlin.Long origin=null
-                        $this: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Int?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="intField"
+                    value: WHEN type=kotlin.Long? origin=null
+                      BRANCH
+                        if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                          arg0: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
+                          arg1: CONST Null type=kotlin.Nothing? value=null
+                        then: CONST Null type=kotlin.Nothing? value=null
+                      BRANCH
+                        if: CONST Boolean type=kotlin.Boolean value=true
+                        then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Int' type=kotlin.Long origin=null
+                          $this: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
       PROPERTY name:longField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private
           EXPRESSION_BODY
@@ -482,25 +488,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Long?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="longField"
-                  value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Long?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="longField"
+                    value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
       PROPERTY name:booleanField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private
           EXPRESSION_BODY
@@ -533,25 +540,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Boolean?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="booleanField"
-                  value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Boolean?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="booleanField"
+                    value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
       PROPERTY name:floatField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private
           EXPRESSION_BODY
@@ -584,25 +592,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Float?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Float?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="floatField"
-                  value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Float?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="floatField"
+                    value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
       PROPERTY name:doubleField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private
           EXPRESSION_BODY
@@ -635,25 +644,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Double?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.Double?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="doubleField"
-                  value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.Double?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="doubleField"
+                    value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
       PROPERTY name:timestampField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private
           EXPRESSION_BODY
@@ -689,25 +699,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmInstant?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setTimestamp <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: io.realm.RealmInstant?): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: io.realm.RealmInstant?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="timestampField"
-                  value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setTimestamp <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: io.realm.RealmInstant?): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: io.realm.RealmInstant?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="timestampField"
+                    value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
       PROPERTY name:child visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private
           EXPRESSION_BODY
@@ -740,25 +751,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:sample.input.Child?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setObject <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setObject?): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: sample.input.Child?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="child"
-                  value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setObject <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setObject?): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: sample.input.Child?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="child"
+                    value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
       PROPERTY name:stringListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private
           EXPRESSION_BODY
@@ -792,25 +804,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.String>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.String
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="stringListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.String
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="stringListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
       PROPERTY name:byteListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private
           EXPRESSION_BODY
@@ -844,25 +857,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Byte>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Byte
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="byteListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Byte
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="byteListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
       PROPERTY name:charListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private
           EXPRESSION_BODY
@@ -896,25 +910,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Char>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Char
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="charListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Char
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="charListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
       PROPERTY name:shortListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private
           EXPRESSION_BODY
@@ -948,25 +963,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Short>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Short
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="shortListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Short
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="shortListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
       PROPERTY name:intListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private
           EXPRESSION_BODY
@@ -1000,25 +1016,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Int>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Int
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="intListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Int
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="intListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
       PROPERTY name:longListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private
           EXPRESSION_BODY
@@ -1052,25 +1069,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Long>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Long
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="longListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Long
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="longListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
       PROPERTY name:booleanListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private
           EXPRESSION_BODY
@@ -1104,25 +1122,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Boolean>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Boolean
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="booleanListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Boolean
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="booleanListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
       PROPERTY name:floatListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private
           EXPRESSION_BODY
@@ -1156,25 +1175,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Float>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Float
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="floatListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Float
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="floatListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
       PROPERTY name:doubleListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private
           EXPRESSION_BODY
@@ -1208,25 +1228,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Double>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Double
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="doubleListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Double
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="doubleListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
       PROPERTY name:timestampListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private
           EXPRESSION_BODY
@@ -1260,25 +1281,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<io.realm.RealmInstant>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: io.realm.RealmInstant
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="timestampListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: io.realm.RealmInstant
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="timestampListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
       PROPERTY name:objectListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private
           EXPRESSION_BODY
@@ -1312,25 +1334,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<sample.input.Sample>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: sample.input.Sample
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="objectListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: sample.input.Sample
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="objectListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
       PROPERTY name:nullableStringListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private
           EXPRESSION_BODY
@@ -1364,25 +1387,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.String?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.String?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableStringListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.String?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableStringListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
       PROPERTY name:nullableByteListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private
           EXPRESSION_BODY
@@ -1416,25 +1440,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Byte?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Byte?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableByteListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Byte?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableByteListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
       PROPERTY name:nullableCharListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private
           EXPRESSION_BODY
@@ -1468,25 +1493,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Char?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Char?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableCharListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Char?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableCharListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
       PROPERTY name:nullableShortListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private
           EXPRESSION_BODY
@@ -1520,25 +1546,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Short?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Short?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableShortListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Short?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableShortListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
       PROPERTY name:nullableIntListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private
           EXPRESSION_BODY
@@ -1572,25 +1599,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Int?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Int?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableIntListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Int?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableIntListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
       PROPERTY name:nullableLongListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private
           EXPRESSION_BODY
@@ -1624,25 +1652,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Long?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Long?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableLongListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Long?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableLongListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
       PROPERTY name:nullableBooleanListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private
           EXPRESSION_BODY
@@ -1676,25 +1705,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Boolean?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Boolean?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableBooleanListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Boolean?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableBooleanListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
       PROPERTY name:nullableFloatListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private
           EXPRESSION_BODY
@@ -1728,25 +1758,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Float?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Float?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableFloatListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Float?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableFloatListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
       PROPERTY name:nullableDoubleListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private
           EXPRESSION_BODY
@@ -1780,25 +1811,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Double?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: kotlin.Double?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableDoubleListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: kotlin.Double?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableDoubleListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
       PROPERTY name:nullableTimestampListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private
           EXPRESSION_BODY
@@ -1832,25 +1864,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<io.realm.RealmInstant?>
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
-                  value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <T>: io.realm.RealmInstant?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  col: CONST String type=kotlin.String value="nullableTimestampListField"
-                  list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <T>: io.realm.RealmInstant?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    col: CONST String type=kotlin.String value="nullableTimestampListField"
+                    list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
       FUN name:dumpSchema visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:kotlin.String
         $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
         BLOCK_BODY
@@ -2410,25 +2443,26 @@ MODULE_FRAGMENT name:<main>
           $this: VALUE_PARAMETER name:<this> type:sample.input.Child
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
-            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
-              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Child' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
-                $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
-            WHEN type=kotlin.Unit origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-                  receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
-                  value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                  <R>: kotlin.String?
-                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
-                  propertyName: CONST String type=kotlin.String value="name"
-                  value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val]
+                CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in sample.input.Child' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
+                    value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    <R>: kotlin.String?
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
+                    propertyName: CONST String type=kotlin.String value="name"
+                    value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
       CLASS OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any; io.realm.internal.RealmObjectCompanion]
         $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child.Companion
         CONSTRUCTOR visibility:private <> () returnType:sample.input.Child.Companion [primary]

--- a/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
@@ -22,8 +22,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-id> (): kotlin.Long declared in sample.input.Sample'
                 WHEN type=kotlin.Long origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Long
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -42,8 +45,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-id> (<set-?>: kotlin.Long): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Long
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -111,8 +117,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-stringField> (): kotlin.String? declared in sample.input.Sample'
                 WHEN type=kotlin.String? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -131,8 +140,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-stringField> (<set-?>: kotlin.String?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -156,8 +168,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-byteField> (): kotlin.Byte? declared in sample.input.Sample'
                 WHEN type=kotlin.Byte? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: BLOCK type=kotlin.Byte? origin=null
                       BLOCK type=kotlin.Byte? origin=SAFE_CALL
                         VAR IR_TEMPORARY_VARIABLE name:tmp0_coreValue type:kotlin.Any? [val]
@@ -189,8 +204,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-byteField> (<set-?>: kotlin.Byte?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Byte?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -223,8 +241,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-charField> (): kotlin.Char? declared in sample.input.Sample'
                 WHEN type=kotlin.Char? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: BLOCK type=kotlin.Char? origin=null
                       BLOCK type=kotlin.Char? origin=SAFE_CALL
                         VAR IR_TEMPORARY_VARIABLE name:tmp0_coreValue type:kotlin.Any? [val]
@@ -256,8 +277,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-charField> (<set-?>: kotlin.Char?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Char?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -290,8 +314,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-shortField> (): kotlin.Short? declared in sample.input.Sample'
                 WHEN type=kotlin.Short? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: BLOCK type=kotlin.Short? origin=null
                       BLOCK type=kotlin.Short? origin=SAFE_CALL
                         VAR IR_TEMPORARY_VARIABLE name:tmp0_coreValue type:kotlin.Any? [val]
@@ -323,8 +350,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-shortField> (<set-?>: kotlin.Short?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Short?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -359,8 +389,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-intField> (): kotlin.Int? declared in sample.input.Sample'
                 WHEN type=kotlin.Int? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: BLOCK type=kotlin.Int? origin=null
                       BLOCK type=kotlin.Int? origin=SAFE_CALL
                         VAR IR_TEMPORARY_VARIABLE name:tmp0_coreValue type:kotlin.Any? [val]
@@ -392,8 +425,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-intField> (<set-?>: kotlin.Int?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Int?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -426,8 +462,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-longField> (): kotlin.Long? declared in sample.input.Sample'
                 WHEN type=kotlin.Long? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Long?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -446,8 +485,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-longField> (<set-?>: kotlin.Long?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Long?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -471,8 +513,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-booleanField> (): kotlin.Boolean? declared in sample.input.Sample'
                 WHEN type=kotlin.Boolean? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Boolean?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -491,8 +536,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-booleanField> (<set-?>: kotlin.Boolean?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Boolean?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -516,8 +564,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-floatField> (): kotlin.Float? declared in sample.input.Sample'
                 WHEN type=kotlin.Float? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Float?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -536,8 +587,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-floatField> (<set-?>: kotlin.Float?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Float?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -561,8 +615,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-doubleField> (): kotlin.Double? declared in sample.input.Sample'
                 WHEN type=kotlin.Double? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.Double?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -581,8 +638,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-doubleField> (<set-?>: kotlin.Double?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.Double?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -609,8 +669,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-timestampField> (): io.realm.RealmInstant? declared in sample.input.Sample'
                 WHEN type=io.realm.RealmInstant? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getTimestamp <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmInstant? declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmInstant? origin=GET_PROPERTY
                       <R>: io.realm.RealmInstant?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -629,8 +692,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-timestampField> (<set-?>: io.realm.RealmInstant?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setTimestamp <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: io.realm.RealmInstant?): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: io.realm.RealmInstant?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -654,8 +720,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-child> (): sample.input.Child? declared in sample.input.Sample'
                 WHEN type=sample.input.Child? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getObject <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: sample.input.Child?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -674,8 +743,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-child> (<set-?>: sample.input.Child?): kotlin.Unit declared in sample.input.Sample'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setObject <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setObject?): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: sample.input.Child?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -700,8 +772,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-stringListField> (): io.realm.RealmList<kotlin.String> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.String> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.String
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -732,8 +807,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-byteListField> (): io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Byte> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Byte
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -764,8 +842,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-charListField> (): io.realm.RealmList<kotlin.Char> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Char> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Char
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -796,8 +877,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-shortListField> (): io.realm.RealmList<kotlin.Short> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Short> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Short
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -828,8 +912,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-intListField> (): io.realm.RealmList<kotlin.Int> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Int> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Int
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -860,8 +947,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-longListField> (): io.realm.RealmList<kotlin.Long> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Long> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Long
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -892,8 +982,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-booleanListField> (): io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Boolean> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Boolean
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -924,8 +1017,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-floatListField> (): io.realm.RealmList<kotlin.Float> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Float> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Float
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -956,8 +1052,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-doubleListField> (): io.realm.RealmList<kotlin.Double> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Double> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Double
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -988,8 +1087,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-timestampListField> (): io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<io.realm.RealmInstant> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: io.realm.RealmInstant
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1020,8 +1122,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-objectListField> (): io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<sample.input.Sample> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: sample.input.Sample
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1052,8 +1157,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableStringListField> (): io.realm.RealmList<kotlin.String?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.String?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1084,8 +1192,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableByteListField> (): io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Byte?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Byte?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1116,8 +1227,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableCharListField> (): io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Char?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Char?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1148,8 +1262,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableShortListField> (): io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Short?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Short?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1180,8 +1297,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableIntListField> (): io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Int?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Int?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1212,8 +1332,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableLongListField> (): io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Long?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Long?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1244,8 +1367,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableBooleanListField> (): io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Boolean?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Boolean?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1276,8 +1402,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableFloatListField> (): io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Float?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Float?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1308,8 +1437,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableDoubleListField> (): io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<kotlin.Double?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Double?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1340,8 +1472,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-nullableTimestampListField> (): io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample'
                 WHEN type=io.realm.RealmList<io.realm.RealmInstant?> origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: io.realm.RealmInstant?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -1857,193 +1992,29 @@ MODULE_FRAGMENT name:<main>
         overridden:
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private
+      PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.internal.interop.NativePointer?
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? declared in sample.input.Sample'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=io.realm.internal.interop.NativePointer? origin=null
-                receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-$realm$ObjectPointer>' type=sample.input.Sample origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.internal.interop.NativePointer?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-$realm$objectReference>' type=sample.input.Sample origin=null
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$ObjectPointer> (<set-?>: io.realm.internal.interop.NativePointer?): kotlin.Unit [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.interop.NativePointer?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-$realm$ObjectPointer>' type=sample.input.Sample origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.interop.NativePointer? declared in sample.input.Sample.<set-$realm$ObjectPointer>' type=io.realm.internal.interop.NativePointer? origin=null
-      PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Owner> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.internal.RealmReference?
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in sample.input.Sample'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=io.realm.internal.RealmReference? origin=null
-                receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-$realm$Owner>' type=sample.input.Sample origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Owner> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.internal.RealmReference?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Owner> (<set-?>: io.realm.internal.RealmReference?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmReference?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-$realm$Owner>' type=sample.input.Sample origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.RealmReference? declared in sample.input.Sample.<set-$realm$Owner>' type=io.realm.internal.RealmReference? origin=null
-      PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ClassName> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:kotlin.String?
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$ClassName> (): kotlin.String? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ClassName> (): kotlin.String? declared in sample.input.Sample'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.String? origin=null
-                receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-$realm$ClassName>' type=sample.input.Sample origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ClassName> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:kotlin.String?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$ClassName> (<set-?>: kotlin.String?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-$realm$ClassName>' type=sample.input.Sample origin=null
-              value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-$realm$ClassName>' type=kotlin.String? origin=null
-      PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private
-          EXPRESSION_BODY
-            CONST Boolean type=kotlin.Boolean value=false
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$IsManaged> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:kotlin.Boolean
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$IsManaged> (): kotlin.Boolean declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Sample'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Boolean origin=null
-                receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-$realm$IsManaged>' type=sample.input.Sample origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$IsManaged> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:kotlin.Boolean) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$IsManaged> (<set-?>: kotlin.Boolean): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-$realm$IsManaged>' type=sample.input.Sample origin=null
-              value: GET_VAR '<set-?>: kotlin.Boolean declared in sample.input.Sample.<set-$realm$IsManaged>' type=kotlin.Boolean origin=null
-      PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Mediator> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.internal.Mediator?
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in sample.input.Sample'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=io.realm.internal.Mediator? origin=null
-                receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-$realm$Mediator>' type=sample.input.Sample origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Mediator> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.internal.Mediator?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Mediator> (<set-?>: io.realm.internal.Mediator?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.Mediator?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-$realm$Mediator>' type=sample.input.Sample origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.Mediator? declared in sample.input.Sample.<set-$realm$Mediator>' type=io.realm.internal.Mediator? origin=null
-      PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$metadata> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.internal.schema.ClassMetadata?
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in sample.input.Sample'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=io.realm.internal.schema.ClassMetadata? origin=null
-                receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-$realm$metadata>' type=sample.input.Sample origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$metadata> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.internal.schema.ClassMetadata?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$metadata> (<set-?>: io.realm.internal.schema.ClassMetadata?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.schema.ClassMetadata?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-$realm$metadata>' type=sample.input.Sample origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.schema.ClassMetadata? declared in sample.input.Sample.<set-$realm$metadata>' type=io.realm.internal.schema.ClassMetadata? origin=null
-      FUN FAKE_OVERRIDE name:delete visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Unit [fake_override]
-        overridden:
-          public open fun delete (): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:emitFrozenUpdate visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference, change:io.realm.internal.interop.NativePointer, channel:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>) returnType:kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? [fake_override]
-        overridden:
-          public open fun emitFrozenUpdate (frozenRealm: io.realm.internal.RealmReference, change: io.realm.internal.interop.NativePointer, channel: kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>): kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:change index:1 type:io.realm.internal.interop.NativePointer
-        VALUE_PARAMETER name:channel index:2 type:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>
-      FUN FAKE_OVERRIDE name:freeze visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun freeze (frozenRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:isFrozen visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Boolean [fake_override]
-        overridden:
-          public open fun isFrozen (): kotlin.Boolean [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:propertyInfoOrThrow visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, propertyName:kotlin.String) returnType:io.realm.internal.interop.PropertyInfo [fake_override]
-        overridden:
-          public open fun propertyInfoOrThrow (propertyName: kotlin.String): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:propertyName index:0 type:kotlin.String
-      FUN FAKE_OVERRIDE name:realmState visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.internal.RealmState [fake_override]
-        overridden:
-          public open fun realmState (): io.realm.internal.RealmState declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:registerForNotification visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, callback:io.realm.internal.interop.Callback) returnType:io.realm.internal.interop.NativePointer [fake_override]
-        overridden:
-          public open fun registerForNotification (callback: io.realm.internal.interop.Callback): io.realm.internal.interop.NativePointer declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:callback index:0 type:io.realm.internal.interop.Callback
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference, clazz:kotlin.reflect.KClass<out io.realm.RealmObject>) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference, clazz: kotlin.reflect.KClass<out io.realm.RealmObject>): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:clazz index:1 type:kotlin.reflect.KClass<out io.realm.RealmObject>
-      FUN FAKE_OVERRIDE name:version visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.VersionId [fake_override]
-        overridden:
-          public open fun version (): io.realm.VersionId [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-$realm$objectReference>' type=sample.input.Sample origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
     CLASS CLASS name:Child modality:OPEN visibility:public superTypes:[io.realm.RealmObject; io.realm.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
       CONSTRUCTOR visibility:public <> () returnType:sample.input.Child [primary]
@@ -2062,8 +2033,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String? declared in sample.input.Child'
                 WHEN type=kotlin.String? origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Child' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -2082,8 +2056,11 @@ MODULE_FRAGMENT name:<main>
               RETURN type=kotlin.Nothing from='public final fun <set-name> (<set-?>: kotlin.String?): kotlin.Unit declared in sample.input.Child'
                 WHEN type=kotlin.Unit origin=IF
                   BRANCH
-                    if: CALL 'public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Child' type=kotlin.Boolean origin=GET_PROPERTY
-                      $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
+                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCL
+                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                          $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
                     then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
@@ -2202,190 +2179,26 @@ MODULE_FRAGMENT name:<main>
         overridden:
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private
+      PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.internal.interop.NativePointer?
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? declared in sample.input.Child'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=io.realm.internal.interop.NativePointer? origin=null
-                receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-$realm$ObjectPointer>' type=sample.input.Child origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.internal.interop.NativePointer?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-$realm$objectReference>' type=sample.input.Child origin=null
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$ObjectPointer> (<set-?>: io.realm.internal.interop.NativePointer?): kotlin.Unit [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.interop.NativePointer?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-$realm$ObjectPointer>' type=sample.input.Child origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.interop.NativePointer? declared in sample.input.Child.<set-$realm$ObjectPointer>' type=io.realm.internal.interop.NativePointer? origin=null
-      PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Owner> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.internal.RealmReference?
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in sample.input.Child'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=io.realm.internal.RealmReference? origin=null
-                receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-$realm$Owner>' type=sample.input.Child origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Owner> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.internal.RealmReference?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Owner> (<set-?>: io.realm.internal.RealmReference?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmReference?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-$realm$Owner>' type=sample.input.Child origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.RealmReference? declared in sample.input.Child.<set-$realm$Owner>' type=io.realm.internal.RealmReference? origin=null
-      PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ClassName> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:kotlin.String?
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$ClassName> (): kotlin.String? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ClassName> (): kotlin.String? declared in sample.input.Child'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.String? origin=null
-                receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-$realm$ClassName>' type=sample.input.Child origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ClassName> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:kotlin.String?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$ClassName> (<set-?>: kotlin.String?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-$realm$ClassName>' type=sample.input.Child origin=null
-              value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-$realm$ClassName>' type=kotlin.String? origin=null
-      PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private
-          EXPRESSION_BODY
-            CONST Boolean type=kotlin.Boolean value=false
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$IsManaged> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:kotlin.Boolean
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$IsManaged> (): kotlin.Boolean declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in sample.input.Child'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Boolean origin=null
-                receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-$realm$IsManaged>' type=sample.input.Child origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$IsManaged> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:kotlin.Boolean) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$IsManaged> (<set-?>: kotlin.Boolean): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-$realm$IsManaged>' type=sample.input.Child origin=null
-              value: GET_VAR '<set-?>: kotlin.Boolean declared in sample.input.Child.<set-$realm$IsManaged>' type=kotlin.Boolean origin=null
-      PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Mediator> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.internal.Mediator?
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in sample.input.Child'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=io.realm.internal.Mediator? origin=null
-                receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-$realm$Mediator>' type=sample.input.Child origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Mediator> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.internal.Mediator?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Mediator> (<set-?>: io.realm.internal.Mediator?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.Mediator?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-$realm$Mediator>' type=sample.input.Child origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.Mediator? declared in sample.input.Child.<set-$realm$Mediator>' type=io.realm.internal.Mediator? origin=null
-      PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$metadata> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.internal.schema.ClassMetadata?
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in sample.input.Child'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=io.realm.internal.schema.ClassMetadata? origin=null
-                receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-$realm$metadata>' type=sample.input.Child origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$metadata> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.internal.schema.ClassMetadata?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$metadata> (<set-?>: io.realm.internal.schema.ClassMetadata?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.schema.ClassMetadata?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-$realm$metadata>' type=sample.input.Child origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.schema.ClassMetadata? declared in sample.input.Child.<set-$realm$metadata>' type=io.realm.internal.schema.ClassMetadata? origin=null
-      FUN FAKE_OVERRIDE name:delete visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Unit [fake_override]
-        overridden:
-          public open fun delete (): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:emitFrozenUpdate visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference, change:io.realm.internal.interop.NativePointer, channel:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>) returnType:kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? [fake_override]
-        overridden:
-          public open fun emitFrozenUpdate (frozenRealm: io.realm.internal.RealmReference, change: io.realm.internal.interop.NativePointer, channel: kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>): kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:change index:1 type:io.realm.internal.interop.NativePointer
-        VALUE_PARAMETER name:channel index:2 type:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>
-      FUN FAKE_OVERRIDE name:freeze visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun freeze (frozenRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:isFrozen visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Boolean [fake_override]
-        overridden:
-          public open fun isFrozen (): kotlin.Boolean [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:propertyInfoOrThrow visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, propertyName:kotlin.String) returnType:io.realm.internal.interop.PropertyInfo [fake_override]
-        overridden:
-          public open fun propertyInfoOrThrow (propertyName: kotlin.String): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:propertyName index:0 type:kotlin.String
-      FUN FAKE_OVERRIDE name:realmState visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.internal.RealmState [fake_override]
-        overridden:
-          public open fun realmState (): io.realm.internal.RealmState declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:registerForNotification visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, callback:io.realm.internal.interop.Callback) returnType:io.realm.internal.interop.NativePointer [fake_override]
-        overridden:
-          public open fun registerForNotification (callback: io.realm.internal.interop.Callback): io.realm.internal.interop.NativePointer declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:callback index:0 type:io.realm.internal.interop.Callback
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference, clazz:kotlin.reflect.KClass<out io.realm.RealmObject>) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference, clazz: kotlin.reflect.KClass<out io.realm.RealmObject>): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:clazz index:1 type:kotlin.reflect.KClass<out io.realm.RealmObject>
-      FUN FAKE_OVERRIDE name:version visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.VersionId [fake_override]
-        overridden:
-          public open fun version (): io.realm.VersionId [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-$realm$objectReference>' type=sample.input.Child origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null

--- a/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
@@ -18,49 +18,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:id visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-id> (): kotlin.Long declared in sample.input.Sample'
-                WHEN type=kotlin.Long origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-id> (): kotlin.Long declared in sample.input.Sample'
+              BLOCK type=kotlin.Long origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Long origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
-                      <R>: kotlin.Long
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="id"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Long origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                      <R>: kotlin.Long
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="id"
         FUN name:<set-id> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Long) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:id visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-id> (<set-?>: kotlin.Long): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Long
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="id"
-                      value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Long
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="id"
+                  value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
       PROPERTY name:ignoredString visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:ignoredString type:kotlin.String visibility:private
           annotations:
@@ -113,49 +113,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:stringField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-stringField> (): kotlin.String? declared in sample.input.Sample'
-                WHEN type=kotlin.String? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-stringField> (): kotlin.String? declared in sample.input.Sample'
+              BLOCK type=kotlin.String? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.String? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
-                      <R>: kotlin.String?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="stringField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.String? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                      <R>: kotlin.String?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="stringField"
         FUN name:<set-stringField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.String?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:stringField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-stringField> (<set-?>: kotlin.String?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.String?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="stringField"
-                      value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.String?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="stringField"
+                  value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
       PROPERTY name:byteField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private
           EXPRESSION_BODY
@@ -164,71 +164,71 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:byteField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-byteField> (): kotlin.Byte? declared in sample.input.Sample'
-                WHEN type=kotlin.Byte? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-byteField> (): kotlin.Byte? declared in sample.input.Sample'
+              BLOCK type=kotlin.Byte? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Byte? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
+                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Byte? origin=null
+                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
                     then: BLOCK type=kotlin.Byte? origin=null
                       BLOCK type=kotlin.Byte? origin=SAFE_CALL
-                        VAR IR_TEMPORARY_VARIABLE name:tmp0_coreValue type:kotlin.Any? [val]
-                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                        VAR IR_TEMPORARY_VARIABLE name:tmp1_coreValue type:kotlin.Any? [val]
+                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                             <R>: kotlin.Byte?
                             $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                            obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
+                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
                             propertyName: CONST String type=kotlin.String value="byteField"
                         WHEN type=kotlin.Byte? origin=null
                           BRANCH
                             if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                              arg0: GET_VAR 'val tmp0_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-byteField>' type=kotlin.Any? origin=null
+                              arg0: GET_VAR 'val tmp1_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-byteField>' type=kotlin.Any? origin=null
                               arg1: CONST Null type=kotlin.Nothing? value=null
                             then: CONST Null type=kotlin.Nothing? value=null
                           BRANCH
                             if: CONST Boolean type=kotlin.Boolean value=true
                             then: CALL 'public open fun toByte (): kotlin.Byte declared in kotlin.Long' type=kotlin.Byte origin=null
-                              $this: GET_VAR 'val tmp0_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-byteField>' type=kotlin.Any? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Byte? origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
+                              $this: GET_VAR 'val tmp1_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-byteField>' type=kotlin.Any? origin=null
         FUN name:<set-byteField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Byte?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:byteField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Byte?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-byteField> (<set-?>: kotlin.Byte?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Byte?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="byteField"
-                      value: WHEN type=kotlin.Long? origin=null
-                        BRANCH
-                          if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                            arg0: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
-                            arg1: CONST Null type=kotlin.Nothing? value=null
-                          then: CONST Null type=kotlin.Nothing? value=null
-                        BRANCH
-                          if: CONST Boolean type=kotlin.Boolean value=true
-                          then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Byte' type=kotlin.Long origin=null
-                            $this: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Byte?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="byteField"
+                  value: WHEN type=kotlin.Long? origin=null
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: CONST Null type=kotlin.Nothing? value=null
+                    BRANCH
+                      if: CONST Boolean type=kotlin.Boolean value=true
+                      then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Byte' type=kotlin.Long origin=null
+                        $this: GET_VAR '<set-?>: kotlin.Byte? declared in sample.input.Sample.<set-byteField>' type=kotlin.Byte? origin=null
       PROPERTY name:charField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private
           EXPRESSION_BODY
@@ -237,71 +237,71 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:charField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-charField> (): kotlin.Char? declared in sample.input.Sample'
-                WHEN type=kotlin.Char? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-charField> (): kotlin.Char? declared in sample.input.Sample'
+              BLOCK type=kotlin.Char? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Char? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
+                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Char? origin=null
+                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
                     then: BLOCK type=kotlin.Char? origin=null
                       BLOCK type=kotlin.Char? origin=SAFE_CALL
-                        VAR IR_TEMPORARY_VARIABLE name:tmp0_coreValue type:kotlin.Any? [val]
-                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                        VAR IR_TEMPORARY_VARIABLE name:tmp1_coreValue type:kotlin.Any? [val]
+                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                             <R>: kotlin.Char?
                             $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                            obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
+                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
                             propertyName: CONST String type=kotlin.String value="charField"
                         WHEN type=kotlin.Char? origin=null
                           BRANCH
                             if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                              arg0: GET_VAR 'val tmp0_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-charField>' type=kotlin.Any? origin=null
+                              arg0: GET_VAR 'val tmp1_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-charField>' type=kotlin.Any? origin=null
                               arg1: CONST Null type=kotlin.Nothing? value=null
                             then: CONST Null type=kotlin.Nothing? value=null
                           BRANCH
                             if: CONST Boolean type=kotlin.Boolean value=true
                             then: CALL 'public open fun toChar (): kotlin.Char declared in kotlin.Long' type=kotlin.Char origin=null
-                              $this: GET_VAR 'val tmp0_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-charField>' type=kotlin.Any? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Char? origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
+                              $this: GET_VAR 'val tmp1_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-charField>' type=kotlin.Any? origin=null
         FUN name:<set-charField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Char?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:charField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Char?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-charField> (<set-?>: kotlin.Char?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Char?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="charField"
-                      value: WHEN type=kotlin.Long? origin=null
-                        BRANCH
-                          if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                            arg0: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
-                            arg1: CONST Null type=kotlin.Nothing? value=null
-                          then: CONST Null type=kotlin.Nothing? value=null
-                        BRANCH
-                          if: CONST Boolean type=kotlin.Boolean value=true
-                          then: CALL 'public final fun toLong (): kotlin.Long declared in kotlin.Char' type=kotlin.Long origin=null
-                            $this: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Char?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="charField"
+                  value: WHEN type=kotlin.Long? origin=null
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: CONST Null type=kotlin.Nothing? value=null
+                    BRANCH
+                      if: CONST Boolean type=kotlin.Boolean value=true
+                      then: CALL 'public final fun toLong (): kotlin.Long declared in kotlin.Char' type=kotlin.Long origin=null
+                        $this: GET_VAR '<set-?>: kotlin.Char? declared in sample.input.Sample.<set-charField>' type=kotlin.Char? origin=null
       PROPERTY name:shortField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private
           EXPRESSION_BODY
@@ -310,71 +310,71 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:shortField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-shortField> (): kotlin.Short? declared in sample.input.Sample'
-                WHEN type=kotlin.Short? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-shortField> (): kotlin.Short? declared in sample.input.Sample'
+              BLOCK type=kotlin.Short? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Short? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
+                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Short? origin=null
+                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
                     then: BLOCK type=kotlin.Short? origin=null
                       BLOCK type=kotlin.Short? origin=SAFE_CALL
-                        VAR IR_TEMPORARY_VARIABLE name:tmp0_coreValue type:kotlin.Any? [val]
-                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                        VAR IR_TEMPORARY_VARIABLE name:tmp1_coreValue type:kotlin.Any? [val]
+                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                             <R>: kotlin.Short?
                             $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                            obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
+                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
                             propertyName: CONST String type=kotlin.String value="shortField"
                         WHEN type=kotlin.Short? origin=null
                           BRANCH
                             if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                              arg0: GET_VAR 'val tmp0_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-shortField>' type=kotlin.Any? origin=null
+                              arg0: GET_VAR 'val tmp1_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-shortField>' type=kotlin.Any? origin=null
                               arg1: CONST Null type=kotlin.Nothing? value=null
                             then: CONST Null type=kotlin.Nothing? value=null
                           BRANCH
                             if: CONST Boolean type=kotlin.Boolean value=true
                             then: CALL 'public open fun toShort (): kotlin.Short declared in kotlin.Long' type=kotlin.Short origin=null
-                              $this: GET_VAR 'val tmp0_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-shortField>' type=kotlin.Any? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Short? origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
+                              $this: GET_VAR 'val tmp1_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-shortField>' type=kotlin.Any? origin=null
         FUN name:<set-shortField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Short?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:shortField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Short?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-shortField> (<set-?>: kotlin.Short?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Short?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="shortField"
-                      value: WHEN type=kotlin.Long? origin=null
-                        BRANCH
-                          if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                            arg0: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
-                            arg1: CONST Null type=kotlin.Nothing? value=null
-                          then: CONST Null type=kotlin.Nothing? value=null
-                        BRANCH
-                          if: CONST Boolean type=kotlin.Boolean value=true
-                          then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Short' type=kotlin.Long origin=null
-                            $this: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Short?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="shortField"
+                  value: WHEN type=kotlin.Long? origin=null
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: CONST Null type=kotlin.Nothing? value=null
+                    BRANCH
+                      if: CONST Boolean type=kotlin.Boolean value=true
+                      then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Short' type=kotlin.Long origin=null
+                        $this: GET_VAR '<set-?>: kotlin.Short? declared in sample.input.Sample.<set-shortField>' type=kotlin.Short? origin=null
       PROPERTY name:intField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private
           annotations:
@@ -385,71 +385,71 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:intField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-intField> (): kotlin.Int? declared in sample.input.Sample'
-                WHEN type=kotlin.Int? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-intField> (): kotlin.Int? declared in sample.input.Sample'
+              BLOCK type=kotlin.Int? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Int? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
+                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Int? origin=null
+                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
                     then: BLOCK type=kotlin.Int? origin=null
                       BLOCK type=kotlin.Int? origin=SAFE_CALL
-                        VAR IR_TEMPORARY_VARIABLE name:tmp0_coreValue type:kotlin.Any? [val]
-                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                        VAR IR_TEMPORARY_VARIABLE name:tmp1_coreValue type:kotlin.Any? [val]
+                          CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
                             <R>: kotlin.Int?
                             $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                            obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
+                            obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
                             propertyName: CONST String type=kotlin.String value="intField"
                         WHEN type=kotlin.Int? origin=null
                           BRANCH
                             if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                              arg0: GET_VAR 'val tmp0_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-intField>' type=kotlin.Any? origin=null
+                              arg0: GET_VAR 'val tmp1_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-intField>' type=kotlin.Any? origin=null
                               arg1: CONST Null type=kotlin.Nothing? value=null
                             then: CONST Null type=kotlin.Nothing? value=null
                           BRANCH
                             if: CONST Boolean type=kotlin.Boolean value=true
                             then: CALL 'public open fun toInt (): kotlin.Int declared in kotlin.Long' type=kotlin.Int origin=null
-                              $this: GET_VAR 'val tmp0_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-intField>' type=kotlin.Any? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Int? origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
+                              $this: GET_VAR 'val tmp1_coreValue: kotlin.Any? [val] declared in sample.input.Sample.<get-intField>' type=kotlin.Any? origin=null
         FUN name:<set-intField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Int?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:intField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-intField> (<set-?>: kotlin.Int?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Int?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="intField"
-                      value: WHEN type=kotlin.Long? origin=null
-                        BRANCH
-                          if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                            arg0: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
-                            arg1: CONST Null type=kotlin.Nothing? value=null
-                          then: CONST Null type=kotlin.Nothing? value=null
-                        BRANCH
-                          if: CONST Boolean type=kotlin.Boolean value=true
-                          then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Int' type=kotlin.Long origin=null
-                            $this: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Int?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="intField"
+                  value: WHEN type=kotlin.Long? origin=null
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: CONST Null type=kotlin.Nothing? value=null
+                    BRANCH
+                      if: CONST Boolean type=kotlin.Boolean value=true
+                      then: CALL 'public open fun toLong (): kotlin.Long declared in kotlin.Int' type=kotlin.Long origin=null
+                        $this: GET_VAR '<set-?>: kotlin.Int? declared in sample.input.Sample.<set-intField>' type=kotlin.Int? origin=null
       PROPERTY name:longField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private
           EXPRESSION_BODY
@@ -458,49 +458,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:longField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-longField> (): kotlin.Long? declared in sample.input.Sample'
-                WHEN type=kotlin.Long? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-longField> (): kotlin.Long? declared in sample.input.Sample'
+              BLOCK type=kotlin.Long? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Long? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
-                      <R>: kotlin.Long?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="longField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Long? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                      <R>: kotlin.Long?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="longField"
         FUN name:<set-longField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Long?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:longField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-longField> (<set-?>: kotlin.Long?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Long?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="longField"
-                      value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Long?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="longField"
+                  value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
       PROPERTY name:booleanField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private
           EXPRESSION_BODY
@@ -509,49 +509,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:booleanField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-booleanField> (): kotlin.Boolean? declared in sample.input.Sample'
-                WHEN type=kotlin.Boolean? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-booleanField> (): kotlin.Boolean? declared in sample.input.Sample'
+              BLOCK type=kotlin.Boolean? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Boolean? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
-                      <R>: kotlin.Boolean?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="booleanField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Boolean? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                      <R>: kotlin.Boolean?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="booleanField"
         FUN name:<set-booleanField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Boolean?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:booleanField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-booleanField> (<set-?>: kotlin.Boolean?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Boolean?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="booleanField"
-                      value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Boolean?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="booleanField"
+                  value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
       PROPERTY name:floatField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private
           EXPRESSION_BODY
@@ -560,49 +560,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:floatField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-floatField> (): kotlin.Float? declared in sample.input.Sample'
-                WHEN type=kotlin.Float? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-floatField> (): kotlin.Float? declared in sample.input.Sample'
+              BLOCK type=kotlin.Float? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Float? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
-                      <R>: kotlin.Float?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="floatField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Float? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                      <R>: kotlin.Float?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="floatField"
         FUN name:<set-floatField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Float?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:floatField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Float?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-floatField> (<set-?>: kotlin.Float?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Float?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="floatField"
-                      value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Float?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="floatField"
+                  value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
       PROPERTY name:doubleField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private
           EXPRESSION_BODY
@@ -611,49 +611,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:doubleField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-doubleField> (): kotlin.Double? declared in sample.input.Sample'
-                WHEN type=kotlin.Double? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-doubleField> (): kotlin.Double? declared in sample.input.Sample'
+              BLOCK type=kotlin.Double? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
+                WHEN type=kotlin.Double? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
-                      <R>: kotlin.Double?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="doubleField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Double? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                      <R>: kotlin.Double?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="doubleField"
         FUN name:<set-doubleField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Double?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:doubleField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Double?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-doubleField> (<set-?>: kotlin.Double?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.Double?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="doubleField"
-                      value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.Double?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="doubleField"
+                  value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
       PROPERTY name:timestampField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private
           EXPRESSION_BODY
@@ -665,49 +665,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:timestampField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-timestampField> (): io.realm.RealmInstant? declared in sample.input.Sample'
-                WHEN type=io.realm.RealmInstant? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-timestampField> (): io.realm.RealmInstant? declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmInstant? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmInstant? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getTimestamp <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.RealmInstant? declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmInstant? origin=GET_PROPERTY
-                      <R>: io.realm.RealmInstant?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="timestampField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private' type=io.realm.RealmInstant? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getTimestamp <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.RealmInstant? declared in io.realm.internal.RealmObjectHelper' type=io.realm.RealmInstant? origin=GET_PROPERTY
+                      <R>: io.realm.RealmInstant?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="timestampField"
         FUN name:<set-timestampField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmInstant?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:timestampField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmInstant?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-timestampField> (<set-?>: io.realm.RealmInstant?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setTimestamp <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: io.realm.RealmInstant?): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: io.realm.RealmInstant?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="timestampField"
-                      value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.RealmInstant? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setTimestamp <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: io.realm.RealmInstant?): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: io.realm.RealmInstant?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="timestampField"
+                  value: GET_VAR '<set-?>: io.realm.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.RealmInstant? origin=null
       PROPERTY name:child visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private
           EXPRESSION_BODY
@@ -716,49 +716,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:child visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-child> (): sample.input.Child? declared in sample.input.Sample'
-                WHEN type=sample.input.Child? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-child> (): sample.input.Child? declared in sample.input.Sample'
+              BLOCK type=sample.input.Child? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
+                WHEN type=sample.input.Child? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getObject <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
-                      <R>: sample.input.Child?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="child"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=sample.input.Child? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getObject <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                      <R>: sample.input.Child?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="child"
         FUN name:<set-child> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:sample.input.Child?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:child visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:sample.input.Child?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-child> (<set-?>: sample.input.Child?): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun setObject <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setObject?): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: sample.input.Child?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="child"
-                      value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setObject <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setObject?): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: sample.input.Child?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="child"
+                  value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
       PROPERTY name:stringListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private
           EXPRESSION_BODY
@@ -768,49 +768,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:stringListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-stringListField> (): io.realm.RealmList<kotlin.String> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.String> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-stringListField> (): io.realm.RealmList<kotlin.String> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.String> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.String> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.String
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="stringListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private' type=io.realm.RealmList<kotlin.String> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.String
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="stringListField"
         FUN name:<set-stringListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.String>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:stringListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.String>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-stringListField> (<set-?>: io.realm.RealmList<kotlin.String>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.String
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="stringListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.RealmList<kotlin.String> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.String
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="stringListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.RealmList<kotlin.String> origin=null
       PROPERTY name:byteListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private
           EXPRESSION_BODY
@@ -820,49 +820,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:byteListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-byteListField> (): io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Byte> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-byteListField> (): io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Byte> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Byte> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Byte
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="byteListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private' type=io.realm.RealmList<kotlin.Byte> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Byte
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="byteListField"
         FUN name:<set-byteListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Byte>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:byteListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Byte>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-byteListField> (<set-?>: io.realm.RealmList<kotlin.Byte>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Byte
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="byteListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.RealmList<kotlin.Byte> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Byte
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="byteListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.RealmList<kotlin.Byte> origin=null
       PROPERTY name:charListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private
           EXPRESSION_BODY
@@ -872,49 +872,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:charListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-charListField> (): io.realm.RealmList<kotlin.Char> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Char> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-charListField> (): io.realm.RealmList<kotlin.Char> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Char> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Char> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Char
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="charListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private' type=io.realm.RealmList<kotlin.Char> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Char
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="charListField"
         FUN name:<set-charListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Char>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:charListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Char>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-charListField> (<set-?>: io.realm.RealmList<kotlin.Char>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Char
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="charListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.RealmList<kotlin.Char> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Char
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="charListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.RealmList<kotlin.Char> origin=null
       PROPERTY name:shortListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private
           EXPRESSION_BODY
@@ -924,49 +924,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:shortListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-shortListField> (): io.realm.RealmList<kotlin.Short> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Short> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-shortListField> (): io.realm.RealmList<kotlin.Short> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Short> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Short> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Short
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="shortListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private' type=io.realm.RealmList<kotlin.Short> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Short
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="shortListField"
         FUN name:<set-shortListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Short>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:shortListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Short>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-shortListField> (<set-?>: io.realm.RealmList<kotlin.Short>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Short
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="shortListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.RealmList<kotlin.Short> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Short
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="shortListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.RealmList<kotlin.Short> origin=null
       PROPERTY name:intListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private
           EXPRESSION_BODY
@@ -976,49 +976,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:intListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-intListField> (): io.realm.RealmList<kotlin.Int> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Int> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-intListField> (): io.realm.RealmList<kotlin.Int> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Int> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Int> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Int
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="intListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private' type=io.realm.RealmList<kotlin.Int> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Int
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="intListField"
         FUN name:<set-intListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Int>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:intListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Int>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-intListField> (<set-?>: io.realm.RealmList<kotlin.Int>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Int
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="intListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.RealmList<kotlin.Int> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Int
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="intListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.RealmList<kotlin.Int> origin=null
       PROPERTY name:longListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private
           EXPRESSION_BODY
@@ -1028,49 +1028,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:longListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-longListField> (): io.realm.RealmList<kotlin.Long> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Long> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-longListField> (): io.realm.RealmList<kotlin.Long> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Long> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Long> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Long
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="longListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private' type=io.realm.RealmList<kotlin.Long> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Long
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="longListField"
         FUN name:<set-longListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Long>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:longListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Long>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-longListField> (<set-?>: io.realm.RealmList<kotlin.Long>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Long
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="longListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.RealmList<kotlin.Long> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Long
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="longListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.RealmList<kotlin.Long> origin=null
       PROPERTY name:booleanListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private
           EXPRESSION_BODY
@@ -1080,49 +1080,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:booleanListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-booleanListField> (): io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Boolean> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-booleanListField> (): io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Boolean> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Boolean> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Boolean
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="booleanListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private' type=io.realm.RealmList<kotlin.Boolean> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Boolean
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="booleanListField"
         FUN name:<set-booleanListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Boolean>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:booleanListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Boolean>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-booleanListField> (<set-?>: io.realm.RealmList<kotlin.Boolean>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Boolean
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="booleanListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.RealmList<kotlin.Boolean> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Boolean
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="booleanListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.RealmList<kotlin.Boolean> origin=null
       PROPERTY name:floatListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private
           EXPRESSION_BODY
@@ -1132,49 +1132,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:floatListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-floatListField> (): io.realm.RealmList<kotlin.Float> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Float> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-floatListField> (): io.realm.RealmList<kotlin.Float> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Float> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Float> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Float
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="floatListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private' type=io.realm.RealmList<kotlin.Float> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Float
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="floatListField"
         FUN name:<set-floatListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Float>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:floatListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Float>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-floatListField> (<set-?>: io.realm.RealmList<kotlin.Float>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Float
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="floatListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.RealmList<kotlin.Float> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Float
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="floatListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.RealmList<kotlin.Float> origin=null
       PROPERTY name:doubleListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private
           EXPRESSION_BODY
@@ -1184,49 +1184,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:doubleListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-doubleListField> (): io.realm.RealmList<kotlin.Double> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Double> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-doubleListField> (): io.realm.RealmList<kotlin.Double> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Double> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Double> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Double
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="doubleListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private' type=io.realm.RealmList<kotlin.Double> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Double
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="doubleListField"
         FUN name:<set-doubleListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Double>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:doubleListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Double>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-doubleListField> (<set-?>: io.realm.RealmList<kotlin.Double>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Double
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="doubleListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.RealmList<kotlin.Double> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Double
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="doubleListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.RealmList<kotlin.Double> origin=null
       PROPERTY name:timestampListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private
           EXPRESSION_BODY
@@ -1236,49 +1236,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:timestampListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-timestampListField> (): io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<io.realm.RealmInstant> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-timestampListField> (): io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<io.realm.RealmInstant> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<io.realm.RealmInstant> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: io.realm.RealmInstant
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="timestampListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: io.realm.RealmInstant
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="timestampListField"
         FUN name:<set-timestampListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<io.realm.RealmInstant>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:timestampListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<io.realm.RealmInstant>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-timestampListField> (<set-?>: io.realm.RealmList<io.realm.RealmInstant>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: io.realm.RealmInstant
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="timestampListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.RealmList<io.realm.RealmInstant> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: io.realm.RealmInstant
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="timestampListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.RealmList<io.realm.RealmInstant> origin=null
       PROPERTY name:objectListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private
           EXPRESSION_BODY
@@ -1288,49 +1288,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:objectListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-objectListField> (): io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<sample.input.Sample> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-objectListField> (): io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<sample.input.Sample> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<sample.input.Sample> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: sample.input.Sample
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="objectListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private' type=io.realm.RealmList<sample.input.Sample> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: sample.input.Sample
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="objectListField"
         FUN name:<set-objectListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<sample.input.Sample>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:objectListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<sample.input.Sample>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-objectListField> (<set-?>: io.realm.RealmList<sample.input.Sample>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: sample.input.Sample
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="objectListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.RealmList<sample.input.Sample> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: sample.input.Sample
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="objectListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.RealmList<sample.input.Sample> origin=null
       PROPERTY name:nullableStringListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private
           EXPRESSION_BODY
@@ -1340,49 +1340,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableStringListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableStringListField> (): io.realm.RealmList<kotlin.String?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.String?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableStringListField> (): io.realm.RealmList<kotlin.String?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.String?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.String?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.String?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableStringListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private' type=io.realm.RealmList<kotlin.String?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.String?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableStringListField"
         FUN name:<set-nullableStringListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.String?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableStringListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.String?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableStringListField> (<set-?>: io.realm.RealmList<kotlin.String?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.String?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableStringListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.RealmList<kotlin.String?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.String?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableStringListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.RealmList<kotlin.String?> origin=null
       PROPERTY name:nullableByteListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private
           EXPRESSION_BODY
@@ -1392,49 +1392,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableByteListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableByteListField> (): io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Byte?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableByteListField> (): io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Byte?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Byte?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Byte?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableByteListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private' type=io.realm.RealmList<kotlin.Byte?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Byte?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableByteListField"
         FUN name:<set-nullableByteListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Byte?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableByteListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Byte?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableByteListField> (<set-?>: io.realm.RealmList<kotlin.Byte?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Byte?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableByteListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.RealmList<kotlin.Byte?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Byte?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableByteListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.RealmList<kotlin.Byte?> origin=null
       PROPERTY name:nullableCharListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private
           EXPRESSION_BODY
@@ -1444,49 +1444,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableCharListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableCharListField> (): io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Char?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableCharListField> (): io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Char?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Char?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Char?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableCharListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private' type=io.realm.RealmList<kotlin.Char?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Char?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableCharListField"
         FUN name:<set-nullableCharListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Char?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableCharListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Char?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableCharListField> (<set-?>: io.realm.RealmList<kotlin.Char?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Char?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableCharListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.RealmList<kotlin.Char?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Char?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableCharListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.RealmList<kotlin.Char?> origin=null
       PROPERTY name:nullableShortListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private
           EXPRESSION_BODY
@@ -1496,49 +1496,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableShortListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableShortListField> (): io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Short?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableShortListField> (): io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Short?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Short?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Short?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableShortListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private' type=io.realm.RealmList<kotlin.Short?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Short?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableShortListField"
         FUN name:<set-nullableShortListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Short?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableShortListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Short?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableShortListField> (<set-?>: io.realm.RealmList<kotlin.Short?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Short?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableShortListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.RealmList<kotlin.Short?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Short?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableShortListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.RealmList<kotlin.Short?> origin=null
       PROPERTY name:nullableIntListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private
           EXPRESSION_BODY
@@ -1548,49 +1548,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableIntListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableIntListField> (): io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Int?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableIntListField> (): io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Int?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Int?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Int?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableIntListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private' type=io.realm.RealmList<kotlin.Int?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Int?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableIntListField"
         FUN name:<set-nullableIntListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Int?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableIntListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Int?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableIntListField> (<set-?>: io.realm.RealmList<kotlin.Int?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Int?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableIntListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.RealmList<kotlin.Int?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Int?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableIntListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.RealmList<kotlin.Int?> origin=null
       PROPERTY name:nullableLongListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private
           EXPRESSION_BODY
@@ -1600,49 +1600,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableLongListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableLongListField> (): io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Long?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableLongListField> (): io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Long?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Long?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Long?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableLongListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private' type=io.realm.RealmList<kotlin.Long?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Long?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableLongListField"
         FUN name:<set-nullableLongListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Long?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableLongListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Long?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableLongListField> (<set-?>: io.realm.RealmList<kotlin.Long?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Long?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableLongListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.RealmList<kotlin.Long?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Long?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableLongListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.RealmList<kotlin.Long?> origin=null
       PROPERTY name:nullableBooleanListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private
           EXPRESSION_BODY
@@ -1652,49 +1652,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableBooleanListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableBooleanListField> (): io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Boolean?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableBooleanListField> (): io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Boolean?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Boolean?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Boolean?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableBooleanListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private' type=io.realm.RealmList<kotlin.Boolean?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Boolean?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableBooleanListField"
         FUN name:<set-nullableBooleanListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Boolean?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableBooleanListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Boolean?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableBooleanListField> (<set-?>: io.realm.RealmList<kotlin.Boolean?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Boolean?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableBooleanListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.RealmList<kotlin.Boolean?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Boolean?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableBooleanListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.RealmList<kotlin.Boolean?> origin=null
       PROPERTY name:nullableFloatListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private
           EXPRESSION_BODY
@@ -1704,49 +1704,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableFloatListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableFloatListField> (): io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Float?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableFloatListField> (): io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Float?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Float?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Float?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableFloatListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private' type=io.realm.RealmList<kotlin.Float?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Float?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableFloatListField"
         FUN name:<set-nullableFloatListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Float?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableFloatListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Float?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableFloatListField> (<set-?>: io.realm.RealmList<kotlin.Float?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Float?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableFloatListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.RealmList<kotlin.Float?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Float?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableFloatListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.RealmList<kotlin.Float?> origin=null
       PROPERTY name:nullableDoubleListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private
           EXPRESSION_BODY
@@ -1756,49 +1756,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableDoubleListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableDoubleListField> (): io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<kotlin.Double?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableDoubleListField> (): io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<kotlin.Double?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<kotlin.Double?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: kotlin.Double?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableDoubleListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private' type=io.realm.RealmList<kotlin.Double?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: kotlin.Double?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableDoubleListField"
         FUN name:<set-nullableDoubleListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<kotlin.Double?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableDoubleListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<kotlin.Double?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableDoubleListField> (<set-?>: io.realm.RealmList<kotlin.Double?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: kotlin.Double?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableDoubleListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.RealmList<kotlin.Double?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: kotlin.Double?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableDoubleListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.RealmList<kotlin.Double?> origin=null
       PROPERTY name:nullableTimestampListField visibility:public modality:FINAL [var]
         FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private
           EXPRESSION_BODY
@@ -1808,49 +1808,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:nullableTimestampListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-nullableTimestampListField> (): io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample'
-                WHEN type=io.realm.RealmList<io.realm.RealmInstant?> origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-nullableTimestampListField> (): io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample'
+              BLOCK type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
+                WHEN type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
-                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
-                      <R>: io.realm.RealmInstant?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
-                      propertyName: CONST String type=kotlin.String value="nullableTimestampListField"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getList <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): io.realm.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.internal.RealmObjectHelper' type=io.realm.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
+                      <R>: io.realm.RealmInstant?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="nullableTimestampListField"
         FUN name:<set-nullableTimestampListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.RealmList<io.realm.RealmInstant?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableTimestampListField visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.RealmList<io.realm.RealmInstant?>
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-nullableTimestampListField> (<set-?>: io.realm.RealmList<io.realm.RealmInstant?>): kotlin.Unit declared in sample.input.Sample'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
-                    then: CALL 'public final fun setList <T> (obj: io.realm.internal.RealmObjectInternal, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <T>: io.realm.RealmInstant?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
-                      col: CONST String type=kotlin.String value="nullableTimestampListField"
-                      list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
-                      value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Sample' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.RealmList<io.realm.RealmInstant?> visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
+                  value: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun setList <T> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, col: kotlin.String, list: io.realm.RealmList<kotlin.Any?>): kotlin.Unit [inline] declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <T>: io.realm.RealmInstant?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  col: CONST String type=kotlin.String value="nullableTimestampListField"
+                  list: GET_VAR '<set-?>: io.realm.RealmList<io.realm.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.RealmList<io.realm.RealmInstant?> origin=null
       FUN name:dumpSchema visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:kotlin.String
         $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
         BLOCK_BODY
@@ -2386,49 +2386,49 @@ MODULE_FRAGMENT name:<main>
           correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Child
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String? declared in sample.input.Child'
-                WHEN type=kotlin.String? origin=IF
+            RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String? declared in sample.input.Child'
+              BLOCK type=kotlin.String? origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+                  CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
+                WHEN type=kotlin.String? origin=null
                   BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
-                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
-                      <R>: kotlin.String?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
-                      propertyName: CONST String type=kotlin.String value="name"
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Child.<get-name>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.String? origin=null
                       receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'internal final fun getValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String): kotlin.Any? declared in io.realm.internal.RealmObjectHelper' type=kotlin.Any? origin=GET_PROPERTY
+                      <R>: kotlin.String?
+                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Child.<get-name>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                      propertyName: CONST String type=kotlin.String value="name"
         FUN name:<set-name> visibility:public modality:FINAL <> ($this:sample.input.Child, <set-?>:kotlin.String?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [var]
           $this: VALUE_PARAMETER name:<this> type:sample.input.Child
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
-            BLOCK type=kotlin.Nothing origin=null
-              RETURN type=kotlin.Nothing from='public final fun <set-name> (<set-?>: kotlin.String?): kotlin.Unit declared in sample.input.Child'
-                WHEN type=kotlin.Unit origin=IF
-                  BRANCH
-                    if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-                      $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                        arg0: CONST Null type=kotlin.Nothing? value=null
-                        arg1: CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
-                    then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.RealmObjectInternal, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
-                      <R>: kotlin.String?
-                      $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
-                      obj: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
-                      propertyName: CONST String type=kotlin.String value="name"
-                      value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-                      receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
-                      value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val]
+              CALL 'public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in sample.input.Child' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=GET_PROPERTY
+                $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
+            WHEN type=kotlin.Unit origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
+                  value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'internal final fun setValue <R> (obj: io.realm.internal.ObjectReference<out io.realm.RealmObject>, propertyName: kotlin.String, value: R of io.realm.internal.RealmObjectHelper.setValue): kotlin.Unit declared in io.realm.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                  <R>: kotlin.String?
+                  $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.internal.RealmObjectHelper
+                  obj: GET_VAR 'val tmp0_objectReference: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                  propertyName: CONST String type=kotlin.String value="name"
+                  value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
       CLASS OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any; io.realm.internal.RealmObjectCompanion]
         $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child.Companion
         CONSTRUCTOR visibility:private <> () returnType:sample.input.Child.Companion [primary]

--- a/packages/plugin-compiler/src/test/resources/schema/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/schema/expected/00_ValidateIrBeforeLowering.ir
@@ -103,28 +103,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.A'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in schema.input.A'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                 receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-$realm$objectReference>' type=schema.input.A origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-$realm$objectReference>' type=schema.input.A origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.A.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in schema.input.A.<set-$realm$objectReference>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
     CLASS CLASS name:B modality:OPEN visibility:public superTypes:[io.realm.RealmObject; io.realm.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
       CONSTRUCTOR visibility:public <> () returnType:schema.input.B [primary]
@@ -227,28 +227,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.B'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in schema.input.B'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                 receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-$realm$objectReference>' type=schema.input.B origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-$realm$objectReference>' type=schema.input.B origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.B.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in schema.input.B.<set-$realm$objectReference>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
     CLASS CLASS name:C modality:OPEN visibility:public superTypes:[io.realm.RealmObject; io.realm.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
       CONSTRUCTOR visibility:public <> () returnType:schema.input.C [primary]
@@ -351,28 +351,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.C'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in schema.input.C'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
                 receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-$realm$objectReference>' type=schema.input.C origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.RealmObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-$realm$objectReference>' type=schema.input.C origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.C.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? declared in schema.input.C.<set-$realm$objectReference>' type=io.realm.internal.RealmObjectReference<T of io.realm.internal.RealmObjectReference>? origin=null
     PROPERTY name:conf1 visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:conf1 type:io.realm.RealmConfiguration visibility:private [final,static]
         EXPRESSION_BODY

--- a/packages/plugin-compiler/src/test/resources/schema/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/schema/expected/00_ValidateIrBeforeLowering.ir
@@ -102,193 +102,29 @@ MODULE_FRAGMENT name:<main>
         overridden:
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private
+      PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.internal.interop.NativePointer?
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? declared in schema.input.A'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=io.realm.internal.interop.NativePointer? origin=null
-                receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-$realm$ObjectPointer>' type=schema.input.A origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.internal.interop.NativePointer?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.A'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-$realm$objectReference>' type=schema.input.A origin=null
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$ObjectPointer> (<set-?>: io.realm.internal.interop.NativePointer?): kotlin.Unit [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.interop.NativePointer?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-$realm$ObjectPointer>' type=schema.input.A origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.interop.NativePointer? declared in schema.input.A.<set-$realm$ObjectPointer>' type=io.realm.internal.interop.NativePointer? origin=null
-      PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Owner> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.internal.RealmReference?
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in schema.input.A'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=io.realm.internal.RealmReference? origin=null
-                receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-$realm$Owner>' type=schema.input.A origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Owner> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.internal.RealmReference?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Owner> (<set-?>: io.realm.internal.RealmReference?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmReference?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-$realm$Owner>' type=schema.input.A origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.RealmReference? declared in schema.input.A.<set-$realm$Owner>' type=io.realm.internal.RealmReference? origin=null
-      PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ClassName> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:kotlin.String?
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$ClassName> (): kotlin.String? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ClassName> (): kotlin.String? declared in schema.input.A'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.String? origin=null
-                receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-$realm$ClassName>' type=schema.input.A origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ClassName> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:kotlin.String?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$ClassName> (<set-?>: kotlin.String?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-$realm$ClassName>' type=schema.input.A origin=null
-              value: GET_VAR '<set-?>: kotlin.String? declared in schema.input.A.<set-$realm$ClassName>' type=kotlin.String? origin=null
-      PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private
-          EXPRESSION_BODY
-            CONST Boolean type=kotlin.Boolean value=false
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$IsManaged> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:kotlin.Boolean
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$IsManaged> (): kotlin.Boolean declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in schema.input.A'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Boolean origin=null
-                receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-$realm$IsManaged>' type=schema.input.A origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$IsManaged> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:kotlin.Boolean) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$IsManaged> (<set-?>: kotlin.Boolean): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-$realm$IsManaged>' type=schema.input.A origin=null
-              value: GET_VAR '<set-?>: kotlin.Boolean declared in schema.input.A.<set-$realm$IsManaged>' type=kotlin.Boolean origin=null
-      PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Mediator> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.internal.Mediator?
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in schema.input.A'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=io.realm.internal.Mediator? origin=null
-                receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-$realm$Mediator>' type=schema.input.A origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Mediator> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.internal.Mediator?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Mediator> (<set-?>: io.realm.internal.Mediator?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.Mediator?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-$realm$Mediator>' type=schema.input.A origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.Mediator? declared in schema.input.A.<set-$realm$Mediator>' type=io.realm.internal.Mediator? origin=null
-      PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$metadata> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.internal.schema.ClassMetadata?
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in schema.input.A'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=io.realm.internal.schema.ClassMetadata? origin=null
-                receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-$realm$metadata>' type=schema.input.A origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$metadata> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.internal.schema.ClassMetadata?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$metadata> (<set-?>: io.realm.internal.schema.ClassMetadata?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.schema.ClassMetadata?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-$realm$metadata>' type=schema.input.A origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.schema.ClassMetadata? declared in schema.input.A.<set-$realm$metadata>' type=io.realm.internal.schema.ClassMetadata? origin=null
-      FUN FAKE_OVERRIDE name:delete visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Unit [fake_override]
-        overridden:
-          public open fun delete (): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:emitFrozenUpdate visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference, change:io.realm.internal.interop.NativePointer, channel:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>) returnType:kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? [fake_override]
-        overridden:
-          public open fun emitFrozenUpdate (frozenRealm: io.realm.internal.RealmReference, change: io.realm.internal.interop.NativePointer, channel: kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>): kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:change index:1 type:io.realm.internal.interop.NativePointer
-        VALUE_PARAMETER name:channel index:2 type:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>
-      FUN FAKE_OVERRIDE name:freeze visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun freeze (frozenRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:isFrozen visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Boolean [fake_override]
-        overridden:
-          public open fun isFrozen (): kotlin.Boolean [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:propertyInfoOrThrow visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, propertyName:kotlin.String) returnType:io.realm.internal.interop.PropertyInfo [fake_override]
-        overridden:
-          public open fun propertyInfoOrThrow (propertyName: kotlin.String): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:propertyName index:0 type:kotlin.String
-      FUN FAKE_OVERRIDE name:realmState visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.internal.RealmState [fake_override]
-        overridden:
-          public open fun realmState (): io.realm.internal.RealmState declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:registerForNotification visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, callback:io.realm.internal.interop.Callback) returnType:io.realm.internal.interop.NativePointer [fake_override]
-        overridden:
-          public open fun registerForNotification (callback: io.realm.internal.interop.Callback): io.realm.internal.interop.NativePointer declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:callback index:0 type:io.realm.internal.interop.Callback
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference, clazz:kotlin.reflect.KClass<out io.realm.RealmObject>) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference, clazz: kotlin.reflect.KClass<out io.realm.RealmObject>): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:clazz index:1 type:kotlin.reflect.KClass<out io.realm.RealmObject>
-      FUN FAKE_OVERRIDE name:version visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.VersionId [fake_override]
-        overridden:
-          public open fun version (): io.realm.VersionId [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-$realm$objectReference>' type=schema.input.A origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.A.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
     CLASS CLASS name:B modality:OPEN visibility:public superTypes:[io.realm.RealmObject; io.realm.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
       CONSTRUCTOR visibility:public <> () returnType:schema.input.B [primary]
@@ -390,193 +226,29 @@ MODULE_FRAGMENT name:<main>
         overridden:
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private
+      PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.internal.interop.NativePointer?
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? declared in schema.input.B'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=io.realm.internal.interop.NativePointer? origin=null
-                receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-$realm$ObjectPointer>' type=schema.input.B origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.internal.interop.NativePointer?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.B'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-$realm$objectReference>' type=schema.input.B origin=null
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$ObjectPointer> (<set-?>: io.realm.internal.interop.NativePointer?): kotlin.Unit [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.interop.NativePointer?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-$realm$ObjectPointer>' type=schema.input.B origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.interop.NativePointer? declared in schema.input.B.<set-$realm$ObjectPointer>' type=io.realm.internal.interop.NativePointer? origin=null
-      PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Owner> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.internal.RealmReference?
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in schema.input.B'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=io.realm.internal.RealmReference? origin=null
-                receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-$realm$Owner>' type=schema.input.B origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Owner> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.internal.RealmReference?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Owner> (<set-?>: io.realm.internal.RealmReference?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmReference?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-$realm$Owner>' type=schema.input.B origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.RealmReference? declared in schema.input.B.<set-$realm$Owner>' type=io.realm.internal.RealmReference? origin=null
-      PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ClassName> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:kotlin.String?
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$ClassName> (): kotlin.String? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ClassName> (): kotlin.String? declared in schema.input.B'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.String? origin=null
-                receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-$realm$ClassName>' type=schema.input.B origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ClassName> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:kotlin.String?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$ClassName> (<set-?>: kotlin.String?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-$realm$ClassName>' type=schema.input.B origin=null
-              value: GET_VAR '<set-?>: kotlin.String? declared in schema.input.B.<set-$realm$ClassName>' type=kotlin.String? origin=null
-      PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private
-          EXPRESSION_BODY
-            CONST Boolean type=kotlin.Boolean value=false
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$IsManaged> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:kotlin.Boolean
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$IsManaged> (): kotlin.Boolean declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in schema.input.B'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Boolean origin=null
-                receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-$realm$IsManaged>' type=schema.input.B origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$IsManaged> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:kotlin.Boolean) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$IsManaged> (<set-?>: kotlin.Boolean): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-$realm$IsManaged>' type=schema.input.B origin=null
-              value: GET_VAR '<set-?>: kotlin.Boolean declared in schema.input.B.<set-$realm$IsManaged>' type=kotlin.Boolean origin=null
-      PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Mediator> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.internal.Mediator?
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in schema.input.B'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=io.realm.internal.Mediator? origin=null
-                receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-$realm$Mediator>' type=schema.input.B origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Mediator> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.internal.Mediator?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Mediator> (<set-?>: io.realm.internal.Mediator?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.Mediator?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-$realm$Mediator>' type=schema.input.B origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.Mediator? declared in schema.input.B.<set-$realm$Mediator>' type=io.realm.internal.Mediator? origin=null
-      PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$metadata> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.internal.schema.ClassMetadata?
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in schema.input.B'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=io.realm.internal.schema.ClassMetadata? origin=null
-                receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-$realm$metadata>' type=schema.input.B origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$metadata> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.internal.schema.ClassMetadata?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$metadata> (<set-?>: io.realm.internal.schema.ClassMetadata?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.schema.ClassMetadata?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-$realm$metadata>' type=schema.input.B origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.schema.ClassMetadata? declared in schema.input.B.<set-$realm$metadata>' type=io.realm.internal.schema.ClassMetadata? origin=null
-      FUN FAKE_OVERRIDE name:delete visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Unit [fake_override]
-        overridden:
-          public open fun delete (): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:emitFrozenUpdate visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference, change:io.realm.internal.interop.NativePointer, channel:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>) returnType:kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? [fake_override]
-        overridden:
-          public open fun emitFrozenUpdate (frozenRealm: io.realm.internal.RealmReference, change: io.realm.internal.interop.NativePointer, channel: kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>): kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:change index:1 type:io.realm.internal.interop.NativePointer
-        VALUE_PARAMETER name:channel index:2 type:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>
-      FUN FAKE_OVERRIDE name:freeze visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun freeze (frozenRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:isFrozen visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Boolean [fake_override]
-        overridden:
-          public open fun isFrozen (): kotlin.Boolean [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:propertyInfoOrThrow visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, propertyName:kotlin.String) returnType:io.realm.internal.interop.PropertyInfo [fake_override]
-        overridden:
-          public open fun propertyInfoOrThrow (propertyName: kotlin.String): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:propertyName index:0 type:kotlin.String
-      FUN FAKE_OVERRIDE name:realmState visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.internal.RealmState [fake_override]
-        overridden:
-          public open fun realmState (): io.realm.internal.RealmState declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:registerForNotification visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, callback:io.realm.internal.interop.Callback) returnType:io.realm.internal.interop.NativePointer [fake_override]
-        overridden:
-          public open fun registerForNotification (callback: io.realm.internal.interop.Callback): io.realm.internal.interop.NativePointer declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:callback index:0 type:io.realm.internal.interop.Callback
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference, clazz:kotlin.reflect.KClass<out io.realm.RealmObject>) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference, clazz: kotlin.reflect.KClass<out io.realm.RealmObject>): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:clazz index:1 type:kotlin.reflect.KClass<out io.realm.RealmObject>
-      FUN FAKE_OVERRIDE name:version visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.VersionId [fake_override]
-        overridden:
-          public open fun version (): io.realm.VersionId [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-$realm$objectReference>' type=schema.input.B origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.B.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
     CLASS CLASS name:C modality:OPEN visibility:public superTypes:[io.realm.RealmObject; io.realm.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
       CONSTRUCTOR visibility:public <> () returnType:schema.input.C [primary]
@@ -678,193 +350,29 @@ MODULE_FRAGMENT name:<main>
         overridden:
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private
+      PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
+        FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.internal.interop.NativePointer?
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<out io.realm.RealmObject>? declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ObjectPointer> (): io.realm.internal.interop.NativePointer? declared in schema.input.C'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=io.realm.internal.interop.NativePointer? origin=null
-                receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-$realm$ObjectPointer>' type=schema.input.C origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ObjectPointer> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.internal.interop.NativePointer?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ObjectPointer visibility:public modality:OPEN [var]
+            RETURN type=kotlin.Nothing from='public open fun <get-$realm$objectReference> (): io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.C'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
+                receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-$realm$objectReference>' type=schema.input.C origin=null
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$objectReference> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?) returnType:kotlin.Unit
+          correspondingProperty: PROPERTY name:$realm$objectReference visibility:public modality:OPEN [var]
           overridden:
-            public abstract fun <set-$realm$ObjectPointer> (<set-?>: io.realm.internal.interop.NativePointer?): kotlin.Unit [fake_override] declared in io.realm.internal.RealmObjectInternal
+            public abstract fun <set-$realm$objectReference> (<set-?>: io.realm.internal.ObjectReference<out io.realm.RealmObject>?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.interop.NativePointer?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ObjectPointer type:io.realm.internal.interop.NativePointer? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-$realm$ObjectPointer>' type=schema.input.C origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.interop.NativePointer? declared in schema.input.C.<set-$realm$ObjectPointer>' type=io.realm.internal.interop.NativePointer? origin=null
-      PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Owner> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.internal.RealmReference?
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Owner> (): io.realm.internal.RealmReference? declared in schema.input.C'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=io.realm.internal.RealmReference? origin=null
-                receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-$realm$Owner>' type=schema.input.C origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Owner> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.internal.RealmReference?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Owner visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Owner> (<set-?>: io.realm.internal.RealmReference?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.RealmReference?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Owner type:io.realm.internal.RealmReference? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-$realm$Owner>' type=schema.input.C origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.RealmReference? declared in schema.input.C.<set-$realm$Owner>' type=io.realm.internal.RealmReference? origin=null
-      PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$ClassName> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:kotlin.String?
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$ClassName> (): kotlin.String? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$ClassName> (): kotlin.String? declared in schema.input.C'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.String? origin=null
-                receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-$realm$ClassName>' type=schema.input.C origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$ClassName> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:kotlin.String?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$ClassName visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$ClassName> (<set-?>: kotlin.String?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$ClassName type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-$realm$ClassName>' type=schema.input.C origin=null
-              value: GET_VAR '<set-?>: kotlin.String? declared in schema.input.C.<set-$realm$ClassName>' type=kotlin.String? origin=null
-      PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private
-          EXPRESSION_BODY
-            CONST Boolean type=kotlin.Boolean value=false
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$IsManaged> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:kotlin.Boolean
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$IsManaged> (): kotlin.Boolean declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$IsManaged> (): kotlin.Boolean declared in schema.input.C'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Boolean origin=null
-                receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-$realm$IsManaged>' type=schema.input.C origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$IsManaged> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:kotlin.Boolean) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$IsManaged visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$IsManaged> (<set-?>: kotlin.Boolean): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$IsManaged type:kotlin.Boolean visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-$realm$IsManaged>' type=schema.input.C origin=null
-              value: GET_VAR '<set-?>: kotlin.Boolean declared in schema.input.C.<set-$realm$IsManaged>' type=kotlin.Boolean origin=null
-      PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$Mediator> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.internal.Mediator?
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$Mediator> (): io.realm.internal.Mediator? declared in schema.input.C'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=io.realm.internal.Mediator? origin=null
-                receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-$realm$Mediator>' type=schema.input.C origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$Mediator> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.internal.Mediator?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$Mediator visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$Mediator> (<set-?>: io.realm.internal.Mediator?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.Mediator?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$Mediator type:io.realm.internal.Mediator? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-$realm$Mediator>' type=schema.input.C origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.Mediator? declared in schema.input.C.<set-$realm$Mediator>' type=io.realm.internal.Mediator? origin=null
-      PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private
-          EXPRESSION_BODY
-            CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-$realm$metadata> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.internal.schema.ClassMetadata?
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-$realm$metadata> (): io.realm.internal.schema.ClassMetadata? declared in schema.input.C'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=io.realm.internal.schema.ClassMetadata? origin=null
-                receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-$realm$metadata>' type=schema.input.C origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-$realm$metadata> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.internal.schema.ClassMetadata?) returnType:kotlin.Unit
-          correspondingProperty: PROPERTY name:$realm$metadata visibility:public modality:OPEN [var]
-          overridden:
-            public abstract fun <set-$realm$metadata> (<set-?>: io.realm.internal.schema.ClassMetadata?): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-          $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.internal.schema.ClassMetadata?
-          BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$metadata type:io.realm.internal.schema.ClassMetadata? visibility:private' type=kotlin.Unit origin=null
-              receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-$realm$metadata>' type=schema.input.C origin=null
-              value: GET_VAR '<set-?>: io.realm.internal.schema.ClassMetadata? declared in schema.input.C.<set-$realm$metadata>' type=io.realm.internal.schema.ClassMetadata? origin=null
-      FUN FAKE_OVERRIDE name:delete visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Unit [fake_override]
-        overridden:
-          public open fun delete (): kotlin.Unit declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:emitFrozenUpdate visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference, change:io.realm.internal.interop.NativePointer, channel:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>) returnType:kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? [fake_override]
-        overridden:
-          public open fun emitFrozenUpdate (frozenRealm: io.realm.internal.RealmReference, change: io.realm.internal.interop.NativePointer, channel: kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>): kotlinx.coroutines.channels.ChannelResult<kotlin.Unit>? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:change index:1 type:io.realm.internal.interop.NativePointer
-        VALUE_PARAMETER name:channel index:2 type:kotlinx.coroutines.channels.SendChannel<io.realm.notifications.ObjectChange<io.realm.internal.RealmObjectInternal>>
-      FUN FAKE_OVERRIDE name:freeze visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, frozenRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun freeze (frozenRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:frozenRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:isFrozen visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:kotlin.Boolean [fake_override]
-        overridden:
-          public open fun isFrozen (): kotlin.Boolean [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:propertyInfoOrThrow visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, propertyName:kotlin.String) returnType:io.realm.internal.interop.PropertyInfo [fake_override]
-        overridden:
-          public open fun propertyInfoOrThrow (propertyName: kotlin.String): io.realm.internal.interop.PropertyInfo declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:propertyName index:0 type:kotlin.String
-      FUN FAKE_OVERRIDE name:realmState visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.internal.RealmState [fake_override]
-        overridden:
-          public open fun realmState (): io.realm.internal.RealmState declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-      FUN FAKE_OVERRIDE name:registerForNotification visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, callback:io.realm.internal.interop.Callback) returnType:io.realm.internal.interop.NativePointer [fake_override]
-        overridden:
-          public open fun registerForNotification (callback: io.realm.internal.interop.Callback): io.realm.internal.interop.NativePointer declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:callback index:0 type:io.realm.internal.interop.Callback
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-      FUN FAKE_OVERRIDE name:thaw visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal, liveRealm:io.realm.internal.RealmReference, clazz:kotlin.reflect.KClass<out io.realm.RealmObject>) returnType:io.realm.internal.RealmObjectInternal? [fake_override]
-        overridden:
-          public open fun thaw (liveRealm: io.realm.internal.RealmReference, clazz: kotlin.reflect.KClass<out io.realm.RealmObject>): io.realm.internal.RealmObjectInternal? declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
-        VALUE_PARAMETER name:liveRealm index:0 type:io.realm.internal.RealmReference
-        VALUE_PARAMETER name:clazz index:1 type:kotlin.reflect.KClass<out io.realm.RealmObject>
-      FUN FAKE_OVERRIDE name:version visibility:public modality:OPEN <> ($this:io.realm.internal.RealmObjectInternal) returnType:io.realm.VersionId [fake_override]
-        overridden:
-          public open fun version (): io.realm.VersionId [fake_override] declared in io.realm.internal.RealmObjectInternal
-        $this: VALUE_PARAMETER IR_EXTERNAL_DECLARATION_STUB name:<this> type:io.realm.internal.RealmObjectInternal
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:$realm$objectReference type:io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? visibility:private' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-$realm$objectReference>' type=schema.input.C origin=null
+              value: GET_VAR '<set-?>: io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? declared in schema.input.C.<set-$realm$objectReference>' type=io.realm.internal.ObjectReference<T of io.realm.internal.ObjectReference>? origin=null
     PROPERTY name:conf1 visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:conf1 type:io.realm.RealmConfiguration visibility:private [final,static]
         EXPRESSION_BODY

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/MutableRealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/MutableRealmTests.kt
@@ -28,6 +28,7 @@ import io.realm.entities.link.Parent
 import io.realm.query
 import io.realm.query.RealmQuery
 import io.realm.query.RealmSingleQuery
+import io.realm.test.assertFailsWithMessage
 import io.realm.test.platform.PlatformUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -563,7 +564,7 @@ class MutableRealmTests {
     @Test
     fun delete_unmanagedObjectsThrows() {
         realm.writeBlocking {
-            assertFailsWith<IllegalArgumentException> {
+            assertFailsWithMessage<IllegalArgumentException>("Cannot delete unmanaged object") {
                 delete(Parent())
             }
         }

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmSchemaTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/RealmSchemaTests.kt
@@ -245,14 +245,14 @@ public class RealmSchemaTests {
             copyToRealm(Sample())
         }
         // And grab the class metadata instance
-        val classCache = (sample1 as io.realm.internal.RealmObjectInternal).`$realm$metadata`
+        val classCache = (sample1 as io.realm.internal.RealmObjectInternal).`$realm$objectReference`!!.metadata
 
         val sample2 = realm.write {
             copyToRealm(Sample())
         }
 
         // Assert that this is the same for subsequent objects of the same type
-        assertTrue(classCache === (sample2 as io.realm.internal.RealmObjectInternal).`$realm$metadata`)
+        assertTrue(classCache === (sample2 as io.realm.internal.RealmObjectInternal).`$realm$objectReference`!!.metadata)
 
         // Update the schema
         (realm as io.realm.internal.RealmImpl).updateSchema(
@@ -272,9 +272,9 @@ public class RealmSchemaTests {
         val sample3 = realm.write {
             copyToRealm(Sample())
         }
-        assertFalse(classCache === (sample3 as io.realm.internal.RealmObjectInternal).`$realm$metadata`)
+        assertFalse(classCache === (sample3 as io.realm.internal.RealmObjectInternal).`$realm$objectReference`!!.metadata)
         // and that the old frozen objects still have the original class meta data instance
-        assertTrue(classCache === (sample1 as io.realm.internal.RealmObjectInternal).`$realm$metadata`)
-        assertTrue(classCache === (sample2 as io.realm.internal.RealmObjectInternal).`$realm$metadata`)
+        assertTrue(classCache === (sample1 as io.realm.internal.RealmObjectInternal).`$realm$objectReference`!!.metadata)
+        assertTrue(classCache === (sample2 as io.realm.internal.RealmObjectInternal).`$realm$objectReference`!!.metadata)
     }
 }

--- a/test/base/src/commonMain/kotlin/io/realm/test/util/Utils.kt
+++ b/test/base/src/commonMain/kotlin/io/realm/test/util/Utils.kt
@@ -42,7 +42,7 @@ object Utils {
  */
 suspend fun <T : RealmObject> T.update(block: T.() -> Unit): T {
     @Suppress("invisible_reference", "invisible_member")
-    val realm = ((this as io.realm.internal.RealmObjectInternal).`$realm$objectReference`!!.`$realm$Owner`!!).owner as Realm
+    val realm = ((this as io.realm.internal.RealmObjectInternal).`$realm$objectReference`!!.owner).owner as Realm
     return realm.write {
         val liveObject: T = findLatest(this@update)!!
         block(liveObject)

--- a/test/base/src/commonMain/kotlin/io/realm/test/util/Utils.kt
+++ b/test/base/src/commonMain/kotlin/io/realm/test/util/Utils.kt
@@ -42,7 +42,7 @@ object Utils {
  */
 suspend fun <T : RealmObject> T.update(block: T.() -> Unit): T {
     @Suppress("invisible_reference", "invisible_member")
-    val realm = ((this as io.realm.internal.RealmObjectInternal).`$realm$Owner`!!).owner as Realm
+    val realm = ((this as io.realm.internal.RealmObjectInternal).`$realm$objectReference`!!.`$realm$Owner`!!).owner as Realm
     return realm.write {
         val liveObject: T = findLatest(this@update)!!
         block(liveObject)

--- a/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
+++ b/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
@@ -115,9 +115,11 @@ class InstrumentedTests {
             val realmPointer: NativePointer = CPointerWrapper(ptr2.ptr)
             val configuration = RealmConfiguration.with(schema = setOf(Sample::class))
 
-            assertNotNull(realmModel.`$realm$objectReference`)
-            assertEquals(ptr1.rawPtr.toLong(), (realmModel.`$realm$objectReference`!!.objectPointer as CPointerWrapper).ptr.toLong())
-            assertEquals("Sample", realmModel.`$realm$objectReference`!!.className)
+            realmModel.`$realm$objectReference`?.run {
+                assertNotNull(this)
+                assertEquals(ptr1.rawPtr.toLong(), (objectPointer as CPointerWrapper).ptr.toLong())
+                assertEquals("Sample", className)
+            }
         }
     }
 }

--- a/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
+++ b/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
@@ -24,7 +24,7 @@ import io.realm.RealmObject
 import io.realm.entities.Sample
 import io.realm.internal.BaseRealmImpl
 import io.realm.internal.Mediator
-import io.realm.internal.ObjectReference
+import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmObjectCompanion
 import io.realm.internal.RealmObjectInternal
 import io.realm.internal.RealmReference
@@ -104,7 +104,7 @@ class InstrumentedTests {
             val ptr2: COpaquePointerVar = alloc()
 
             // Accessing getters/setters
-            realmModel.`$realm$objectReference` = ObjectReference(
+            realmModel.`$realm$objectReference` = RealmObjectReference(
                 type = RealmObject::class,
                 objectPointer = CPointerWrapper(ptr1.ptr),
                 className = "Sample",

--- a/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
+++ b/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
@@ -54,42 +54,6 @@ class InstrumentedTests {
     //  test is needed at all at this level
     class CPointerWrapper(val ptr: CPointer<out CPointed>?, managed: Boolean = true) : NativePointer
 
-    private val dummyRealmReference = object : RealmReference {
-        override val dbPointer: NativePointer
-            get() = TODO("Not yet implemented")
-        override val owner: BaseRealmImpl
-            get() = TODO("Not yet implemented")
-        override val schemaMetadata: SchemaMetadata
-            get() = object : SchemaMetadata {
-                override fun get(className: String): ClassMetadata = object : ClassMetadata {
-                    override val classKey: ClassKey
-                        get() = TODO("Not yet implemented")
-                    override val className: String
-                        get() = TODO("Not yet implemented")
-                    override val primaryKeyPropertyKey: PropertyKey?
-                        get() = TODO("Not yet implemented")
-
-                    override fun get(propertyKey: PropertyKey): PropertyInfo? {
-                        TODO("Not yet implemented")
-                    }
-
-                    override fun get(propertyName: String): PropertyInfo? {
-                        TODO("Not yet implemented")
-                    }
-                }
-            }
-    }
-
-    private val dummyMediator = object : Mediator {
-        override fun companionOf(clazz: KClass<out RealmObject>): RealmObjectCompanion {
-            TODO("Not yet implemented")
-        }
-
-        override fun createInstanceOf(clazz: KClass<out RealmObject>): RealmObjectInternal {
-            TODO("Not yet implemented")
-        }
-    }
-
     @Test
     @Suppress("invisible_reference", "invisible_member")
     fun testRealmObjectInternalPropertiesGenerated() {
@@ -120,6 +84,38 @@ class InstrumentedTests {
                 assertEquals(ptr1.rawPtr.toLong(), (objectPointer as CPointerWrapper).ptr.toLong())
                 assertEquals("Sample", className)
             }
+        }
+    }
+
+    class MockRealmReference : RealmReference {
+        override val dbPointer: NativePointer
+            get() = TODO("Not yet implemented")
+        override val owner: BaseRealmImpl
+            get() = TODO("Not yet implemented")
+        override val schemaMetadata: SchemaMetadata
+            get() = object : SchemaMetadata {
+                override fun get(className: String): ClassMetadata = object : ClassMetadata {
+                    override val classKey: ClassKey
+                        get() = TODO("Not yet implemented")
+                    override val className: String
+                        get() = TODO("Not yet implemented")
+                    override val primaryKeyPropertyKey: PropertyKey?
+                        get() = TODO("Not yet implemented")
+                    override fun get(propertyKey: PropertyKey): PropertyInfo? {
+                        TODO("Not yet implemented")
+                    }
+                    override fun get(propertyName: String): PropertyInfo? {
+                        TODO("Not yet implemented")
+                    }
+                }
+            }
+    }
+    class MockMediator : Mediator {
+        override fun companionOf(clazz: KClass<out RealmObject>): RealmObjectCompanion {
+            TODO("Not yet implemented")
+        }
+        override fun createInstanceOf(clazz: KClass<out RealmObject>): RealmObjectInternal {
+            TODO("Not yet implemented")
         }
     }
 }

--- a/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
+++ b/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
@@ -72,8 +72,8 @@ class InstrumentedTests {
                 type = RealmObject::class,
                 objectPointer = CPointerWrapper(ptr1.ptr),
                 className = "Sample",
-                owner = dummyRealmReference,
-                mediator = dummyMediator
+                owner = MockRealmReference(),
+                mediator = MockMediator()
             )
 
             val realmPointer: NativePointer = CPointerWrapper(ptr2.ptr)

--- a/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
+++ b/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
@@ -20,7 +20,9 @@ package io.realm.test
 // FIXME API-CLEANUP Do we actually want to expose this. Test should probably just be reeavluated
 //  or moved.
 import io.realm.RealmConfiguration
+import io.realm.RealmObject
 import io.realm.entities.Sample
+import io.realm.internal.ObjectReference
 import io.realm.internal.interop.NativePointer
 import kotlinx.cinterop.COpaquePointerVar
 import kotlinx.cinterop.CPointed
@@ -31,6 +33,7 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.toLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class InstrumentedTests {
 
@@ -54,16 +57,16 @@ class InstrumentedTests {
             val ptr2: COpaquePointerVar = alloc()
 
             // Accessing getters/setters
-            realmModel.`$realm$IsManaged` = true
-            realmModel.`$realm$ObjectPointer` = CPointerWrapper(ptr1.ptr)
+            realmModel.`$realm$objectReference` = ObjectReference(RealmObject::class)
+            realmModel.`$realm$objectReference`!!.objectPointer = CPointerWrapper(ptr1.ptr)
 
             val realmPointer: NativePointer = CPointerWrapper(ptr2.ptr)
             val configuration = RealmConfiguration.with(schema = setOf(Sample::class))
-            realmModel.`$realm$ClassName` = "Sample"
+            realmModel.`$realm$objectReference`!!.className = "Sample"
 
-            assertEquals(true, realmModel.`$realm$IsManaged`)
-            assertEquals(ptr1.rawPtr.toLong(), (realmModel.`$realm$ObjectPointer` as CPointerWrapper).ptr.toLong())
-            assertEquals("Sample", realmModel.`$realm$ClassName`)
+            assertNotNull(realmModel.`$realm$objectReference`)
+            assertEquals(ptr1.rawPtr.toLong(), (realmModel.`$realm$objectReference`!!.objectPointer as CPointerWrapper).ptr.toLong())
+            assertEquals("Sample", realmModel.`$realm$objectReference`!!.className)
         }
     }
 }

--- a/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
+++ b/test/base/src/macosTest/kotlin/io/realm/test/InstrumentedTests.kt
@@ -24,9 +24,9 @@ import io.realm.RealmObject
 import io.realm.entities.Sample
 import io.realm.internal.BaseRealmImpl
 import io.realm.internal.Mediator
-import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmObjectCompanion
 import io.realm.internal.RealmObjectInternal
+import io.realm.internal.RealmObjectReference
 import io.realm.internal.RealmReference
 import io.realm.internal.interop.ClassKey
 import io.realm.internal.interop.NativePointer


### PR DESCRIPTION
Moves all properties from `RealmObjectInternal` into the composite object `ObjectReference`. By doing this we can enforce the invariant that only an object with the composite object is a managed object, and thus all its properties must be non-null.

Tasks
- [x] Refactor base code.
- [x] Update compiler plugin to use the new composite object and adopt invariants.
- [x] Remove now unnecessary nullability asserts.
- [x] Rename properties, no need to hide them behind a dollar sign.
- [x] Homogenise object creation and linking.

This PR does not try to optimize the access to the the native pointer, neither tries to merge `RealmObjectHelper` in `ObjectReference`.