### PR TITLE
Add support for `User.remove()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 * [Sync] Support for the extension property `Realm.syncSession`, which returns the sync session associated with the realm.
 * [Sync] Support for `SyncSession.downloadAllServerChanges()` and `SyncSession.uploadAllLocalChanges()`.
 * [Sync] Support for `App.allUsers()`.
+* [Sync] Support for `User.remove()`.
 
 ### Fixed
-* Using latest Kotlin version (EAP) for the `kmm-sample` app to test compatibility with the latest/upcoming Kotlin version. 
+* Using latest Kotlin version (EAP) for the `kmm-sample` app to test compatibility with the latest/upcoming Kotlin version.
 
 ### Compatibility
 * This release is compatible with:

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -232,6 +232,7 @@ expect object RealmInterop {
     fun realm_app_get_all_users(app: RealmAppPointer): List<RealmUserPointer>
     fun realm_app_log_in_with_credentials(app: RealmAppPointer, credentials: RealmCredentialsPointer, callback: AppCallback<RealmUserPointer>)
     fun realm_app_log_out(app: RealmAppPointer, user: RealmUserPointer, callback: AppCallback<Unit>)
+    fun realm_app_remove_user(app: RealmAppPointer, user: RealmUserPointer, callback: AppCallback<Unit>)
     fun realm_clear_cached_apps()
 
     // User

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -1428,6 +1428,26 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_app_remove_user(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        callback: AppCallback<Unit>
+    ) {
+        checkedBooleanResult(
+            realm_wrapper.realm_app_remove_user(
+                app.cptr(),
+                user.cptr(),
+                staticCFunction { userData, error ->
+                    handleAppCallback(userData, error) { /* No-op, returns Unit */ }
+                },
+                StableRef.create(callback).asCPointer(),
+                staticCFunction { userdata ->
+                    disposeUserData<AppCallback<RealmUserPointer>>(userdata)
+                }
+            )
+        )
+    }
+
     actual fun realm_clear_cached_apps() {
         realm_wrapper.realm_clear_cached_apps()
     }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -682,6 +682,14 @@ actual object RealmInterop {
         realmc.realm_app_log_out(app.cptr(), user.cptr(), callback)
     }
 
+    actual fun realm_app_remove_user(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        callback: AppCallback<Unit>
+    ) {
+        realmc.realm_app_remove_user(app.cptr(), user.cptr(), callback)
+    }
+
     actual fun realm_app_get_current_user(app: RealmAppPointer): RealmUserPointer? {
         val ptr = realmc.realm_app_get_current_user(app.cptr())
         return nativePointerOrNull(ptr)

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -291,10 +291,17 @@ jobject app_exception_from_app_error(JNIEnv* env, const realm_app_error_t* error
                                                 "(Ljava/lang/String;)V");
 
     std::stringstream message;
+
+    // This is needed to avoid sending NULL to the "<<" operator as it will crash otherwise
+    const char* server_logs = "NO LOGS";
+    if (error->link_to_server_logs != nullptr) {
+        server_logs = error->link_to_server_logs;
+    }
+
     message << error->message << " ["
             << "error_category=" << error->error_category << ", "
             << "error_code=" << error->error_code << ", "
-            << "link_to_server_logs=" << error->link_to_server_logs
+            << "link_to_server_logs=" << server_logs
             << "]";
 
     return env->NewObject(JavaClassGlobalDef::app_exception_class(),

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/User.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/User.kt
@@ -70,6 +70,18 @@ public interface User {
     public suspend fun logOut()
 
     /**
+     * Removes the user and any Realms the user has from the device. No data is removed from the
+     * server.
+     *
+     * If the user is logged in when calling this method, the user will be logged out before any
+     * data is deleted.
+     *
+     * @throws AppException if an error occurred while trying to remove the user.
+     * @return the user that was removed.
+     */
+    public suspend fun remove(): User
+
+    /**
      * Two Users are considered equal if they have the same user identity and are associated
      * with the same app.
      */

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/UserImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/UserImpl.kt
@@ -50,9 +50,24 @@ public class UserImpl(
                     // No-op
                 }.freeze()
             )
-            return channel.receive()
+            return@use channel.receive()
                 .getOrThrow()
         }
+    }
+
+    override suspend fun remove(): User {
+        Channel<Result<Unit>>(1).use { channel ->
+            RealmInterop.realm_app_remove_user(
+                app.nativePointer,
+                nativePointer,
+                channelResultCallback<Unit, Unit>(channel) {
+                    // No-op
+                }.freeze()
+            )
+            return@use channel.receive()
+                .getOrThrow()
+        }
+        return this
     }
 
     override fun equals(other: Any?): Boolean {

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -26,6 +26,7 @@ import io.realm.test.mongodb.asTestApp
 import io.realm.test.util.TestHelper.randomEmail
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -265,6 +266,7 @@ class UserTests {
 //
 
     @Test
+    @Ignore
     fun removeUser() {
         runBlocking {
             // Removing logged in user
@@ -288,6 +290,7 @@ class UserTests {
     }
 
     @Test
+    @Ignore
     fun removeUser_throwsIfUserAlreadyRemoved() {
         runBlocking {
             val user1 = createUserAndLogin()

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -29,7 +29,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -29,6 +29,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -269,7 +270,7 @@ class UserTests {
            val user1 = createUserAndLogin()
            assertEquals(user1, app.currentUser)
            assertEquals(1, app.allUsers().size)
-           user1.remove()
+           assertEquals(user1, user1.remove())
            assertEquals(User.State.REMOVED, user1.state)
            assertNull(app.currentUser)
            assertEquals(0, app.allUsers().size)
@@ -279,7 +280,7 @@ class UserTests {
            user2.logOut()
            assertNull(app.currentUser)
            assertEquals(1, app.allUsers().size)
-           user2.remove()
+           assertEquals(user2, user2.remove())
            assertEquals(User.State.REMOVED, user2.state)
            assertEquals(0, app.allUsers().size)
        }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -266,7 +266,6 @@ class UserTests {
 //
 
     @Test
-    @Ignore
     fun removeUser() {
         runBlocking {
             // Removing logged in user

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -261,29 +261,30 @@ class UserTests {
 //        }
 //    }
 //
-//    @Test
-//    fun removeUser() {
-//        anonUser.logOut() // Remove user used by other tests
-//
-//        // Removing logged in user
-//        val user1 = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
-//        assertEquals(user1, app.currentUser)
-//        assertEquals(1, app.allUsers().size)
-//        app.removeUser(user1)
-//        assertEquals(User.State.REMOVED, user1.state)
-//        assertNull(app.currentUser)
-//        assertEquals(0, app.allUsers().size)
-//
-//        // Remove logged out user
-//        val user2 = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
-//        user2.logOut()
-//        assertNull(app.currentUser)
-//        assertEquals(1, app.allUsers().size)
-//        app.removeUser(user2)
-//        assertEquals(User.State.REMOVED, user2.state)
-//        assertEquals(0, app.allUsers().size)
-//    }
-//
+
+   @Test
+   fun removeUser() {
+       runBlocking {
+           // Removing logged in user
+           val user1 = createUserAndLogin()
+           assertEquals(user1, app.currentUser)
+           assertEquals(1, app.allUsers().size)
+           user1.remove()
+           assertEquals(User.State.REMOVED, user1.state)
+           assertNull(app.currentUser)
+           assertEquals(0, app.allUsers().size)
+
+           // Remove logged out user
+           val user2 = createUserAndLogin()
+           user2.logOut()
+           assertNull(app.currentUser)
+           assertEquals(1, app.allUsers().size)
+           user2.remove()
+           assertEquals(User.State.REMOVED, user2.state)
+           assertEquals(0, app.allUsers().size)
+       }
+   }
+
 //    @Test
 //    fun getApiKeyAuthProvider() {
 //        val user: User = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -26,7 +26,6 @@ import io.realm.test.mongodb.asTestApp
 import io.realm.test.util.TestHelper.randomEmail
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -263,28 +263,28 @@ class UserTests {
 //    }
 //
 
-   @Test
-   fun removeUser() {
-       runBlocking {
-           // Removing logged in user
-           val user1 = createUserAndLogin()
-           assertEquals(user1, app.currentUser)
-           assertEquals(1, app.allUsers().size)
-           assertEquals(user1, user1.remove())
-           assertEquals(User.State.REMOVED, user1.state)
-           assertNull(app.currentUser)
-           assertEquals(0, app.allUsers().size)
+    @Test
+    fun removeUser() {
+        runBlocking {
+            // Removing logged in user
+            val user1 = createUserAndLogin()
+            assertEquals(user1, app.currentUser)
+            assertEquals(1, app.allUsers().size)
+            assertEquals(user1, user1.remove())
+            assertEquals(User.State.REMOVED, user1.state)
+            assertNull(app.currentUser)
+            assertEquals(0, app.allUsers().size)
 
-           // Remove logged out user
-           val user2 = createUserAndLogin()
-           user2.logOut()
-           assertNull(app.currentUser)
-           assertEquals(1, app.allUsers().size)
-           assertEquals(user2, user2.remove())
-           assertEquals(User.State.REMOVED, user2.state)
-           assertEquals(0, app.allUsers().size)
-       }
-   }
+            // Remove logged out user
+            val user2 = createUserAndLogin()
+            user2.logOut()
+            assertNull(app.currentUser)
+            assertEquals(1, app.allUsers().size)
+            assertEquals(user2, user2.remove())
+            assertEquals(User.State.REMOVED, user2.state)
+            assertEquals(0, app.allUsers().size)
+        }
+    }
 
 //    @Test
 //    fun getApiKeyAuthProvider() {

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -18,6 +18,7 @@ package io.realm.test.mongodb.shared
 
 import io.realm.internal.platform.runBlocking
 import io.realm.mongodb.App
+import io.realm.mongodb.AppException
 import io.realm.mongodb.Credentials
 import io.realm.mongodb.User
 import io.realm.test.mongodb.TestApp
@@ -27,6 +28,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotSame
@@ -282,6 +284,17 @@ class UserTests {
             assertEquals(user2, user2.remove())
             assertEquals(User.State.REMOVED, user2.state)
             assertEquals(0, app.allUsers().size)
+        }
+    }
+
+    @Test
+    fun removeUser_throwsIfUserAlreadyRemoved() {
+        runBlocking {
+            val user1 = createUserAndLogin()
+            assertEquals(user1, user1.remove())
+            assertFailsWith<AppException> {
+                user1.remove()
+            }
         }
     }
 

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/UserTests.kt
@@ -290,7 +290,6 @@ class UserTests {
     }
 
     @Test
-    @Ignore
     fun removeUser_throwsIfUserAlreadyRemoved() {
         runBlocking {
             val user1 = createUserAndLogin()


### PR DESCRIPTION
Closes #244

Added `User.remove()`. We decided not to implement `App.removeUser(user)` as we can grab users with `App.allUsers()` and delete them from there.