### PR TITLE
Support running tests on apple silicon

### DIFF
--- a/dependencies.list
+++ b/dependencies.list
@@ -1,5 +1,11 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
 MONGODB_REALM_SERVER=2022-05-21
+
+# `BAAS` and `BAAS-UI` projects commit hashes matching MONGODB_REALM_SERVER image version
+# note that the MONGODB_REALM_SERVER image is a nightly build, find the matching commits
+# for that date within the following repositories: 
+# https://github.com/10gen/baas/ 
+# https://github.com/10gen/baas-ui/
 REALM_BAAS_GIT_HASH=87e4edf99a6510aa8468450e87af69dcfc74abe7
 REALM_BAAS_UI_GIT_HASH=57c5b89882d5492bc0f4971c376e25ba50b65b5f

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,3 +1,5 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
 MONGODB_REALM_SERVER=2022-05-21
+REALM_BAAS_GIT_HASH=87e4edf99a6510aa8468450e87af69dcfc74abe7
+REALM_BAAS_UI_GIT_HASH=57c5b89882d5492bc0f4971c376e25ba50b65b5f

--- a/test/base/build.gradle.kts
+++ b/test/base/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
             dependencies {
                 // TODO AtomicFu doesn't work on the test project due to
                 //  https://github.com/Kotlin/kotlinx.atomicfu/issues/90#issuecomment-597872907
-                implementation("co.touchlab:stately-concurrency:1.1.7")
+                implementation("co.touchlab:stately-concurrency:1.2.0")
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}")
@@ -155,8 +155,15 @@ kotlin {
 }
 
 kotlin {
-    iosX64("ios")
-    macosX64("macos")
+    // define targets depending on the host platform (Apple or Intel)
+    if(System.getProperty("os.arch") == "aarch64") {
+        iosSimulatorArm64("ios")
+        macosArm64("macos")
+    } else if(System.getProperty("os.arch") == "x86_64") {
+        iosX64("ios")
+        macosX64("macos")
+    }
+
     sourceSets {
         val macosMain by getting
         val macosTest by getting

--- a/test/base/src/commonTest/kotlin/io/realm/kotlin/test/NotificationTests.kt
+++ b/test/base/src/commonTest/kotlin/io/realm/kotlin/test/NotificationTests.kt
@@ -35,48 +35,41 @@ interface NotificationTests {
     // Currently, closing a Realm will not cancel any flows from Realm
     //
     @Test
-    @Ignore // Until proper Realm tracking is in place
     fun closingRealmDoesNotCancelFlows()
 
-    @Test
-    @Ignore
-    fun addChangeListener_emitOnProvidedDispatcher() {
-        // FIXME Implement in another PR
-    }
+    // @Test
+    // fun addChangeListener_emitOnProvidedDispatcher() {
+    //     // FIXME Implement in another PR
+    // }
 
-    @Ignore
-    @Test
-    fun addChangeListener() {
-        // FIXME Implement in another PR
-    }
+    // @Test
+    // fun addChangeListener() {
+    //     // FIXME Implement in another PR
+    // }
 
-    @Test
-    @Ignore
-    fun openSameRealmFileWithDifferentDispatchers() {
-        // FIXME
-    }
+    // @Test
+    // fun openSameRealmFileWithDifferentDispatchers() {
+    //     // FIXME
+    // }
 
     // Verify that the Main dispatcher can be used for both writes and notifications
     // It should be considered an anti-pattern in production, but is plausible in tests.
-    @Test
-    @Ignore
-    fun useMainDispatchers() {
-        // FIXME
-    }
+    // @Test
+    // fun useMainDispatchers() {
+    //     // FIXME
+    // }
 
     // Verify that users can use the Main dispatcher for notifications and a background
     // dispatcher for writes. This is the closest match to how this currently works
     // in Realm Java.
-    @Test
-    @Ignore
-    fun useMainNotifierDispatcherAndBackgroundWriterDispatcher() {
-        // FIXME
-    }
+    // @Test
+    // fun useMainNotifierDispatcherAndBackgroundWriterDispatcher() {
+    //     // FIXME
+    // }
 
     // Verify that the special test dispatchers provided by Google also when using Realm.
-    @Test
-    @Ignore
-    fun useTestDispatchers() {
-        // FIXME
-    }
+    // @Test
+    // fun useTestDispatchers() {
+    //     // FIXME
+    // }
 }

--- a/test/sync/build.gradle.kts
+++ b/test/sync/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
             dependencies {
                 // TODO AtomicFu doesn't work on the test project due to
                 //  https://github.com/Kotlin/kotlinx.atomicfu/issues/90#issuecomment-597872907
-                implementation("co.touchlab:stately-concurrency:1.1.7")
+                implementation("co.touchlab:stately-concurrency:1.2.0")
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:${Versions.datetime}")
@@ -161,8 +161,15 @@ kotlin {
 }
 
 kotlin {
-    iosX64("ios")
-    macosX64("macos")
+    // define targets depending on the host platform (Apple or Intel)
+    if(System.getProperty("os.arch") == "aarch64") {
+        iosSimulatorArm64("ios")
+        macosArm64("macos")
+    } else if(System.getProperty("os.arch") == "x86_64") {
+        iosX64("ios")
+        macosX64("macos")
+    }
+
     sourceSets {
         val macosMain by getting
         val macosTest by getting

--- a/tools/sync_test_server/Dockerfile
+++ b/tools/sync_test_server/Dockerfile
@@ -29,6 +29,5 @@ WORKDIR "/tmp"
 COPY mongodb-realm-command-server.js /tmp/
 RUN npm install winston@2.4.0 temp httpdispatcher@1.0.0 fs-extra moment is-port-available@0.1.5 mongodb@4.5 mongodb-query-parser@2.4.6
 
-# Run integration test server
-# The rest of the services are found within docker
+# Run integration test server with the rest of the services found within docker
 CMD /tmp/mongodb-realm-command-server.js 127.0.0.1

--- a/tools/sync_test_server/Dockerfile.local
+++ b/tools/sync_test_server/Dockerfile.local
@@ -30,5 +30,5 @@ COPY mongodb-realm-command-server.js /tmp/
 RUN npm install winston@2.4.0 temp httpdispatcher@1.0.0 fs-extra moment is-port-available@0.1.5 mongodb@4.5 mongodb-query-parser@2.4.6
 
 # Run integration test server
-# The rest of the services are found within docker
-CMD /tmp/mongodb-realm-command-server.js 127.0.0.1
+# The rest of the services are found outside docker
+CMD /tmp/mongodb-realm-command-server.js host.docker.internal

--- a/tools/sync_test_server/Dockerfile.local
+++ b/tools/sync_test_server/Dockerfile.local
@@ -29,6 +29,5 @@ WORKDIR "/tmp"
 COPY mongodb-realm-command-server.js /tmp/
 RUN npm install winston@2.4.0 temp httpdispatcher@1.0.0 fs-extra moment is-port-available@0.1.5 mongodb@4.5 mongodb-query-parser@2.4.6
 
-# Run integration test server
-# The rest of the services are found outside docker
+# Run integration test server with the rest of the services found outside docker
 CMD /tmp/mongodb-realm-command-server.js host.docker.internal

--- a/tools/sync_test_server/bind_android_ports.sh
+++ b/tools/sync_test_server/bind_android_ports.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# This scripts tries to bind the android emulator ports to point the local development server.
+
+adb reverse tcp:9443 tcp:9443 && \
+adb reverse tcp:9080 tcp:9080 && \
+adb reverse tcp:9090 tcp:9090 && \
+adb reverse tcp:8888 tcp:8888 && \
+echo "Done" || { echo "Failed to reverse android emulator ports." ;}

--- a/tools/sync_test_server/mongodb-realm-command-server.js
+++ b/tools/sync_test_server/mongodb-realm-command-server.js
@@ -15,8 +15,12 @@ var http = require('http');
 var url = require('url');
 const fs = require('fs');
 const { MongoClient, ObjectID } = require("mongodb");
+
+const BAAS_HOST = process.argv[2];
+winston.info(`BAAS host: ${BAAS_HOST}`)
+
 const mdb_uri =
-"mongodb://host.docker.internal:26000/?readPreference=primary&directConnection=true&ssl=false";
+`mongodb://${BAAS_HOST}:26000/?readPreference=primary&directConnection=true&ssl=false`;
 const parser = require('mongodb-query-parser');
 const isPortAvailable = require('is-port-available');
 
@@ -45,7 +49,13 @@ function handleForwardPatchRequest(clientReq, clientResp) {
 
         // Construct the intended request
         const forwardUrl = url.parse(clientReq.url, true).query["url"];
-        var urlParts = url.parse(forwardUrl, false);
+
+        // If pointing to a localhost, replace target by the actual local BAAS server
+        // depending if the services are host inside or outside docker.
+
+        // host.docker.internal -> external to docker
+        // 127.0.0.1 -> internal to docker
+        var urlParts = url.parse(forwardUrl.replace("127.0.0.1", BAAS_HOST), false);
 
         var options = {
             hostname: urlParts.hostname,

--- a/tools/sync_test_server/mongodb-realm-command-server.js
+++ b/tools/sync_test_server/mongodb-realm-command-server.js
@@ -16,7 +16,7 @@ var url = require('url');
 const fs = require('fs');
 const { MongoClient, ObjectID } = require("mongodb");
 const mdb_uri =
-"mongodb://localhost:26000/?readPreference=primary&directConnection=true&ssl=false";
+"mongodb://host.docker.internal:26000/?readPreference=primary&directConnection=true&ssl=false";
 const parser = require('mongodb-query-parser');
 const isPortAvailable = require('is-port-available');
 

--- a/tools/sync_test_server/start_local_server.sh
+++ b/tools/sync_test_server/start_local_server.sh
@@ -7,9 +7,10 @@
 # It requires the following tools installed in your system.
 # * node
 # * yarn
+# * jq
 # * realm-cli@1.3.4
-# * artifactory credentials
-# * machine hostname defined in /etc/hosts
+# * artifactory credentials. See https://wiki.corp.mongodb.com/display/BUILD/How+to+configure+npm+to+use+Artifactory
+# * machine hostname defined in /etc/hosts. See https://wiki.corp.mongodb.com/display/MMS/Cloud+Developer+Setup#CloudDeveloperSetup-SensibleHostnameForYourMac
 
 NC='\033[0m'
 RED='\033[0;31m'
@@ -23,6 +24,15 @@ function echo_step () {
 }
 
 function check_dependencies () {
+  if  ! realm-cli --version 2>&1 | grep -q "1.3.4"; then
+    echo "Error: realm-cli@1.3.4 not found" && exit 1
+  fi
+  if [ -z ${AWS_ACCESS_KEY_ID} ]; then
+    echo "Error: AWS_ACCESS_KEY_ID not defined" && exit 1
+  fi
+  if [ -z ${AWS_SECRET_ACCESS_KEY} ]; then
+    echo "Error: AWS_SECRET_ACCESS_KEY not defined" && exit 1
+  fi
   if  ! which -s node; then
     echo "Error: NodeJS not found" && exit 1
   fi
@@ -161,3 +171,4 @@ echo_step "Building and booting command server"
 boot_command_server
 
 echo_step "Template apps are generated in/served from ${YELLOW}$APP_CONFIG_DIR"
+echo_step "Server available at http://localhost:9090/"

--- a/tools/sync_test_server/start_local_server.sh
+++ b/tools/sync_test_server/start_local_server.sh
@@ -94,6 +94,7 @@ function install_baas () {
 
   # boot baas in bg
   $EVERGREEN_DIR/install_baas.sh -w $BAAS_INSTALL_PATH &
+  INSTALL_BAAS_PID=$!
 
   # We need to bind the UI after the baas server has been checked
 
@@ -149,6 +150,14 @@ function import_apps () {
       jq '.app_id' "$app/$manifest_file" -r > "$app/app_id"
   done
 }
+
+function cleanup () {
+  kill -9 $INSTALL_BAAS_PID
+  $SCRIPTPATH/stop_local_server.sh
+}
+
+# terminate install_baas.sh and its processes
+trap cleanup INT TERM ERR
 
 # Get the script dir which contains the Dockerfile
 

--- a/tools/sync_test_server/start_local_server.sh
+++ b/tools/sync_test_server/start_local_server.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # This script will download and install the BAAS server locally instead of using a docker image.
 #
@@ -25,7 +26,7 @@ function echo_step () {
 
 function check_dependencies () {
   if  ! realm-cli --version 2>&1 | grep -q "1.3.4"; then
-    echo "Error: realm-cli@1.3.4 not found" && exit 1
+    echo "Error: realm-cli@1.3.4 not found. Install using 'npm install -g mongodb-realm-cli@1.3.4'" && exit 1
   fi
   if [ -z ${AWS_ACCESS_KEY_ID} ]; then
     echo "Error: AWS_ACCESS_KEY_ID not defined" && exit 1
@@ -45,7 +46,9 @@ function check_dependencies () {
   if ! ping -qo `hostname` >/dev/null 2>&1; then
     echo "Error: Hostname `hostname` missing in /etc/hosts" && exit 1
   fi
-
+  if  ! which -s yq; then
+    echo "Error: yq not found. Install using 'brew install yq'" && exit 1
+  fi
   echo "Ok"
 }
 

--- a/tools/sync_test_server/start_local_server.sh
+++ b/tools/sync_test_server/start_local_server.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+# This script will download and install the BAAS server locally instead of using a docker image.
+#
+# The install location is ~/.realm_baas
+#
+# It requires the following tools installed in your system.
+# * node
+# * yarn
+# * realm-cli@1.3.4
+# * artifactory credentials
+# * machine hostname defined in /etc/hosts
+
+NC='\033[0m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+
+BAAS_INSTALL_PATH="$HOME/.realm_baas"
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function echo_step () {
+  echo -e "${RED}----> $1${NC}" 
+}
+
+function check_dependencies () {
+  if  ! which -s node; then
+    echo "Error: NodeJS not found" && exit 1
+  fi
+  if ! which -s yarn; then
+    echo "Error: Yarn not found" && exit 1
+  fi
+  if [[ ! -e ~/.npmrc ]]; then
+    echo "Error: Artifactory credentials not configured" && exit 1
+  fi
+  if ! ping -qo `hostname` >/dev/null 2>&1; then
+    echo "Error: Hostname `hostname` missing in /etc/hosts" && exit 1
+  fi
+
+  echo "Ok"
+}
+
+function bind_android_emulator_ports () {
+  $SCRIPTPATH/bind_android_ports.sh
+}
+
+function install_baas_ui () {
+  mkdir -p $BAAS_INSTALL_PATH
+
+  pushd $BAAS_INSTALL_PATH
+  git clone git@github.com:10gen/baas-ui.git
+  pushd baas-ui
+  yarn run build 
+  popd
+  popd
+}
+
+function wait_for_mongod {
+  RETRY_COUNT=${2:-120}
+  WAIT_COUNTER=0
+  until pgrep -F $BAAS_INSTALL_PATH/mongod.pid > /dev/null 2>&1; do
+    
+    WAIT_COUNTER=$(($WAIT_COUNTER + 1 ))
+    if [[ $WAIT_COUNTER = $RETRY_COUNT ]]; then
+        echo "Error: Timed out waiting for mongod to start"
+        exit 1
+    fi
+
+    sleep 5
+  done
+}
+
+function bind_baas_ui () {
+  pushd $BAAS_INSTALL_PATH
+  mkdir -p baas/static
+  ln -s ../../baas-ui baas/static/app
+  popd
+}
+
+function install_baas () {
+  EVERGREEN_DIR=$SCRIPTPATH/../../packages/external/core/evergreen
+
+  # boot baas in bg
+  $EVERGREEN_DIR/install_baas.sh -w $BAAS_INSTALL_PATH &
+
+  # We need to bind the UI after the baas server has been checked
+
+  echo_step "Waiting for mongod to boot to bind ui$" 
+  wait_for_mongod
+
+  echo_step "Binding baas ui" 
+  bind_baas_ui
+
+  # wait for service to come up
+  $EVERGREEN_DIR/wait_for_baas.sh "$BAAS_INSTALL_PATH/baas_server.pid"
+}
+
+function boot_command_server () {
+  docker build $SCRIPTPATH -t mongodb-realm-command-server
+  docker run --rm -i -t -d -p8888:8888 -v$APP_CONFIG_DIR:/apps --name mongodb-realm-command-server mongodb-realm-command-server
+}
+
+function generate_app_configs () {
+  APP_CONFIG_DIR=`mktemp -d -t app_config`
+  $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template partition testapp1 testapp2
+  $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template flex testapp3
+}
+
+function import_apps () {
+  app_dir=$1
+  realm-cli login --config-path=/tmp/stitch-config --base-url=http://localhost:9090 --auth-provider=local-userpass --username=unique_user@domain.com --password=password -y
+  access_token=$(yq e ".access_token" /tmp/stitch-config)
+  group_id=$(curl --header "Authorization: Bearer $access_token" http://localhost:9090/api/admin/v3.0/auth/profile -s | jq '.roles[0].group_id' -r)
+  cd $app_dir
+  for app in *; do
+      echo "importing app: ${app}"
+
+      manifest_file="config.json"
+      app_id_param=""
+      if [ -f "$app/secrets.json" ]; then
+          # create app by importing an empty skeleton with the same name
+          app_name=$(jq '.name' "$app/$manifest_file" -r)
+          temp_app="/tmp/stitch-apps/$app"
+          mkdir -p "$temp_app" && echo "{ \"name\": \"$app_name\" }" > "$temp_app/$manifest_file"
+          realm-cli import --config-path=/tmp/stitch-config --base-url=http://localhost:9090 --path="$temp_app" --project-id $group_id -y --strategy replace
+
+          app_id=$(jq '.app_id' "$temp_app/$manifest_file" -r)
+          app_id_param="--app-id=$app_id"
+
+          # import secrets into the created app
+          while read -r secret value; do
+              realm-cli secrets add --config-path=/tmp/stitch-config --base-url=http://localhost:9090 --app-id=$app_id --name="$secret" --value="$(echo $value | sed 's/\\n/\n/g')"
+          done < <(jq 'to_entries[] | [.key, .value] | @tsv' "$app/secrets.json" -r)
+      fi
+
+      realm-cli import --config-path=/tmp/stitch-config --base-url=http://localhost:9090 --path="$app" $app_id_param --project-id $group_id -y --strategy replace
+      jq '.app_id' "$app/$manifest_file" -r > "$app/app_id"
+  done
+}
+
+# Get the script dir which contains the Dockerfile
+
+echo_step "Checking dependencies"
+check_dependencies
+
+echo_step "Try to bind android emulator ports" 
+bind_android_emulator_ports
+
+echo_step "Installing baas-ui in ${YELLOW}$BAAS_INSTALL_PATH" 
+install_baas_ui
+
+echo_step "Installing and booting BAAS in ${YELLOW}$BAAS_INSTALL_PATH" 
+install_baas
+
+echo_step "Generate configs" 
+generate_app_configs
+
+echo_step "Importing apps" 
+import_apps $APP_CONFIG_DIR
+
+echo_step "Building and booting command server" 
+boot_command_server
+
+echo_step "Template apps are generated in/served from ${YELLOW}$APP_CONFIG_DIR"

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -26,10 +26,7 @@ DOCKERFILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 MONGODB_REALM_VERSION=$(grep MONGODB_REALM_SERVER $DOCKERFILE_DIR/../../dependencies.list | cut -d'=' -f2)
 
-adb reverse tcp:9443 tcp:9443 && \
-adb reverse tcp:9080 tcp:9080 && \
-adb reverse tcp:9090 tcp:9090 && \
-adb reverse tcp:8888 tcp:8888 || { echo "Failed to reverse adb port." ; exit 1 ; }
+$DOCKERFILE_DIR/bind_android_ports.sh
 
 # Make sure that Docker works correctly with Github Docker Registry by logging in
 docker login docker.pkg.github.com -u $GITHUB_DOCKER_USER -p $GITHUB_DOCKER_TOKEN

--- a/tools/sync_test_server/stop_local_server.sh
+++ b/tools/sync_test_server/stop_local_server.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+WORK_PATH="$HOME/.realm_baas"
+BAAS_PID=""
+MONGOD_PID=""
+if [[ -f $WORK_PATH/baas_server.pid ]]; then
+    BAAS_PID="$(< "$WORK_PATH/baas_server.pid")"
+fi
+
+if [[ -f $WORK_PATH/mongod.pid ]]; then
+    MONGOD_PID="$(< "$WORK_PATH/mongod.pid")"
+fi
+
+if [[ -n "$BAAS_PID" ]]; then
+    echo "Stopping baas $BAAS_PID"
+    kill -9 "$BAAS_PID"
+fi
+
+
+if [[ -n "$MONGOD_PID" ]]; then
+    echo "Killing mongod $MONGOD_PID"
+    kill -9 "$MONGOD_PID"
+fi
+
+docker stop mongodb-realm-command-server -t0


### PR DESCRIPTION
This PR attempts to allow building and running `library-base` tests on Apple silicon. `library-sync` are not yet available to be run natively on Apple silicon but they can be emulated with Rosetta.

Tests target is now selected automatically based on the local machine architecture.

Two new sync server scripts have been introduced: `start_local_server.sh` and `stop_local_server.sh` that allow running the baas server locally instead of doing it on a docker image. It is a temporary solution until we get ARM64 baas server images.

Rosetta can be enabled by setting `JAVA_HOME` to an Intel JDK, tested with `jdk-11.0.15`, and then running the sync macos sync tests.