### PR TITLE
Decrease posibility of test failing

### DIFF
--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
@@ -256,7 +256,7 @@ class SyncSessionTests {
             // being uploaded and it not being immediately ready for download
             // on another Realm. In order to reduce the flakyness, we are
             // re-evaluating the assertion multiple times.
-            for (i in 300 downTo 0) { // Wait for max 30 sec.
+            for (i in 1200 downTo 0) { // Wait for max 2 minutes.
                 assertTrue(realm2.syncSession.downloadAllServerChanges())
                 when (val size = realm2.query<ParentPk>().count().find()) {
                     10L -> break // Test succeeded


### PR DESCRIPTION
Increases test timeout for `uploadAndDownloadChangesSuccessfully`, which sometimes seems to fail on macOS/iOS. While the 30-second timeout should be more than enough, sometimes it is not. The root cause for this is not fully understood, but could just be CI resources being constrained.

So for now, increase the timeout more and 🤞 it fixes it.