### PR TITLE
Add support for writing initial data when opening a Realm file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Enhancements
 * [Sync] Added support for `ObjectId` ([#652](https://github.com/realm/realm-kotlin/issues/652)). `ObjectId` can be used as a primary key in model definition.
+* [Sync] Support for `SyncConfiguration.Builder.InitialData()`. (Issue [#422](https://github.com/realm/realm-kotlin/issues/422))
+* Support for `RealmConfiguration.Builder.initialData()`. (Issue [#579](https://github.com/realm/realm-kotlin/issues/579))
 
 ### Fixed
 * Creating a `RealmConfiguration` off the main thread on Kotlin Native could crash with `IncorrectDereferenceException`. (Issue [#799](https://github.com/realm/realm-kotlin/issues/799))

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/Callback.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/Callback.kt
@@ -57,5 +57,5 @@ fun interface MigrationCallback {
 // The underlying Core implementation can also pass in Realm pointer, but since it is not
 // useful during construction, we omit it from this callback as it is only used as a signal.
 fun interface DataInitializationCallback {
-    fun invoke()
+    fun invoke(): Boolean
 }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -127,10 +127,16 @@ expect object RealmInterop {
      *  way to get a dispatcher for the current execution environment on Native so that we can avoid
      *  passing the dispatcher from outside. See comments in native implementation on how this
      *  could maybe be achieved.
+     *
+     *  The [config] Pointer passed in should only be used _once_ to open a Realm.
+     *
+     *  @return Pair of `(pointer, fileCreated)` where `pointer` is a reference to the SharedReam
+     *  that was opened and `fileCreated` indicate wether or not the file was created as part of
+     *  opening the Realm.
      */
     // The dispatcher argument is only used on Native to build a core scheduler dispatching to the
     // dispatcher. The realm itself must also be opened on the same thread
-    fun realm_open(config: RealmConfigurationPointer, dispatcher: CoroutineDispatcher? = null): LiveRealmPointer
+    fun realm_open(config: RealmConfigurationPointer, dispatcher: CoroutineDispatcher? = null): Pair<LiveRealmPointer, Boolean>
 
     fun realm_add_realm_changed_callback(realm: LiveRealmPointer, block: () -> Unit): RealmCallbackTokenPointer
     fun realm_add_schema_changed_callback(realm: LiveRealmPointer, block: (RealmSchemaPointer) -> Unit): RealmCallbackTokenPointer

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -439,6 +439,7 @@ actual object RealmInterop {
         val fileCreated = atomic(false)
         val callback = DataInitializationCallback {
             fileCreated.value = true
+            true
         }
         realm_wrapper.realm_config_set_data_initialization_function(
             config.cptr(),

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -29,6 +29,7 @@ import io.realm.internal.interop.sync.Response
 import io.realm.internal.interop.sync.SyncError
 import io.realm.internal.interop.sync.SyncErrorCode
 import io.realm.internal.interop.sync.SyncErrorCodeCategory
+import kotlinx.atomicfu.atomic
 import kotlinx.cinterop.BooleanVar
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ByteVarOf
@@ -434,8 +435,23 @@ actual object RealmInterop {
         )
     }
 
-    actual fun realm_open(config: RealmConfigurationPointer, dispatcher: CoroutineDispatcher?): LiveRealmPointer {
-        printlntid("opening")
+    actual fun realm_open(config: RealmConfigurationPointer, dispatcher: CoroutineDispatcher?): Pair<LiveRealmPointer, Boolean> {
+        val fileCreated = atomic(false)
+        val callback = DataInitializationCallback {
+            fileCreated.value = true
+        }
+        realm_wrapper.realm_config_set_data_initialization_function(
+            config.cptr(),
+            staticCFunction { userdata, _ ->
+                stableUserData<DataInitializationCallback>(userdata).get().invoke()
+                true
+            },
+            StableRef.create(callback).asCPointer(),
+            staticCFunction { userdata ->
+                disposeUserData<DataInitializationCallback>(userdata)
+            }
+        )
+
         // TODO Consider just grabbing the current dispatcher by
         //      val dispatcher = runBlocking { coroutineContext[CoroutineDispatcher.Key] }
         //  but requires opting in for @ExperimentalStdlibApi, and have really gotten it to play
@@ -452,7 +468,7 @@ actual object RealmInterop {
         val realmPtr = CPointerWrapper<LiveRealmT>(realm_wrapper.realm_open(config.cptr()))
         // Ensure that we can read version information, etc.
         realm_begin_read(realmPtr)
-        return realmPtr
+        return Pair(realmPtr, fileCreated.value)
     }
 
     actual fun realm_add_realm_changed_callback(realm: LiveRealmPointer, block: () -> Unit): RealmCallbackTokenPointer {

--- a/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -440,7 +440,7 @@ actual object RealmInterop {
         val callback = DataInitializationCallback {
             fileCreated.value = true
             true
-        }
+        }.freeze()
         realm_wrapper.realm_config_set_data_initialization_function(
             config.cptr(),
             staticCFunction { userdata, _ ->

--- a/packages/cinterop/src/darwinTest/kotlin/io/realm/test/CinteropTest.kt
+++ b/packages/cinterop/src/darwinTest/kotlin/io/realm/test/CinteropTest.kt
@@ -170,7 +170,7 @@ class CinteropTest {
             RealmInterop.realm_config_set_schema_mode(nativeConfig, SchemaMode.RLM_SCHEMA_MODE_AUTOMATIC)
             RealmInterop.realm_config_set_schema_version(nativeConfig, 1)
 
-            val realm = RealmInterop.realm_open(nativeConfig)
+            val (realm, fileCreated) = RealmInterop.realm_open(nativeConfig)
             assertEquals(1L, RealmInterop.realm_get_num_classes(realm))
         }
     }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/internal/interop/RealmInterop.kt
@@ -157,9 +157,17 @@ actual object RealmInterop {
         realmc.realm_config_set_data_initialization_function(config.cptr(), callback)
     }
 
-    actual fun realm_open(config: RealmConfigurationPointer, dispatcher: CoroutineDispatcher?): LiveRealmPointer {
-        // create a custom Scheduler for JVM if a Coroutine Dispatcher is provided other wise pass null to use the generic one
+    actual fun realm_open(config: RealmConfigurationPointer, dispatcher: CoroutineDispatcher?): Pair<LiveRealmPointer, Boolean> {
+        // Configure callback to track if the file was created as part of opening
+        var fileCreated = false
+        val callback = DataInitializationCallback {
+            fileCreated = true
+            true
+        }
+        realm_config_set_data_initialization_function(config, callback)
 
+        // create a custom Scheduler for JVM if a Coroutine Dispatcher is provided other wise
+        // pass null to use the generic one
         val realmPtr = LongPointerWrapper<LiveRealmT>(
             realmc.open_realm_with_scheduler(
                 (config as LongPointerWrapper).ptr,
@@ -168,7 +176,7 @@ actual object RealmInterop {
         )
         // Ensure that we can read version information, etc.
         realm_begin_read(realmPtr)
-        return realmPtr
+        return Pair(realmPtr, fileCreated)
     }
 
     actual fun realm_add_realm_changed_callback(realm: LiveRealmPointer, block: () -> Unit): RealmCallbackTokenPointer {

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -355,14 +355,16 @@ bool realm_should_compact_callback(void* userdata, uint64_t total_bytes, uint64_
     return result;
 }
 
-void realm_data_initialization_callback(void* userdata) {
+bool realm_data_initialization_callback(void* userdata, realm_t* realm) {
     auto env = get_env(true);
     static JavaClass java_data_init_class(env, "io/realm/internal/interop/DataInitializationCallback");
     static JavaMethod java_data_init_method(env, java_data_init_class, "invoke", "()Z");
 
+    (void)realm; // Ignore Realm as we don't expose the Realm in this callback right now.
     jobject callback = static_cast<jobject>(userdata);
-    env->CallVoidMethod(callback, java_data_init_method);
+    jboolean result = env->CallBooleanMethod(callback, java_data_init_method);
     jni_check_exception(env);
+    return result;
 }
 
 static void send_request_via_jvm_transport(JNIEnv *jenv, jobject network_transport, const realm_http_request_t request, jobject j_response_callback) {

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -53,8 +53,8 @@ open_realm_with_scheduler(int64_t config_ptr, jobject dispatchScheduler);
 bool
 realm_should_compact_callback(void* userdata, uint64_t total_bytes, uint64_t used_bytes);
 
-void
-realm_data_initialization_callback(void* userdata);
+bool
+realm_data_initialization_callback(void* userdata, realm_t* realm);
 
 void
 invoke_core_notify_callback(int64_t core_notify_function);

--- a/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/Configuration.kt
@@ -52,6 +52,20 @@ public fun interface CompactOnLaunchCallback {
  * part of opening a Realm on a background thread.
  */
 public fun interface InitialDataCallback {
+    /**
+     * Creates a write transaction in which the initial data can be written with
+     * [MutableRealm] as a receiver. This mirrors the API when using [Realm.write]
+     * and allows for the following pattern:
+     *
+     * ```
+     * val config = RealmConfiguration.Builder()
+     *   .initialData { // this: MutableRealm
+     *       copyToRealm(Person("Jane Doe"))
+     *   }
+     *   .build()
+     * val realm = Realm.open(config)
+     * ```
+     */
     public fun MutableRealm.write()
 }
 
@@ -130,6 +144,17 @@ public interface Configuration {
     /**
      * Callback that will be triggered in order to write initial data when the Realm file is
      * created for the first time.
+     *
+     * The callback has a [MutableRealm]] as a receiver, which allows for the following pattern:
+     *
+     * ```
+     * val config = RealmConfiguration.Builder()
+     *   .initialData { // this: MutableRealm
+     *       copyToRealm(Person("Jane Doe"))
+     *   }
+     *   .build()
+     * val realm = Realm.open(config)
+     * ```
      *
      * @return `null` if no initial data should be written when opening a Realm file, otherwise
      * the callback return is the one responsible for writing the data.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/Realm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/Realm.kt
@@ -76,7 +76,7 @@ public interface Realm : TypedRealm {
          * @throws IllegalStateException if the schema has changed and migration failed.
          */
         public fun open(configuration: Configuration): Realm {
-            return RealmImpl(configuration as InternalConfiguration)
+            return RealmImpl.create(configuration as InternalConfiguration)
         }
 
         /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/RealmConfiguration.kt
@@ -133,7 +133,8 @@ public interface RealmConfiguration : Configuration {
                 encryptionKey,
                 deleteRealmIfMigrationNeeded,
                 compactOnLaunchCallback,
-                migration
+                migration,
+                initialDataCallback
             )
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/ConfigurationImpl.kt
@@ -18,6 +18,7 @@ package io.realm.internal
 
 import io.realm.BaseRealmObject
 import io.realm.CompactOnLaunchCallback
+import io.realm.InitialDataCallback
 import io.realm.LogConfiguration
 import io.realm.dynamic.DynamicMutableRealm
 import io.realm.dynamic.DynamicMutableRealmObject
@@ -58,6 +59,7 @@ public open class ConfigurationImpl constructor(
     private val userEncryptionKey: ByteArray?,
     compactOnLaunchCallback: CompactOnLaunchCallback?,
     private val userMigration: RealmMigration?,
+    initialDataCallback: InitialDataCallback?
 ) : InternalConfiguration {
 
     override val path: String
@@ -87,6 +89,8 @@ public open class ConfigurationImpl constructor(
 
     override val compactOnLaunchCallback: CompactOnLaunchCallback?
 
+    override val initialDataCallback: InitialDataCallback?
+
     override fun createNativeConfiguration(): RealmConfigurationPointer {
         val nativeConfig: RealmConfigurationPointer = RealmInterop.realm_config_new()
         return configInitializer(nativeConfig)
@@ -106,6 +110,7 @@ public open class ConfigurationImpl constructor(
         this.schemaVersion = schemaVersion
         this.schemaMode = schemaMode
         this.compactOnLaunchCallback = compactOnLaunchCallback
+        this.initialDataCallback = initialDataCallback
 
         // We need to freeze `compactOnLaunchCallback` reference on initial thread for Kotlin Native
         val compactCallback = compactOnLaunchCallback?.let { callback ->
@@ -156,6 +161,7 @@ public open class ConfigurationImpl constructor(
             RealmInterop.realm_config_set_path(nativeConfig, this.path)
             RealmInterop.realm_config_set_schema_mode(nativeConfig, schemaMode)
             RealmInterop.realm_config_set_schema_version(config = nativeConfig, version = schemaVersion)
+
             compactCallback?.let { callback ->
                 RealmInterop.realm_config_set_should_compact_on_launch_function(
                     nativeConfig,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalConfiguration.kt
@@ -40,6 +40,9 @@ public interface InternalConfiguration : Configuration {
      * Creates a new native Config object based on all the settings in this configuration.
      * Each pointer should only be used to open _one_ realm. If you want to open multiple realms
      * with the same [Configuration], this method should be called for each one of them.
+     *
+     * [fileCreated] will be called if the Realm file was created when using this configuration to
+     * open a Realm. If the file already exists, it will do nothing.
      */
     public open fun createNativeConfiguration(): RealmConfigurationPointer
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/InternalConfiguration.kt
@@ -40,9 +40,6 @@ public interface InternalConfiguration : Configuration {
      * Creates a new native Config object based on all the settings in this configuration.
      * Each pointer should only be used to open _one_ realm. If you want to open multiple realms
      * with the same [Configuration], this method should be called for each one of them.
-     *
-     * [fileCreated] will be called if the Realm file was created when using this configuration to
-     * open a Realm. If the file already exists, it will do nothing.
      */
     public open fun createNativeConfiguration(): RealmConfigurationPointer
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/LiveRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/LiveRealm.kt
@@ -44,7 +44,7 @@ internal abstract class LiveRealm(val owner: RealmImpl, configuration: InternalC
     internal val versionTracker = VersionTracker(owner.log)
 
     override val realmReference: LiveRealmReference by lazy {
-        val dbPointer = RealmInterop.realm_open(configuration.createNativeConfiguration(), dispatcher)
+        val (dbPointer, fileCreated) = RealmInterop.realm_open(configuration.createNativeConfiguration(), dispatcher)
         LiveRealmReference(this, dbPointer)
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/RealmConfigurationImpl.kt
@@ -18,6 +18,7 @@ package io.realm.internal
 
 import io.realm.BaseRealmObject
 import io.realm.CompactOnLaunchCallback
+import io.realm.InitialDataCallback
 import io.realm.LogConfiguration
 import io.realm.RealmConfiguration
 import io.realm.internal.interop.SchemaMode
@@ -40,7 +41,8 @@ internal class RealmConfigurationImpl constructor(
     encryptionKey: ByteArray?,
     override val deleteRealmIfMigrationNeeded: Boolean,
     compactOnLaunchCallback: CompactOnLaunchCallback?,
-    migration: RealmMigration?
+    migration: RealmMigration?,
+    initialDataCallback: InitialDataCallback?
 ) : ConfigurationImpl(
     directory,
     name,
@@ -56,6 +58,7 @@ internal class RealmConfigurationImpl constructor(
     },
     encryptionKey,
     compactOnLaunchCallback,
-    migration
+    migration,
+    initialDataCallback
 ),
     RealmConfiguration

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -43,6 +43,11 @@ internal open class DynamicMutableRealmImpl(
     DynamicMutableRealm,
     WriteTransactionManager {
 
+    internal constructor(
+        configuration: InternalConfiguration,
+        realmPointer: Pair<LiveRealmPointer, Boolean>
+    ) : this(configuration, realmPointer.first)
+
     override val realmReference: LiveRealmReference = LiveRealmReference(this, dbPointer)
 
     override fun query(

--- a/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -45,8 +45,8 @@ internal open class DynamicMutableRealmImpl(
 
     internal constructor(
         configuration: InternalConfiguration,
-        realmPointer: Pair<LiveRealmPointer, Boolean>
-    ) : this(configuration, realmPointer.first)
+        realm: Pair<LiveRealmPointer, Boolean>
+    ) : this(configuration, realm.first)
 
     override val realmReference: LiveRealmReference = LiveRealmReference(this, dbPointer)
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/mongodb/sync/SyncConfiguration.kt
@@ -187,7 +187,8 @@ public interface SyncConfiguration : Configuration {
                 SchemaMode.RLM_SCHEMA_MODE_ADDITIVE_DISCOVERED,
                 encryptionKey,
                 compactOnLaunchCallback,
-                null // migration is not relevant for sync
+                null, // migration is not relevant for sync,
+                initialDataCallback
             )
 
             return SyncConfigurationImpl(

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/InitialDataTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/InitialDataTests.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.test.shared
+
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import io.realm.entities.Sample
+import io.realm.internal.platform.threadId
+import io.realm.test.assertFailsWithMessage
+import io.realm.test.platform.PlatformUtils
+import io.realm.test.util.use
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import io.realm.query
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import io.realm.internal.platform.fileExists
+
+/**
+ * Class testing [io.realm.Configuration.initialDataCallback] functionality.
+ */
+class InitialDataTests {
+
+    private lateinit var tmpDir: String
+    private lateinit var configBuilder: RealmConfiguration.Builder
+
+    @BeforeTest
+    fun setup() {
+        tmpDir = PlatformUtils.createTempDir()
+        configBuilder = RealmConfiguration.Builder(schema = setOf(Sample::class))
+            .directory(tmpDir)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        PlatformUtils.deleteTempDir(tmpDir)
+    }
+
+    @Test
+    fun initialData_defaultConfiguration() {
+        val defaultConfig = RealmConfiguration.with(schema = setOf())
+        assertNull(defaultConfig.compactOnLaunchCallback)
+    }
+
+    @Test
+    fun initialData_errorFailsToOpenRealm() {
+        val config = configBuilder.initialData {
+            throw RuntimeException("Boom!")
+        }.build()
+
+        assertFailsWithMessage<RuntimeException>("Boom!") {
+            Realm.open(config)
+        }
+    }
+
+    @Test
+    fun initialData_runOnWriterThread() {
+        val startThread: ULong = threadId()
+        val initialDataThread: AtomicRef<ULong?> = atomic(null)
+        val config = configBuilder.initialData {
+            initialDataThread.value = threadId()
+        }.build()
+
+        val writerThread: AtomicRef<ULong?> = atomic(null)
+        Realm.open(config).use {
+            it.writeBlocking {
+                writerThread.value = threadId()
+                cancelWrite()
+            }
+        }
+
+        // `initialData` will run on the writer notifier
+        assertEquals(writerThread.value, initialDataThread.value)
+        assertNotEquals(startThread, initialDataThread.value)
+    }
+
+    @Test
+    fun initialData_triggersWhenMigrationDeletesFile() {
+        val config1 = RealmConfiguration.Builder(schema = setOf(io.realm.entities.migration.before.MigrationSample::class))
+            .directory(tmpDir)
+            .initialData {
+                copyToRealm(io.realm.entities.migration.before.MigrationSample())
+            }
+            .build()
+
+        val config2 = RealmConfiguration.Builder(schema = setOf(io.realm.entities.migration.after.MigrationSample::class))
+            .directory(tmpDir)
+            .deleteRealmIfMigrationNeeded()
+            .initialData {
+                copyToRealm(io.realm.entities.migration.after.MigrationSample())
+            }
+            .build()
+
+        assertEquals(config1.path, config2.path)
+
+        Realm.open(config1).use {
+            assertEquals(1, it.query<io.realm.entities.migration.before.MigrationSample>().count().find())
+        }
+        Realm.open(config2).use {
+            assertEquals(1, it.query<io.realm.entities.migration.after.MigrationSample>().count().find())
+        }
+    }
+
+    @Test
+    fun initialData_triggerWhenFileIsDeleted() {
+        val config = configBuilder.initialData {
+            copyToRealm(Sample())
+        }.build()
+
+        Realm.open(config).use { realm ->
+            assertEquals(1, realm.query<Sample>().count().find())
+        }
+        Realm.deleteRealm(config)
+        assertTrue(!fileExists(config.path))
+        Realm.open(config).use { realm ->
+            assertEquals(1, realm.query<Sample>().count().find())
+        }
+    }
+
+    @Test
+    fun initialData_runOnlyOncePrFile() {
+        val config = configBuilder.initialData {
+            copyToRealm(Sample())
+        }.build()
+
+        Realm.open(config).use { realm ->
+            assertEquals(1, realm.query<Sample>().count().find())
+        }
+        Realm.open(config).use { realm ->
+            assertEquals(1, realm.query<Sample>().count().find())
+        }
+    }
+}

--- a/test/base/src/androidTest/kotlin/io/realm/test/shared/InitialDataTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/test/shared/InitialDataTests.kt
@@ -19,7 +19,9 @@ package io.realm.test.shared
 import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.entities.Sample
+import io.realm.internal.platform.fileExists
 import io.realm.internal.platform.threadId
+import io.realm.query
 import io.realm.test.assertFailsWithMessage
 import io.realm.test.platform.PlatformUtils
 import io.realm.test.util.use
@@ -29,11 +31,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import io.realm.query
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import io.realm.internal.platform.fileExists
 
 /**
  * Class testing [io.realm.Configuration.initialDataCallback] functionality.
@@ -61,6 +61,7 @@ class InitialDataTests {
         assertNull(defaultConfig.compactOnLaunchCallback)
     }
 
+    @Suppress("TooGenericExceptionThrown")
     @Test
     fun initialData_errorFailsToOpenRealm() {
         val config = configBuilder.initialData {

--- a/test/base/src/commonMain/kotlin/io/realm/test/StandaloneDynamicMutableRealm.kt
+++ b/test/base/src/commonMain/kotlin/io/realm/test/StandaloneDynamicMutableRealm.kt
@@ -34,6 +34,7 @@ internal class StandaloneDynamicMutableRealm(configuration: InternalConfiguratio
         configuration,
         RealmInterop.realm_open(configuration.createNativeConfiguration(), null)
     ) {
+
     fun close() {
         realmReference.close()
     }

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
@@ -30,12 +30,14 @@ import io.realm.mongodb.User
 import io.realm.mongodb.exceptions.SyncException
 import io.realm.mongodb.sync.SyncConfiguration
 import io.realm.mongodb.sync.SyncSession
+import io.realm.query
 import io.realm.test.mongodb.TestApp
 import io.realm.test.mongodb.asTestApp
 import io.realm.test.mongodb.createUserAndLogIn
 import io.realm.test.util.TestHelper
 import io.realm.test.util.TestHelper.getRandomKey
 import io.realm.test.util.TestHelper.randomEmail
+import io.realm.test.util.use
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlin.random.Random
@@ -47,9 +49,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import io.realm.query
 import kotlin.test.assertTrue
-import io.realm.test.util.use
 
 const val DEFAULT_NAME = "test.realm"
 
@@ -151,9 +151,11 @@ class SyncConfigTests {
     fun initialData() {
         val user = createTestUser()
         val callback = InitialDataCallback {
-            copyToRealm(ParentPk().apply {
-                _id = Random.nextLong().toString()
-            })
+            copyToRealm(
+                ParentPk().apply {
+                    _id = Random.nextLong().toString()
+                }
+            )
         }
         val config = SyncConfiguration.Builder(
             schema = setOf(ParentPk::class, ChildPk::class),

--- a/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/test/mongodb/shared/SyncConfigTests.kt
@@ -146,7 +146,7 @@ class SyncConfigTests {
     }
 
     // Smoke-test...most functionality is tested in InitialDataTests
-    // See XXX
+    // See https://github.com/realm/realm-kotlin/pull/839
     @Test
     fun initialData() {
         val user = createTestUser()


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/302
Closes https://github.com/realm/realm-kotlin/issues/422

Add support Configuration.initialData(), which works for both RealmConfiguration and SyncConfiguration. Similar to how it works in Realm Java.

This also sets a pattern for adding other functionality required to run at startup, like `initialSubscriptions` which was the reason for adding this now.

**Alternative designs**

The current design extends `realm_open`, which works because a previous PR changed our native configs, so they are created just before being needed, thus ensuring they are tied to a single Realm.

At first, I did attempt a different approach where the `DataInitialization` callback was passed into `InternalConfiguration.createNativeConfiguration()`, but it just made call sites really awkward since you needed a way to pass the boolean across thread boundaries on Native. 

While the `DataInitialization` callback, in theory, can provide a `SharedRealm` pointer, the rest of our code is not constructed in a way that makes it possible to use our API's until _after_ `realm_open` returns, so instead we just use the fact that `DataInitialization` is triggered as a signal that the file was recreated, allowing us to run any code we want _after_ the Realm is opened. This will also enable API's like `SyncConfiguration.waitForInitialRemoteData()` and `SyncConfiguration.initialSubscriptions()`






