### PR TITLE
Clean up strings stored in realm_value_t managed by the JVM-cinterop layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 1.0.1 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* Fix JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10 and above.
+  * Coroutines 1.6.0-native-mt. Also compatible with Coroutines 1.6.0 but requires enabling of the new memory model and disabling of freezing, see https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility for details on that.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.0.0 (2022-06-07)
 
 ### Breaking Changes

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -17,6 +17,7 @@
 package io.realm.kotlin.internal.interop
 
 import io.realm.kotlin.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
+import io.realm.kotlin.internal.interop.RealmInterop.cptr
 import io.realm.kotlin.internal.interop.sync.AuthProvider
 import io.realm.kotlin.internal.interop.sync.CoreSubscriptionSetState
 import io.realm.kotlin.internal.interop.sync.CoreSyncSessionState
@@ -329,11 +330,26 @@ actual object RealmInterop {
     }
 
     actual fun realm_object_create_with_primary_key(realm: LiveRealmPointer, classKey: ClassKey, primaryKey: RealmValue): RealmObjectPointer {
-        return LongPointerWrapper(realmc.realm_object_create_with_primary_key(realm.cptr(), classKey.key, to_realm_value(primaryKey)))
+        return memScope {
+            LongPointerWrapper<RealmObjectT>(
+                realmc.realm_object_create_with_primary_key(
+                    realm.cptr(),
+                    classKey.key,
+                    managedRealmValue(primaryKey)
+                )
+            )
+        }
     }
     actual fun realm_object_get_or_create_with_primary_key(realm: LiveRealmPointer, classKey: ClassKey, primaryKey: RealmValue): RealmObjectPointer {
         val created = booleanArrayOf(false)
-        return LongPointerWrapper(realmc.realm_object_get_or_create_with_primary_key(realm.cptr(), classKey.key, to_realm_value(primaryKey), created))
+        return memScope {
+            LongPointerWrapper(
+                realmc.realm_object_get_or_create_with_primary_key(
+                    realm.cptr(), classKey.key,
+                    managedRealmValue(primaryKey), created
+                )
+            )
+        }
     }
 
     actual fun realm_object_is_valid(obj: RealmObjectPointer): Boolean {
@@ -399,6 +415,8 @@ actual object RealmInterop {
                     value.asLink()
                 realm_value_type_e.RLM_TYPE_NULL ->
                     null
+                realm_value_type_e.RLM_TYPE_BINARY ->
+                    value.binary
                 else ->
                     TODO("Unsupported type for from_realm_value ${value.type}")
             }
@@ -406,8 +424,9 @@ actual object RealmInterop {
     }
 
     actual fun realm_set_value(obj: RealmObjectPointer, key: PropertyKey, value: RealmValue, isDefault: Boolean) {
-        val cvalue = to_realm_value(value)
-        realmc.realm_set_value(obj.cptr(), key.key, cvalue, isDefault)
+        memScope {
+            realmc.realm_set_value(obj.cptr(), key.key, managedRealmValue(value), isDefault)
+        }
     }
 
     actual fun realm_set_embedded(obj: RealmObjectPointer, key: PropertyKey): RealmObjectPointer {
@@ -436,8 +455,9 @@ actual object RealmInterop {
     }
 
     actual fun realm_list_add(list: RealmListPointer, index: Long, value: RealmValue) {
-        val cvalue = to_realm_value(value)
-        realmc.realm_list_insert(list.cptr(), index, cvalue)
+        memScope {
+            realmc.realm_list_insert(list.cptr(), index, managedRealmValue(value))
+        }
     }
 
     actual fun realm_list_insert_embedded(list: RealmListPointer, index: Long): RealmObjectPointer {
@@ -446,7 +466,9 @@ actual object RealmInterop {
 
     actual fun realm_list_set(list: RealmListPointer, index: Long, value: RealmValue): RealmValue {
         return realm_list_get(list, index).also {
-            realmc.realm_list_set(list.cptr(), index, to_realm_value(value))
+            memScope {
+                realmc.realm_list_set(list.cptr(), index, managedRealmValue(value))
+            }
         }
     }
 
@@ -485,83 +507,6 @@ actual object RealmInterop {
 
     actual fun realm_list_is_valid(list: RealmListPointer): Boolean {
         return realmc.realm_list_is_valid(list.cptr())
-    }
-
-    // TODO OPTIMIZE Maybe move this to JNI to avoid multiple round trips for allocating and
-    //  updating before actually calling
-    @Suppress("ComplexMethod", "LongMethod")
-    private fun to_realm_value(realmValue: RealmValue): realm_value_t {
-        val cvalue = realm_value_t()
-        val value = realmValue.value
-        if (value == null) {
-            cvalue.type = realm_value_type_e.RLM_TYPE_NULL
-        } else {
-            when (value) {
-                is String -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_STRING
-                    cvalue.string = value
-                }
-                /*is Byte -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_INT
-                    cvalue.integer = value.toLong()
-                }
-                is Char -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_INT
-                    cvalue.integer = value.toLong()
-                }
-                is Short -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_INT
-                    cvalue.integer = value.toLong()
-                }
-                is Int -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_INT
-                    cvalue.integer = value.toLong()
-                }*/
-                is Long -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_INT
-                    cvalue.integer = value
-                }
-                is Boolean -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_BOOL
-                    cvalue._boolean = value
-                }
-                is Float -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_FLOAT
-                    cvalue.fnum = value
-                }
-                is Double -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_DOUBLE
-                    cvalue.dnum = value
-                }
-                is Timestamp -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_TIMESTAMP
-                    cvalue.timestamp = realm_timestamp_t().apply {
-                        seconds = value.seconds
-                        nanoseconds = value.nanoSeconds
-                    }
-                }
-                is ObjectIdWrapper -> {
-                    cvalue.type = realm_value_type_e.RLM_TYPE_OBJECT_ID
-                    cvalue.object_id = realm_object_id_t().apply {
-                        val data = ShortArray(OBJECT_ID_BYTES_SIZE)
-                        @OptIn(ExperimentalUnsignedTypes::class)
-                        (0 until OBJECT_ID_BYTES_SIZE).map {
-                            data[it] = value.bytes[it].toShort()
-                        }
-                        bytes = data
-                    }
-                }
-                is RealmObjectInterop -> {
-                    val nativePointer = value.objectPointer
-                    cvalue.link = realmc.realm_object_as_link(nativePointer.cptr())
-                    cvalue.type = realm_value_type_e.RLM_TYPE_LINK
-                }
-                else -> {
-                    TODO("Unsupported type for to_realm_value `${value!!::class.simpleName}`")
-                }
-            }
-        }
-        return cvalue
     }
 
     actual fun realm_object_add_notification_callback(obj: RealmObjectPointer, callback: Callback<RealmChangesPointer>): RealmNotificationTokenPointer {
@@ -1097,10 +1042,20 @@ actual object RealmInterop {
     actual fun realm_query_parse(realm: RealmPointer, classKey: ClassKey, query: String, args: Array<RealmValue>): RealmQueryPointer {
         val count = args.size
         val cArgs = realmc.new_valueArray(count)
-        args.mapIndexed { i, arg ->
-            realmc.valueArray_setitem(cArgs, i, to_realm_value(arg))
+        return memScope {
+            args.mapIndexed { i, arg ->
+                realmc.valueArray_setitem(cArgs, i, managedRealmValue(arg))
+            }
+            LongPointerWrapper<RealmQueryT>(
+                realmc.realm_query_parse(
+                    realm.cptr(),
+                    classKey.key,
+                    query,
+                    count.toLong(),
+                    cArgs
+                )
+            )
         }
-        return LongPointerWrapper(realmc.realm_query_parse(realm.cptr(), classKey.key, query, count.toLong(), cArgs))
     }
 
     actual fun realm_query_parse_for_results(
@@ -1110,12 +1065,14 @@ actual object RealmInterop {
     ): RealmQueryPointer {
         val count = args.size
         val cArgs = realmc.new_valueArray(count)
-        args.mapIndexed { i, arg ->
-            realmc.valueArray_setitem(cArgs, i, to_realm_value(arg))
+        return memScope {
+            args.mapIndexed { i, arg ->
+                realmc.valueArray_setitem(cArgs, i, managedRealmValue(arg))
+            }
+            LongPointerWrapper(
+                realmc.realm_query_parse_for_results(results.cptr(), query, count.toLong(), cArgs)
+            )
         }
-        return LongPointerWrapper(
-            realmc.realm_query_parse_for_results(results.cptr(), query, count.toLong(), cArgs)
-        )
     }
 
     actual fun realm_query_find_first(query: RealmQueryPointer): Link? {
@@ -1148,12 +1105,14 @@ actual object RealmInterop {
     ): RealmQueryPointer {
         val count = args.size
         val cArgs = realmc.new_valueArray(count)
-        args.mapIndexed { i, arg ->
-            realmc.valueArray_setitem(cArgs, i, to_realm_value(arg))
+        return memScope {
+            args.mapIndexed { i, arg ->
+                realmc.valueArray_setitem(cArgs, i, managedRealmValue(arg))
+            }
+            LongPointerWrapper(
+                realmc.realm_query_append_query(query.cptr(), filter, count.toLong(), cArgs)
+            )
         }
-        return LongPointerWrapper(
-            realmc.realm_query_append_query(query.cptr(), filter, count.toLong(), cArgs)
-        )
     }
 
     actual fun realm_query_get_description(query: RealmQueryPointer): String {
@@ -1212,10 +1171,22 @@ actual object RealmInterop {
         return LongPointerWrapper(realmc.realm_get_object(realm.cptr(), link.classKey.key, link.objKey))
     }
 
-    actual fun realm_object_find_with_primary_key(realm: RealmPointer, classKey: ClassKey, primaryKey: RealmValue): RealmObjectPointer? {
-        val cprimaryKey = to_realm_value(primaryKey)
-        val found = booleanArrayOf(false)
-        return nativePointerOrNull(realmc.realm_object_find_with_primary_key(realm.cptr(), classKey.key, cprimaryKey, found))
+    actual fun realm_object_find_with_primary_key(
+        realm: RealmPointer,
+        classKey: ClassKey,
+        primaryKey: RealmValue
+    ): RealmObjectPointer? {
+        return memScope {
+            val found = booleanArrayOf(false)
+            nativePointerOrNull(
+                realmc.realm_object_find_with_primary_key(
+                    realm.cptr(),
+                    classKey.key,
+                    managedRealmValue(primaryKey),
+                    found
+                )
+            )
+        }
     }
 
     actual fun realm_results_delete_all(results: RealmResultsPointer) {
@@ -1441,6 +1412,113 @@ actual object RealmInterop {
         }
         return Link(ClassKey(this.link.target_table), this.link.target)
     }
+}
+
+/**
+ * A factory and container for various resources that can be freed when calling [free].
+ *
+ * @see memScope
+ */
+private class MemScope {
+    val values: MutableSet<realm_value_t> = mutableSetOf()
+
+    fun managedRealmValue(value: RealmValue): realm_value_t {
+        val element = capiRealmValue(value)
+        values.add(element)
+        return element
+    }
+
+    fun free() {
+        values.map { realmc.realm_value_t_cleanup(it) }
+    }
+}
+
+/**
+ * A scope providing a [MemScope] that collects the created resources and automatically frees them
+ * upon exiting the scope.
+ */
+private fun <R> memScope(block: MemScope.() -> R): R {
+    val scope = MemScope()
+    val result: R = block(scope)
+    scope.free()
+    return result
+}
+
+// TODO OPTIMIZE Maybe move this to JNI to avoid multiple round trips for allocating and
+//  updating before actually calling
+@Suppress("ComplexMethod", "LongMethod")
+private fun capiRealmValue(realmValue: RealmValue): realm_value_t {
+    val cvalue = realm_value_t()
+    val value = realmValue.value
+    if (value == null) {
+        cvalue.type = realm_value_type_e.RLM_TYPE_NULL
+    } else {
+        when (value) {
+            is String -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_STRING
+                cvalue.string = value
+            }
+            /*is Byte -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_INT
+                cvalue.integer = value.toLong()
+            }
+            is Char -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_INT
+                cvalue.integer = value.toLong()
+            }
+            is Short -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_INT
+                cvalue.integer = value.toLong()
+            }
+            is Int -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_INT
+                cvalue.integer = value.toLong()
+            }*/
+            is Long -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_INT
+                cvalue.integer = value
+            }
+            is Boolean -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_BOOL
+                cvalue._boolean = value
+            }
+            is Float -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_FLOAT
+                cvalue.fnum = value
+            }
+            is Double -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_DOUBLE
+                cvalue.dnum = value
+            }
+            is Timestamp -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_TIMESTAMP
+                cvalue.timestamp = realm_timestamp_t().apply {
+                    seconds = value.seconds
+                    nanoseconds = value.nanoSeconds
+                }
+            }
+            is ObjectIdWrapper -> {
+                cvalue.type = realm_value_type_e.RLM_TYPE_OBJECT_ID
+                cvalue.object_id = realm_object_id_t().apply {
+                    val data = ShortArray(OBJECT_ID_BYTES_SIZE)
+                    @OptIn(ExperimentalUnsignedTypes::class)
+                    (0 until OBJECT_ID_BYTES_SIZE).map {
+                        data[it] = value.bytes[it].toShort()
+                    }
+                    bytes = data
+                }
+            }
+            is RealmObjectInterop -> {
+                val nativePointer = value.objectPointer
+                cvalue.link = realmc.realm_object_as_link(nativePointer.cptr())
+                cvalue.type = realm_value_type_e.RLM_TYPE_LINK
+            }
+            else -> {
+                TODO("Unsupported type for capiRealmValue `${value!!::class.simpleName}`")
+            }
+        }
+    }
+    return cvalue
 }
 
 private class JVMScheduler(dispatcher: CoroutineDispatcher) {

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -210,7 +210,7 @@ typedef jstring realm_string_t;
 
 // Typemap used for passing realm_string_t into the C-API in situations where the string buffer
 // needs to be kept alive after returning from C-API call. This will copy the string buffer to the
-// heap and this have to be explicitly freed at a later point.
+// heap and this has to be explicitly freed at a later point.
 // Currently just matching 'realm_string_t string' arguments to match realm_value_t.string = $input
 %typemap(in) realm_string_t string (char* buf) {
     buf = (char*)jenv->GetStringUTFChars($arg,0);

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -689,3 +689,22 @@ sync_after_client_reset_handler(realm_sync_config_t* config, jobject after_handl
     };
     realm_sync_config_set_after_client_reset_handler(config, after_func, user_data, free_func);
 }
+
+// Explicit clean up method for releasing heap allocated data of a realm_value_t instance
+void
+realm_value_t_cleanup(realm_value_t* value) {
+    switch (value->type) {
+        case RLM_TYPE_STRING:  {
+            const char* buf = value->string.data;
+            if (buf) delete buf;
+            break;
+        }
+        case RLM_TYPE_BINARY: {
+            // TODO Once binary data is supported we should also deallocate heap allocated data
+            //  buffers for that
+            throw std::runtime_error("Deallocation of binary data is not yet implemented");
+        }
+        default:
+            break;
+    }
+}

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -90,4 +90,8 @@ sync_before_client_reset_handler(realm_sync_config_t* config, jobject before_han
 void
 sync_after_client_reset_handler(realm_sync_config_t* config, jobject after_handler);
 
+// Explicit clean up method for releasing heap allocated data of a realm_value_t instance
+void
+realm_value_t_cleanup(realm_value_t* value);
+
 #endif //TEST_REALM_API_HELPERS_H


### PR DESCRIPTION
This PR add explicit copying of string data passed to `realm_value_t.string`, thus when the `realm_value_t` is managed by the cinterop layer.

Questions:
- [x] We could introduce a `memScope`-method with specific `scope.to_realm_value` to automatically collect and release these
- [x] How to verify deallocation ... for now just manually verified by profiler inspection during our conventional memory test

Closes #890 