### PR TITLE
Static analysis shouldn't trigger building native libs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,16 +136,15 @@ pipeline {
                       }
                     }
                 }
-
-                stage('Build') {
-                    steps {
-                        runBuild()
-                    }
-                }
                 stage('Static Analysis') {
                     when { expression { runTests } }
                     steps {
                         runStaticAnalysis()
+                    }
+                }
+                stage('Build') {
+                    steps {
+                        runBuild()
                     }
                 }
                 stage('Benchmarks') {

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -612,7 +612,11 @@ tasks.named("cinteropRealm_wrapperMacos") {
 }
 
 tasks.named("jvmMainClasses") {
-    dependsOn(buildJVMSharedLibs)
+    if (project.extra.properties["ignoreNativeLibs"] != true) {
+        dependsOn(buildJVMSharedLibs)
+    } else {
+        logger.warn("CInterop: Skip building native libs")
+    }
 }
 
 // Maven Central requires JavaDoc so add empty javadoc artifacts

--- a/packages/plugin-compiler/build.gradle.kts
+++ b/packages/plugin-compiler/build.gradle.kts
@@ -36,7 +36,9 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:${Versions.kotlinCompileTesting}")
     // Have to be mentioned explicitly as it is not an api dependency of library
-    implementation(project(":cinterop"))
+    implementation(project(":cinterop") {
+        this.extra["ignoreNativeLibs"] = true
+    })
     testImplementation(project(":library-base"))
     testImplementation(project(":library-sync"))
 }


### PR DESCRIPTION
Running detekt and ktlint was causing the compiler plugin to trigger a build of the native code due to the way the dependency was set up.

Adding an option that ignores the native code allows us to run the static analysis before doing a full build.