### PR TITLE
Preparing the compiler plugin to be compatible with Kotlin 1.7.0-RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [Sync] Added support for `ObjectId` ([#652](https://github.com/realm/realm-kotlin/issues/652)). `ObjectId` can be used as a primary key in model definition.
 * [Sync] Support for `SyncConfiguration.Builder.InitialData()`. (Issue [#422](https://github.com/realm/realm-kotlin/issues/422))
 * Support for `RealmConfiguration.Builder.initialData()`. (Issue [#579](https://github.com/realm/realm-kotlin/issues/579))
+* Preparing the compiler plugin to be compatible with Kotlin `1.7.0-RC`. (Issue [#843](https://github.com/realm/realm-kotlin/issues/843))
 
 ### Fixed
 * Creating a `RealmConfiguration` off the main thread on Kotlin Native could crash with `IncorrectDereferenceException`. (Issue [#799](https://github.com/realm/realm-kotlin/issues/799))

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -80,7 +80,7 @@ object Versions {
     const val jvmTarget = "1.8"
     // When updating the Kotlin version, also remember to update /examples/min-android-sample/build.gradle.kts
     const val kotlin = "1.6.10" // https://github.com/JetBrains/kotlin and https://kotlinlang.org/docs/releases.html#release-details
-    const val latestKotlin = "1.6.20" // https://kotlinlang.org/docs/eap.html#build-details
+    const val latestKotlin = "1.7.0-RC" // https://kotlinlang.org/docs/eap.html#build-details
     const val kotlinCompileTesting = "1.4.2" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlint = "0.45.2" // https://github.com/pinterest/ktlint
     const val ktor = "1.6.8" // https://github.com/ktorio/ktor

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/compiler/RealmModelLoweringExtension.kt
@@ -20,7 +20,6 @@ import io.realm.compiler.FqNames.MODEL_OBJECT_ANNOTATION
 import io.realm.compiler.FqNames.REALM_MODEL_COMPANION
 import io.realm.compiler.FqNames.REALM_OBJECT_INTERNAL_INTERFACE
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
-import org.jetbrains.kotlin.backend.common.checkDeclarationParents
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower
@@ -42,7 +41,6 @@ import org.jetbrains.kotlin.platform.konan.isNative
 class RealmModelLoweringExtension : IrGenerationExtension {
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
         RealmModelLowering(pluginContext).lower(moduleFragment)
-        moduleFragment.checkDeclarationParents()
     }
 }
 
@@ -63,14 +61,11 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
             // able to resolve the companion object during runtime due to absence of
             // kotlin.reflect.full.companionObjectInstance
             if (pluginContext.platform.isNative()) {
-                val modelObjectAnnotation = IrConstructorCallImpl(
-                    UNDEFINED_OFFSET,
-                    UNDEFINED_OFFSET,
+                val modelObjectAnnotation = IrConstructorCallImpl.fromSymbolOwner(
+                    startOffset = UNDEFINED_OFFSET,
+                    endOffset = UNDEFINED_OFFSET,
                     type = modelObjectAnnotationClass.defaultType,
-                    symbol = modelObjectAnnotationClass.primaryConstructor!!.symbol,
-                    constructorTypeArgumentsCount = 0,
-                    typeArgumentsCount = 0,
-                    valueArgumentsCount = 1
+                    constructorSymbol = modelObjectAnnotationClass.primaryConstructor!!.symbol
                 ).apply {
                     putValueArgument(
                         0,


### PR DESCRIPTION
The usage of `IrConstructorCallImpl` has changed in Kotlin 1.7.0-RC. To be compatible with the upcoming release we switch to using the `IrConstructorCallImpl.fromSymbolOwner` builder. 
