### PR TITLE
Fix missing symbol on Apple silicon prevents samples to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Added `AppConfiguration.create(...)` as convenience method for `AppConfiguration.Builder(...).build()` (Issue [#835](https://github.com/realm/realm-kotlin/issues/835))
 
 ### Fixed
+* Fix missing symbol (`___bid_IDEC_glbround`) on Apple silicon
 * Creating a `RealmConfiguration` off the main thread on Kotlin Native could crash with `IncorrectDereferenceException`. (Issue [#799](https://github.com/realm/realm-kotlin/issues/799))
 * Compiler error when using cyclic references in compiled module. (Issue [#339](https://github.com/realm/realm-kotlin/issues/339))
 

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -456,6 +456,7 @@ fun Task.build_C_API_Macos_Universal(releaseBuild: Boolean = false) {
                 "-DREALM_ENABLE_SYNC=1",
                 "-DREALM_NO_TESTS=1",
                 "-DREALM_BUILD_LIB_ONLY=true",
+                "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64",
                 "-G",
                 "Xcode",
                 ".."
@@ -465,15 +466,12 @@ fun Task.build_C_API_Macos_Universal(releaseBuild: Boolean = false) {
             workingDir(project.file(directory))
             commandLine(
                 "xcodebuild",
-                "-arch",
-                "arm64",
-                "-arch",
-                "x86_64",
+                "-destination",
+                "generic/platform=macOS",
                 "-sdk",
                 "macosx",
                 "-configuration",
                 "$buildType",
-                "ONLY_ACTIVE_ARCH=NO",
                 "-UseModernBuildSystem=NO" // TODO remove flag when https://github.com/realm/realm-kotlin/issues/141 is fixed
             )
         }


### PR DESCRIPTION
Samples build targeting Apple silicon fail to run because they cannot resolve a symbol from the [IntelRDFPMathLib20U2](https://github.com/realm/realm-core/tree/master/src/external/IntelRDFPMathLib20U2).

The issue is caused by a misconfiguration in the build command for the cinterop macos universal target.