### PR TITLE
Request to expose removeSystemLogger() in Configuration.SharedBuilder

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
@@ -280,7 +280,7 @@ public interface Configuration {
          * @see [Configuration.Builder.log]
          */
         // TODO Evaluate if this should be part of the public API. For now keep it internal.
-        internal fun removeSystemLogger() = apply { this.removeSystemLogger = true } as S
+        public fun removeSystemLogger() = apply { this.removeSystemLogger = true } as S
 
         protected fun validateEncryptionKey(encryptionKey: ByteArray): ByteArray {
             if (encryptionKey.size != Realm.ENCRYPTION_KEY_LENGTH) {


### PR DESCRIPTION
Hi Realm-Kotlin Team!

I'm trying to implement a Koin Test with Realm. [Link to an example repo](https://github.com/thipokch/KoinXRealm).

However, it failed with ExceptionInInitializerError at the following line:
https://github.com/realm/realm-kotlin/blob/d457df0aaa6475572931f7969dec5ab699744475/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt#L117-L119


I would like to be able to remove the system logger by exposing this function to be able to perform tests with Koin.

https://github.com/realm/realm-kotlin/blob/d457df0aaa6475572931f7969dec5ab699744475/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt#L282-L283


***

Here's the full stack trace for the error.

```
java.lang.ExceptionInInitializerError
	at io.realm.RealmConfiguration$Builder.build(RealmConfiguration.kt:76)
	at io.realm.RealmConfiguration$Companion.with(RealmConfiguration.kt:102)
	at ch.thipok.koinxrealm.di.PlatformModulesKt$platformModules$1$1.invoke(platformModules.kt:10)
	at ch.thipok.koinxrealm.di.PlatformModulesKt$platformModules$1$1.invoke(platformModules.kt:10)
	at org.koin.core.instance.InstanceFactory.create(InstanceFactory.kt:53)
	at org.koin.core.instance.SingleInstanceFactory.create(SingleInstanceFactory.kt:46)
	at org.koin.core.instance.SingleInstanceFactory$get$1.invoke(SingleInstanceFactory.kt:53)
	at org.koin.core.instance.SingleInstanceFactory$get$1.invoke(SingleInstanceFactory.kt:51)
	at org.koin.mp.KoinPlatformTools.synchronized(PlatformToolsJVM.kt:20)
	at org.koin.core.instance.SingleInstanceFactory.get(SingleInstanceFactory.kt:51)
	at org.koin.core.registry.InstanceRegistry.resolveInstance$koin_core(InstanceRegistry.kt:110)
	at org.koin.core.scope.Scope.resolveValue(Scope.kt:254)
	at org.koin.core.scope.Scope.resolveInstance(Scope.kt:241)
	at org.koin.core.scope.Scope.get(Scope.kt:204)
	at ch.thipok.koinxrealm.RepositoryTest$special$$inlined$inject$default$1.invoke(KoinTest.kt:53)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at ch.thipok.koinxrealm.RepositoryTest.getRealmConfiguration(realmTest.kt:16)
	at ch.thipok.koinxrealm.RepositoryTest.testRealmInit(realmTest.kt:32)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.NullPointerException: RELEASE must not be null
	at io.realm.internal.platform.SystemUtilsAndroidKt.<clinit>(SystemUtilsAndroid.kt:8)
	... 62 more

```