### PR TITLE
Add support for Flexible Sync to test apps and on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -479,7 +479,8 @@ def testWithServer(tasks) {
             }
             def commandServerEnv = docker.build 'mongodb-realm-command-server', "tools/sync_test_server"
             def tempDir = runCommand('mktemp -d -t app_config.XXXXXXXXXX')
-            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template testapp1 testapp2"
+            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template partition testapp1 testapp2"
+            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template flex testapp3"
 
             sh "docker network create ${dockerNetworkId}"
             mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000 -e AWS_ACCESS_KEY_ID='$BAAS_AWS_ACCESS_KEY_ID' -e AWS_SECRET_ACCESS_KEY='$BAAS_AWS_SECRET_ACCESS_KEY'")

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,3 +1,3 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2021-03-30
+MONGODB_REALM_SERVER=2022-05-04

--- a/test/sync/src/commonMain/kotlin/io/realm/entities/sync/flx/FlexChildObject.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/entities/sync/flx/FlexChildObject.kt
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
- package io.realm.entities.sync.flx
+package io.realm.entities.sync.flx
 
 import io.realm.RealmObject
 
 /**
  * Object used when testing Flexible Sync.
  */
-class FlexChildObject: RealmObject {
+class FlexChildObject : RealmObject {
     var section: Int = 0
     var name: String = ""
 }

--- a/test/sync/src/commonMain/kotlin/io/realm/entities/sync/flx/FlexChildObject.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/entities/sync/flx/FlexChildObject.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package io.realm.entities.sync.flx
+
+import io.realm.RealmObject
+
+/**
+ * Object used when testing Flexible Sync.
+ */
+class FlexChildObject: RealmObject {
+    var section: Int = 0
+    var name: String = ""
+}

--- a/test/sync/src/commonMain/kotlin/io/realm/entities/sync/flx/FlexParentObject.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/entities/sync/flx/FlexParentObject.kt
@@ -16,15 +16,15 @@
 
 package io.realm.entities.sync.flx
 
-import io.realm.annotations.PrimaryKey
 import io.realm.RealmObject
+import io.realm.annotations.PrimaryKey
 import kotlin.random.Random
 
 /**
  * Object used when testing Flexible Sync.
  */
-class FlexParentObject(): RealmObject {
-    constructor(section: Int): this() {
+class FlexParentObject() : RealmObject {
+    constructor(section: Int) : this() {
         this.section = section
     }
     @PrimaryKey

--- a/test/sync/src/commonMain/kotlin/io/realm/entities/sync/flx/FlexParentObject.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/entities/sync/flx/FlexParentObject.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities.sync.flx
+
+import io.realm.annotations.PrimaryKey
+import io.realm.RealmObject
+import kotlin.random.Random
+
+/**
+ * Object used when testing Flexible Sync.
+ */
+class FlexParentObject(): RealmObject {
+    constructor(section: Int): this() {
+        this.section = section
+    }
+    @PrimaryKey
+    var _id: String = "id-${Random.nextInt()}"
+    var section: Int = 0
+    var name: String = ""
+}

--- a/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/test/mongodb/TestApp.kt
@@ -35,7 +35,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 
 const val COMMAND_SERVER_BASE_URL = "http://127.0.0.1:8888"
 const val TEST_SERVER_BASE_URL = "http://127.0.0.1:9090"
-const val TEST_APP_1 = "testapp1" // Id for the default test app
+const val TEST_APP_1 = "testapp1" // With Partion-based Sync
+const val TEST_APP_2 = "testapp2" // Copy of Test App 1
+const val TEST_APP_3 = "testapp3" // With Flexible Sync
 
 /**
  * This class merges the classes `App` and `AdminApi` making it easier to create an App that can be

--- a/tools/sync_test_server/app_config_generator.sh
+++ b/tools/sync_test_server/app_config_generator.sh
@@ -1,9 +1,48 @@
 #!/bin/bash
 TARGET_APP_PATH=$1;shift
 TEMPLATE_APP_PATH=$1;shift
+SYNC_MODE=$1;shift # Must be either "partition" or "flex"
 mkdir -p $TARGET_APP_PATH
 for APP_NAME in "$@"
 do
     cp -r $TEMPLATE_APP_PATH $TARGET_APP_PATH/$APP_NAME
     sed -i'.bak' 's/APP_NAME_PLACEHOLDER/'$APP_NAME'/g' $TARGET_APP_PATH/$APP_NAME/config.json
+done
+
+# Setup sync configuration
+for APP_NAME in "$@"
+do
+    JSON="placeholder"
+    if [ "$SYNC_MODE" = "partition" ]; then
+      JSON='
+        "sync": {
+            "state": "enabled",
+            "database_name": "test_data",
+            "partition": {
+                "key": "realm_id",
+                "type": "string",
+                "permissions": {
+                    "read": true,
+                    "write": true
+                }
+            }
+        }
+      '
+    fi
+    if [ "$SYNC_MODE" = "flex" ]; then
+      JSON='
+        "flexible_sync": {
+            "state": "enabled",
+            "database_name": "test_data",
+            "queryable_fields_names": [
+                "name",
+                "section"
+            ]
+        }
+      '
+    fi
+
+    ESCAPED_JSON=`echo ${JSON} | tr '\n' "\\n"`
+    cp -r $TEMPLATE_APP_PATH $TARGET_APP_PATH/$APP_NAME
+    sed -i'.bak' "s/%SYNC_CONFIG%/$ESCAPED_JSON/g" $TARGET_APP_PATH/$APP_NAME/services/BackingDB/config.json
 done

--- a/tools/sync_test_server/app_template/services/BackingDB/config.json
+++ b/tools/sync_test_server/app_template/services/BackingDB/config.json
@@ -3,18 +3,7 @@
     "name": "BackingDB",
     "type": "mongodb",
     "config": {
-        "sync": {
-            "state": "enabled",
-            "database_name": "test_data",
-            "partition": {
-                "key": "realm_id",
-                "type": "string",
-                "permissions": {
-                    "read": true,
-                    "write": true
-                }
-            }
-        }
+        %SYNC_CONFIG% 
     },
     "secret_config": {
         "uri": "BackingDB_uri"

--- a/tools/sync_test_server/app_template/services/BackingDB/rules/test_data.FlexChildObject.json
+++ b/tools/sync_test_server/app_template/services/BackingDB/rules/test_data.FlexChildObject.json
@@ -1,0 +1,30 @@
+{
+    "collection": "FlexChildObject",
+    "database": "test_data",
+    "roles": [
+        {
+            "name": "default",
+            "apply_when": {},
+            "insert": true,
+            "delete": true,
+            "additional_fields": {}
+        }
+    ],
+    "schema": {
+        "properties": {
+            "_id": {
+                "bsonType": "objectId"
+            },
+            "name": {
+                "bsonType": "string"
+            },
+            "realm_id": {
+                "bsonType": "string"
+            }
+        },
+        "required": [
+            "name"
+        ],
+        "title": "FlexChildObject"
+    }
+}

--- a/tools/sync_test_server/app_template/services/BackingDB/rules/test_data.FlexParentObject.json
+++ b/tools/sync_test_server/app_template/services/BackingDB/rules/test_data.FlexParentObject.json
@@ -1,0 +1,45 @@
+{
+    "collection": "FlexParentObject",
+    "database": "test_data",
+    "relationships": {
+        "child": {
+            "ref": "#/relationship/BackingDB/test_data/FlexChildObject",
+            "source_key": "child",
+            "foreign_key": "_id",
+            "is_list": false
+        }
+    },
+    "roles": [
+        {
+            "name": "default",
+            "apply_when": {},
+            "insert": true,
+            "delete": true,
+            "additional_fields": {}
+        }
+    ],
+    "schema": {
+        "properties": {
+            "_id": {
+                "bsonType": "objectId"
+            },
+            "realm_id": {
+                "bsonType": "string"
+            },
+            "section": {
+                "bsonType": "int"
+            },
+            "name": {
+                "bsonType": "string"
+            },
+            "child": {
+                "bsonType": "objectId"
+            }
+        },
+        "required": [
+            "name",
+            "section"
+        ],
+        "title": "FlexParentObject"
+    }
+}

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -38,7 +38,8 @@ SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 # Create app configurations
 APP_CONFIG_DIR=`mktemp -d -t app_config`
-$SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template testapp1
+$SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template partition testapp1 testapp2
+$SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template flex testapp3
 
 # Run Stitch and Stitch CLI Docker images
 docker network create mongodb-realm-network


### PR DESCRIPTION
Splitting #824 into smaller pieces.

This PR adds a test app configured with Flexible Sync that can be used for testing, locally and on CI. It mirrors the setup in Realm Java.