### PR TITLE
Introduce SyncedRealmContext and expose Realm.syncSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements
 * [Sync] Support for new types of `Credentials`: `apiKey`, `apple`, `facebook`, `google` and `jwt`.
+* [Sync] Support for the extension property `Realm.syncSession`, which returns the sync session associated with the realm.
 
 ### Fixed
 * None.

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -215,6 +215,8 @@ expect object RealmInterop {
     )
     fun realm_sync_set_error_handler(syncConfig: NativePointer, errorHandler: SyncErrorCallback)
 
+    fun realm_sync_session_get(realm: NativePointer): NativePointer
+
     // AppConfig
     fun realm_network_transport_new(networkTransport: NetworkTransport): NativePointer
     fun realm_app_config_new(

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -1481,6 +1481,10 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_sync_session_get(realm: NativePointer): NativePointer {
+        return CPointerWrapper(realm_wrapper.realm_sync_session_get(realm.cptr()))
+    }
+
     actual fun realm_network_transport_new(networkTransport: NetworkTransport): NativePointer {
         return CPointerWrapper(
             realm_wrapper.realm_http_transport_new(

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -744,6 +744,10 @@ actual object RealmInterop {
         realmc.sync_set_error_handler(syncConfig.cptr(), errorHandler)
     }
 
+    actual fun realm_sync_session_get(realm: NativePointer): NativePointer {
+        return LongPointerWrapper(realmc.realm_sync_session_get(realm.cptr()))
+    }
+
     @Suppress("LongParameterList")
     actual fun realm_app_config_new(
         appId: String,

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -160,7 +160,8 @@ return $jnicall;
                realm_results_t*, realm_notification_token_t*, realm_object_changes_t*,
                realm_list_t*, realm_app_credentials_t*, realm_app_config_t*, realm_app_t*,
                realm_sync_client_config_t*, realm_user_t*, realm_sync_config_t*,
-               realm_http_completion_func_t, realm_http_transport_t*, realm_collection_changes_t*};
+               realm_sync_session_t*, realm_http_completion_func_t, realm_http_transport_t*,
+               realm_collection_changes_t*};
 
 // For all functions returning a pointer or bool, check for null/false and throw an error if
 // realm_get_last_error returns true.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/BaseRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/BaseRealmImpl.kt
@@ -45,7 +45,7 @@ public abstract class BaseRealmImpl internal constructor(
      * updated to point to a new frozen version after writes or notification, so care should be
      * taken not to spread operations over different references.
      */
-    internal abstract val realmReference: RealmReference
+    public abstract val realmReference: RealmReference
 
     override fun realmState(): RealmState {
         return realmReference

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlin.reflect.KClass
 
 // TODO API-PUBLIC Document platform specific internals (RealmInitializer, etc.)
+// TODO Public due to being accessed from `SyncedRealmContext`
 public class RealmImpl private constructor(
     configuration: InternalConfiguration,
     dbPointer: NativePointer

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmImpl.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlin.reflect.KClass
 
 // TODO API-PUBLIC Document platform specific internals (RealmInitializer, etc.)
-internal class RealmImpl private constructor(
+public class RealmImpl private constructor(
     configuration: InternalConfiguration,
     dbPointer: NativePointer
 ) : BaseRealmImpl(configuration), Realm, InternalTypedRealm, Flowable<RealmChange<Realm>> {
@@ -82,6 +82,10 @@ internal class RealmImpl private constructor(
     //  constructing the initial frozen version in the initialization of updatableRealm.
     private val versionTracker = VersionTracker(log)
 
+    // Injection point for synchronized Realms. This property should only be used to hold state
+    // required by synchronized realms. See `SyncedRealmContext` for more details.
+    public var syncContext: AtomicRef<Any?> = atomic(null)
+
     init {
         // TODO Find a cleaner way to get the initial frozen instance. Currently we expect the
         //  primary constructor supplied dbPointer to be a pointer to a live realm, so get the
@@ -98,7 +102,7 @@ internal class RealmImpl private constructor(
         }
     }
 
-    constructor(configuration: InternalConfiguration) :
+    internal constructor(configuration: InternalConfiguration) :
         this(
             configuration,
             try {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/RealmExt.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/RealmExt.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.mongodb
+
+import io.realm.Realm
+import io.realm.mongodb.internal.SyncedRealmContext
+import io.realm.mongodb.internal.executeInSyncContext
+
+/**
+ * This class contains extension methods that are available when using synced realms.
+ *
+ * Calling these methods on a local realms created using a [io.realm.RealmConfiguration] will
+ * throw an [IllegalStateException].
+ */
+
+/**
+ * Returns the [SyncSession] associated with this Realm.
+ */
+public val Realm.syncSession: SyncSession
+    get() {
+        return executeInSyncContext(this) { context: SyncedRealmContext ->
+            context.session
+        }
+    }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncedRealmContext.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/SyncedRealmContext.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.mongodb.internal
+
+import io.realm.Realm
+import io.realm.internal.RealmImpl
+import io.realm.internal.interop.NativePointer
+import io.realm.internal.interop.RealmInterop
+import io.realm.mongodb.SyncConfiguration
+import io.realm.mongodb.SyncSession
+
+/**
+ * Since extension functions has limited capabilities, like not allowing backing fields. This class
+ * contains all fields and functionality needed to expose public Sync API's. Meaning that the
+ * extension functions only need to verify that the call is valid and otherwise just delegate
+ * to this class.
+ *
+ * In order to work around the bootstrap problem, all public API entry points that access this
+ * class must do so through the [executeInSyncContext] closure.
+ */
+internal class SyncedRealmContext(db: NativePointer) {
+    internal val session: SyncSession = SyncSessionImpl(RealmInterop.realm_sync_session_get(db))
+}
+
+/**
+ * Helper methods that can be used by public API entry points to grant safe access to the
+ * [SyncedRealmContext], or otherwise throw an appropriate exception.
+ */
+internal fun <T> executeInSyncContext(realm: Realm, block: (context: SyncedRealmContext) -> T): T {
+    val config = realm.configuration
+    if (config is SyncConfiguration) {
+        if (realm is RealmImpl) {
+            val context: SyncedRealmContext = initSyncContextIfNeeded(realm)
+            return block(context)
+        } else {
+            // Should never happen. Indicates a problem with our internal architecture.
+            throw IllegalStateException("This method is not available on objects of type: $realm")
+        }
+    } else {
+        // Public error
+        throw IllegalStateException("This method is only available on synchronized realms.")
+    }
+}
+
+private fun initSyncContextIfNeeded(realm: RealmImpl): SyncedRealmContext {
+    // INVARIANT: `syncContext` is only ever set once, and never to `null`.
+    // This code works around the fact that `Mutex`'s can only be locked inside suspend functions on
+    // Kotlin Native.
+    val syncContext = realm.syncContext
+    return if (syncContext.value != null) {
+        syncContext.value!! as SyncedRealmContext
+    } else {
+        // Worst case, two SyncedRealmContext will be created and one of them will thrown
+        // away. As long as SyncedRealmContext is cheap to create, this should be fine. If, at
+        // some point, it start having too much state, we can consider making `lazy` properties
+        // inside the class to defer the construction cost.
+        syncContext.compareAndSet(null, SyncedRealmContext(realm.realmReference.dbPointer))
+        syncContext.value!! as SyncedRealmContext
+    }
+}

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncSessionTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncSessionTests.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.test.mongodb.shared
+
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import io.realm.entities.sync.ChildPk
+import io.realm.entities.sync.ParentPk
+import io.realm.internal.platform.runBlocking
+import io.realm.mongodb.SyncConfiguration
+import io.realm.mongodb.SyncSession
+import io.realm.mongodb.User
+import io.realm.mongodb.syncSession
+import io.realm.test.mongodb.TestApp
+import io.realm.test.mongodb.asTestApp
+import io.realm.test.mongodb.createUserAndLogIn
+import io.realm.test.platform.PlatformUtils
+import io.realm.test.util.TestHelper
+import io.realm.test.util.use
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+class SyncSessionTests {
+
+    private lateinit var user: User
+    private lateinit var tmpDir: String
+    private lateinit var app: TestApp
+
+    @BeforeTest
+    fun setup() {
+        app = TestApp()
+        val (email, password) = TestHelper.randomEmail() to "password1234"
+        user = runBlocking {
+            app.createUserAndLogIn(email, password)
+        }
+        tmpDir = PlatformUtils.createTempDir()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (this::app.isInitialized) {
+            app.asTestApp.close()
+        }
+        PlatformUtils.deleteTempDir(tmpDir)
+    }
+
+    @Test
+    fun session() {
+        val config = createSyncConfig(user, tmpDir)
+        Realm.open(config).use { realm: Realm ->
+            val session: SyncSession = realm.syncSession
+            assertNotNull(session)
+        }
+    }
+
+    // The same object is returned for each call to `Realm.session`
+    @Test
+    fun session_identity() {
+        val config = createSyncConfig(user, tmpDir)
+        Realm.open(config).use { realm: Realm ->
+            val session1: SyncSession = realm.syncSession
+            val session2: SyncSession = realm.syncSession
+            assertSame(session1, session2)
+        }
+    }
+
+    // If multiple instances of the same Realm is opened. The Kotlin SyncSession objects will
+    // differ, but they point to the same underlying Core Sync Session.
+    @Test
+    fun session_sharedStateBetweenRealms() {
+        val config1 = createSyncConfig(user, tmpDir, "realm1.realm")
+        val config2 = createSyncConfig(user, tmpDir, "realm2.realm")
+        val realm1 = Realm.open(config1)
+        val realm2 = Realm.open(config2)
+        assertNotEquals(realm1.configuration.path, realm2.configuration.path)
+        assertNotSame(realm1.syncSession, realm2.syncSession)
+        // TODO I don't think there is a good way to test this until we have more knobs to turn
+        //  on SyncSession. One option is using `start/stop` and `getState()`.
+    }
+
+    @Test
+    fun session_localRealmThrows() {
+        val config = RealmConfiguration.Builder(schema = setOf(ParentPk::class, ChildPk::class))
+            .directory(tmpDir)
+            .build()
+        Realm.open(config).use { realm ->
+            assertFailsWith<IllegalStateException> { realm.syncSession }
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun createSyncConfig(
+        user: User,
+        directory: String? = null,
+        name: String = DEFAULT_NAME,
+    ): SyncConfiguration = SyncConfiguration.Builder(
+        schema = setOf(ParentPk::class, ChildPk::class),
+        user = user,
+        partitionValue = DEFAULT_PARTITION_VALUE
+    )
+        .directory(directory)
+        .name(name)
+        .build()
+}


### PR DESCRIPTION
Closes #246 

This PR lays the groundwork for exposing sync functionality in the public API, starting with `Realm.syncSession`.

**API Notes**

- In Java we have a `Sync` class which basically just keep tracks of SyncSessions across thread-confined Realm instances and then offer the `reconnect()` method. Since the Realm instance is thread-safe in Kotlin, the need for such a class seems non-existent. So for now I don't think it is worth exposing it. We can offer the `reconnect()` method on the `SyncSession` directly. That it also reconnects all other sessions is just a side-effect that should be okay.


**Some design notes:**

- I kept `Realm.open` as is and then lazily inject the `SyncedRealmContext` on first access. This has the drawback that all public API entry points must be accessed in a special way, but the expectation is that this number is going to be low, basically just `Realm.syncSession` and `Realm.subscriptions`.

- I attempted to create a new extension function `Realm.open(SyncConfiguration)` alongside the default `Realm.open(RealmConfiguration)`, but ruled it out as 1) It was a breaking change compared to the current and 2) Discoverability of extension methods still seem a bit poor, which is problematic for the main entry API. 

- I also tried to adjust the current API with two new `Realm.open()` extension methods, one for each configuration type, but that changes the import required to call `open()` which would yet again break `Realm.open(RealmConfiguration)`, so I ruled it out.

- I toyed with the idea of introducing the same `ObjectServerFacade` we have in Java, but we don't have nearly as many extension points we need to track + it introduces reflection on startup, so I ruled it out and went with the current approach using atomic refs.