### PR TITLE
Cleanup HttpEngine in tests

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/sync/NetworkTransport.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/sync/NetworkTransport.kt
@@ -36,6 +36,12 @@ interface NetworkTransport {
         body: String,
         callback: ResponseCallback
     )
+
+    /**
+     * Close any native resources associated with running a NetworkClient.
+     * E.g. in Ktor, the HttpClient should be closed
+     */
+    fun close()
 }
 
 fun interface ResponseCallback {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
@@ -14,7 +14,6 @@ import io.realm.internal.platform.freeze
  * This allows us to either cache the Client or re-create it pr. request
  * on a platform basis.
  */
-
 internal fun createClient(timeoutMs: Long, customLogger: Logger?): HttpClient {
     // Need to freeze value as it is used inside the client's init lambda block, which also
     // freezes captured objects too, see:
@@ -46,6 +45,7 @@ internal fun createClient(timeoutMs: Long, customLogger: Logger?): HttpClient {
 
 internal expect class HttpClientCache(timeoutMs: Long, customLogger: Logger? = null) {
     fun getClient(): HttpClient
+    fun close() // Close any resources stored in the cache.
 }
 
 public expect fun createPlatformClient(block: HttpClientConfig<*>.() -> Unit): HttpClient

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/KtorNetworkTransport.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/internal/KtorNetworkTransport.kt
@@ -24,7 +24,6 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
-import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.statement.HttpResponse
@@ -52,7 +51,6 @@ public class KtorNetworkTransport(
     logger: Logger? = null,
 ) : NetworkTransport {
 
-    // FIXME Figure out how to reuse the HttpClient across all network requests.
     private val clientCache: HttpClientCache = HttpClientCache(timeoutMs, logger)
 
     @Suppress("ComplexMethod", "TooGenericExceptionCaught")
@@ -63,14 +61,7 @@ public class KtorNetworkTransport(
         body: String,
         callback: ResponseCallback,
     ) {
-        // FIXME When using a shared HttpClient we are seeing sporadic
-        //  network failures on macOS. They manifest as ClientRequestException
-        //  even though the request appear to be valid. This could indicate
-        //  that some state isn't cleaned up correctly between requests, but
-        //  it is unclear what. As a temporary work-around, we now create a
-        //  HttpClient pr. request.
         val client = clientCache.getClient()
-
         CoroutineScope(dispatcher).async {
             val response = try {
                 val requestBuilderBlock: HttpRequestBuilder.() -> Unit = {
@@ -105,7 +96,13 @@ public class KtorNetworkTransport(
                 }
                 when (method) {
                     "delete" -> client.delete<HttpResponse>(url, requestBuilderBlock)
-                    "patch" -> client.patch<HttpResponse>(url, requestBuilderBlock)
+                    "patch" -> {
+                        // PATCH is currently broken on macOS (Ktor 1.8.6): https://youtrack.jetbrains.com/issue/KTOR-4101/JsonFeature:-HttpClient-always-timeout-when-sending-PATCH-reques
+                        // But not used by user API's. Throw if we, in the future, attempt to use it
+                        // as we need to implement a work-around.
+                        // client.patch<HttpResponse>(url, requestBuilderBlock)
+                        throw IllegalArgumentException("PATCH requests are not supported: $url")
+                    }
                     "post" -> client.post<HttpResponse>(url, requestBuilderBlock)
                     "put" -> client.put<HttpResponse>(url, requestBuilderBlock)
                     "get" -> client.get<HttpResponse>(url, requestBuilderBlock)
@@ -127,6 +124,10 @@ public class KtorNetworkTransport(
             }
             callback.response(response)
         }
+    }
+
+    override fun close() {
+        clientCache.close()
     }
 
     private suspend fun processHttpResponse(response: HttpResponse): Response {

--- a/packages/library-sync/src/iosMain/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/iosMain/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
@@ -7,12 +7,14 @@ import io.ktor.client.features.logging.Logger
 
 /**
  * Cache HttpClient on iOS.
- * https://github.com/realm/realm-kotlin/issues/480 only seem to be a problem on macOS.
  */
 internal actual class HttpClientCache actual constructor(timeoutMs: Long, customLogger: Logger?) {
-    private val client = createClient(timeoutMs, customLogger)
+    private val client: HttpClient by lazy { createClient(timeoutMs, customLogger) }
     actual fun getClient(): HttpClient {
         return client
+    }
+    actual fun close() {
+        client.close()
     }
 }
 

--- a/packages/library-sync/src/jvm/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/jvm/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
@@ -11,9 +11,12 @@ import io.ktor.client.features.logging.Logger
  * https://github.com/realm/realm-kotlin/issues/480 only seem to be a problem on macOS.
  */
 internal actual class HttpClientCache actual constructor(timeoutMs: Long, customLogger: Logger?) {
-    private val client = createClient(timeoutMs, customLogger)
+    private val client: HttpClient by lazy { createClient(timeoutMs, customLogger) }
     actual fun getClient(): HttpClient {
         return client
+    }
+    actual fun close() {
+        client.close()
     }
 }
 

--- a/packages/library-sync/src/jvm/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/jvm/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
@@ -11,12 +11,12 @@ import io.ktor.client.features.logging.Logger
  * https://github.com/realm/realm-kotlin/issues/480 only seem to be a problem on macOS.
  */
 internal actual class HttpClientCache actual constructor(timeoutMs: Long, customLogger: Logger?) {
-    private val client: HttpClient by lazy { createClient(timeoutMs, customLogger) }
+    private val httpClient: HttpClient by lazy { createClient(timeoutMs, customLogger) }
     actual fun getClient(): HttpClient {
-        return client
+        return httpClient
     }
     actual fun close() {
-        client.close()
+        httpClient.close()
     }
 }
 

--- a/packages/library-sync/src/macosMain/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/macosMain/kotlin/io/realm/mongodb/internal/HttpClientCache.kt
@@ -6,12 +6,16 @@ import io.ktor.client.engine.curl.Curl
 import io.ktor.client.features.logging.Logger
 
 /**
- * On MacOS we need to re-create the Client on each request due to
- * https://github.com/realm/realm-kotlin/issues/480.
+ * Cache HttpClient on macOS.
  */
 internal actual class HttpClientCache actual constructor(private val timeoutMs: Long, private val customLogger: Logger?) {
+    private val client: HttpClient by lazy { createClient(timeoutMs, customLogger) }
+
     actual fun getClient(): HttpClient {
-        return createClient(timeoutMs, customLogger)
+        return client
+    }
+    actual fun close() {
+        client.close()
     }
 }
 

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/internal/KtorNetworkTransportTest.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/internal/KtorNetworkTransportTest.kt
@@ -22,6 +22,7 @@ import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.internal.util.use
 import io.realm.mongodb.internal.KtorNetworkTransport
 import kotlinx.coroutines.channels.Channel
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -36,7 +37,11 @@ internal class KtorNetworkTransportTest {
     enum class HTTPMethod(val nativeKey: String) {
         GET("get"),
         POST("post"),
-        PATCH("patch"),
+        // PATCH is currently broken on macOS if you read the content, which
+        // our NetworkTransport does: https://youtrack.jetbrains.com/issue/KTOR-4101/JsonFeature:-HttpClient-always-timeout-when-sending-PATCH-reques
+        // So for now, ignore PATCH in our tests. User API's does not use this anyway, only
+        // the AdminAPI, which has a work-around.
+        // PATCH("patch")
         PUT("put"),
         DELETE("delete")
     }
@@ -47,6 +52,11 @@ internal class KtorNetworkTransportTest {
             timeoutMs = 5000,
             dispatcher = singleThreadDispatcher("ktor-test")
         )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        transport.close()
     }
 
     @Test

--- a/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/shared/SyncedRealmTests.kt
@@ -44,7 +44,6 @@ import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -197,7 +196,6 @@ class SyncedRealmTests {
     }
 
     @Test
-    @Ignore // See https://github.com/realm/realm-kotlin/issues/814
     fun testErrorHandler() {
         // Open a realm with a schema. Close it without doing anything else
         val channel = Channel<SyncException>(1).freeze()

--- a/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
@@ -20,6 +20,7 @@ package io.realm.test.mongodb
 
 import io.ktor.client.request.get
 import io.realm.internal.interop.RealmInterop
+import io.realm.internal.platform.close
 import io.realm.internal.platform.runBlocking
 import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.log.LogLevel
@@ -44,7 +45,7 @@ const val TEST_APP_1 = "testapp1" // Id for the default test app
  * @param app gives access to the [App] class delegate for testing purposes
  * @param debug enable trace of command server and rest api calls in the test app.
  */
-class TestApp constructor(
+class TestApp private constructor(
     val app: App,
     dispatcher: CoroutineDispatcher = singleThreadDispatcher("test-app-dispatcher"),
     debug: Boolean = false
@@ -70,7 +71,6 @@ class TestApp constructor(
         debug: Boolean = false
     ) : this(
         App.create(
-            // builder(testAppConfigurationBuilder(appId, logLevel, tmpDir))
             builder(testAppConfigurationBuilder(appId, logLevel))
                 .dispatcher(dispatcher)
                 .build()
@@ -89,6 +89,9 @@ class TestApp constructor(
             deleteAllUsers()
         }
 
+        // Close network client resources
+        closeClient()
+
         // Make sure to clear cached apps before deleting files
         RealmInterop.realm_clear_cached_apps()
 
@@ -98,10 +101,10 @@ class TestApp constructor(
 
     companion object {
         suspend fun getAppId(appName: String, debug: Boolean): String {
-            return defaultClient(
-                "$appName-initializer",
-                debug
-            ).get("$COMMAND_SERVER_BASE_URL/$appName")
+            val client = defaultClient("$appName-initializer", debug)
+            return client.get<String>("$COMMAND_SERVER_BASE_URL/$appName").also {
+                client.close()
+            }
         }
 
         fun testAppConfigurationBuilder(

--- a/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
@@ -20,7 +20,6 @@ package io.realm.test.mongodb
 
 import io.ktor.client.request.get
 import io.realm.internal.interop.RealmInterop
-import io.realm.internal.platform.close
 import io.realm.internal.platform.runBlocking
 import io.realm.internal.platform.singleThreadDispatcher
 import io.realm.log.LogLevel

--- a/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/util/HttpClient.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/util/HttpClient.kt
@@ -31,7 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 
 // TODO Consider moving it to util package?
 fun defaultClient(name: String, debug: Boolean, block: HttpClientConfig<*>.() -> Unit = {}): HttpClient {
-    val timeout = 15.seconds.inWholeMilliseconds
+    val timeout = 5.seconds.inWholeMilliseconds
     return createPlatformClient {
         // Charset defaults to UTF-8 (https://ktor.io/docs/http-plain-text.html#configuration)
         install(HttpTimeout) {


### PR DESCRIPTION
Closes #814 

This PR introduces a `close()` method for the NetworkTransport. This allows us to close the underlying HttpEngine, which seems to be required on macOS, as creating many engines eventually causes requests to timeout. Probably because some underlying resources is shared and not closed correctly.

`TestApp` has been reworked to correctly close the engines it uses but it is not doing anything for the public API.

In the public API, the NetworkTransport is tied to `AppConfiguration` which is a problem since we cannot close it from the App/Realm instances as it might be shared between many Apps/Realms. We need to figure out a pattern that allows people to do this, perhaps by lazily creating the network transport when needed.  

