### PR TITLE
RealmUUID datatype

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmUUID.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmUUID.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.types
+
+/**
+ * A class that represents an immutable universally unique identifier (UUID). A UUID represents a 128-bit value.
+ *
+ * It does not enforce the standard [RFC4122](https://datatracker.ietf.org/doc/html/rfc4122)
+ */
+public interface RealmUUID : Comparable<RealmUUID> {
+    public companion object {
+        /**
+         * Generates a new [RealmUUID] with a random UUID value.
+         */
+        public fun random(): RealmUUID = TODO()
+
+        /**
+         * Generates a new [RealmUUID] from an UUID string representation.
+         */
+        public fun from(uuidString: String): RealmUUID = TODO("validates uuid validity")
+
+        /**
+         * Generates a new [RealmUUID] from an UUID byte array representation.
+         */
+        public fun from(bytes: ByteArray): RealmUUID = TODO("validates uuid validity")
+    }
+
+    /**
+     * The UUID represented as a 16 byte array
+     */
+    public val bytes: ByteArray
+}

--- a/test/base/src/androidTest/kotlin/io/realm/kotlin/test/shared/RealmUUIDTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/kotlin/test/shared/RealmUUIDTests.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.test.shared
+
+import io.realm.kotlin.test.assertFailsWithMessage
+import io.realm.kotlin.types.RealmUUID
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class RealmUUIDTests {
+    @Test
+    fun from_uuidString() {
+        // Invalid arguments
+        assertFailsWithMessage<IllegalArgumentException>("invalid string representation of an UUID: ''") {
+            RealmUUID.from("") // empty string
+        }
+
+        assertFailsWithMessage<IllegalArgumentException>("invalid string representation of an UUID: 'ffffffff-ffff-xxxx-ffff-ffffffffffff'") {
+            RealmUUID.from("ffffffff-ffff-xxxx-ffff-ffffffffffff") // invalid uuid value
+        }
+
+        // Boundaries
+        assertContentEquals(
+            ByteArray(16) { 0x00.toByte() },
+            RealmUUID.from("00000000-0000-0000-0000-000000000000").bytes
+        )
+
+        assertContentEquals(
+            ByteArray(16) { 0xFF.toByte() },
+            RealmUUID.from("ffffffff-ffff-ffff-ffff-ffffffffffff").bytes
+        )
+
+        // Values
+    }
+
+    @Test
+    fun from_bytes() {
+        // Invalid arguments
+        assertFailsWithMessage<IllegalArgumentException>("byte array size must be 16") {
+            RealmUUID.from(byteArrayOf()) // 16 char needed
+        }
+
+        assertFailsWithMessage<IllegalArgumentException>("byte array size too small, size must be 16") {
+            RealmUUID.from(ByteArray(6) { 0x00 })
+        }
+
+        assertFailsWithMessage<IllegalArgumentException>("byte array size too small, size must be 16") {
+            RealmUUID.from(ByteArray(20) { 0x00 })
+        }
+
+        // Boundaries
+        assertContentEquals(
+            RealmUUID.from(ByteArray(16) { 0x00.toByte() }).bytes,
+            ByteArray(16) { 0x00.toByte() },
+        )
+
+        assertContentEquals(
+            RealmUUID.from(ByteArray(16) { 0xFF.toByte() }).bytes,
+            ByteArray(16) { 0xFF.toByte() }
+        )
+
+        // Some values
+    }
+
+    @Test
+    fun random() {
+        // It yields different values
+        assertContentNotEquals(
+            RealmUUID.random(),
+            RealmUUID.random()
+        )
+    }
+
+    @Test
+    fun compare() {
+        // equals
+
+        // less than
+
+        // greater than
+    }
+
+    @Test
+    fun to_String() {
+        // roundtrip
+    }
+}


### PR DESCRIPTION
Because there is no official support for UUID on KMM we have decided to create a custom wrapper around the core data-structure, as we did previously with `RealmInstant`.

As the core data-structure this type does not validity checks against the RFC4122 spec, we leave it to the user to enforce any pattern if required.