### PR TITLE
Fix reading strings containing null-characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
 * Fixed crash present on release-mode apps using Sync due to missing Proguard exception for `ResponseCallback`.
 * The compiler plugin did not set the generic parameter correctly for an internal field inside model classes. This could result in other libraries that operated on the source code throwing an error of the type: `undeclared type variable: T`. (Issue [#901](https://github.com/realm/realm-kotlin/issues/901))
+* Strings from Realm was mistakenly being treated as zero-terminated on Kotlin Native, resulting in data with NULL characters not being read out incorrectly. Inserting data worked correctly. (Issue [#898](https://github.com/realm/realm-kotlin/pull/898)) 
 
 ### Compatibility
 * This release is compatible with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
 * Fixed crash present on release-mode apps using Sync due to missing Proguard exception for `ResponseCallback`.
 * The compiler plugin did not set the generic parameter correctly for an internal field inside model classes. This could result in other libraries that operated on the source code throwing an error of the type: `undeclared type variable: T`. (Issue [#901](https://github.com/realm/realm-kotlin/issues/901))
-* Strings from Realm was mistakenly being treated as zero-terminated on Kotlin Native, resulting in data with NULL characters not being read out incorrectly. Inserting data worked correctly. (Issue [#898](https://github.com/realm/realm-kotlin/pull/898)) 
+* String read from a realm was mistakenly treated as zero-terminated, resulting in strings with `\0`-characters to be truncated when read. Inserting data worked correctly. (Issue [#911](https://github.com/realm/realm-kotlin/issues/911)) 
 
 ### Compatibility
 * This release is compatible with:

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -19,7 +19,6 @@
 package io.realm.kotlin.internal.interop
 
 import io.realm.kotlin.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
-import io.realm.kotlin.internal.interop.RealmInterop.safeKString
 import io.realm.kotlin.internal.interop.sync.AppError
 import io.realm.kotlin.internal.interop.sync.AppErrorCategory
 import io.realm.kotlin.internal.interop.sync.AuthProvider
@@ -60,7 +59,6 @@ import kotlinx.cinterop.cstr
 import kotlinx.cinterop.get
 import kotlinx.cinterop.getBytes
 import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.nativeHeap.alloc
 import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.readBytes
@@ -220,20 +218,20 @@ fun realm_value_t.set(memScope: MemScope, realmValue: RealmValue): realm_value_t
  *
  * @throws NullPointerException if `realm_string_t` is null.
  */
-fun realm_string_t.toKString(): String {
+fun realm_string_t.toKotlinString(): String {
     if (size == 0UL) {
         return ""
     }
     val data: CPointer<ByteVarOf<Byte>>? = this.data
     val readBytes: ByteArray? = data?.readBytes(this.size.toInt())
-    return readBytes?.toKString()!!
+    return readBytes?.decodeToString(0, size.toInt(), throwOnInvalidSequence = false)!!
 }
 
-fun realm_string_t.toNullableKString(): String? {
+fun realm_string_t.toNullableKotlinString(): String? {
     return if (data == null) {
         null
     } else {
-        return toKString()
+        return toKotlinString()
     }
 }
 
@@ -784,7 +782,7 @@ actual object RealmInterop {
                 realm_value_type.RLM_TYPE_BOOL ->
                     value.boolean
                 realm_value_type.RLM_TYPE_STRING ->
-                    value.string.toKString()
+                    value.string.toKotlinString()
                 realm_value_type.RLM_TYPE_FLOAT ->
                     value.fnum
                 realm_value_type.RLM_TYPE_DOUBLE ->
@@ -2039,19 +2037,19 @@ actual object RealmInterop {
 
     actual fun realm_sync_subscription_name(subscription: RealmSubscriptionPointer): String? {
         return realm_wrapper.realm_sync_subscription_name(subscription.cptr()).useContents {
-            this.toNullableKString()
+            this.toNullableKotlinString()
         }
     }
 
     actual fun realm_sync_subscription_object_class_name(subscription: RealmSubscriptionPointer): String {
         return realm_wrapper.realm_sync_subscription_object_class_name(subscription.cptr()).useContents {
-            this.toKString()
+            this.toKotlinString()
         }
     }
 
     actual fun realm_sync_subscription_query_string(subscription: RealmSubscriptionPointer): String {
         return realm_wrapper.realm_sync_subscription_query_string(subscription.cptr()).useContents {
-            this.toKString()
+            this.toKotlinString()
         }
     }
 

--- a/packages/cinterop/src/darwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/darwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -29,7 +29,7 @@ import io.realm.kotlin.internal.interop.SchemaMode
 import io.realm.kotlin.internal.interop.SchemaValidationMode
 import io.realm.kotlin.internal.interop.coreErrorAsThrowable
 import io.realm.kotlin.internal.interop.set
-import io.realm.kotlin.internal.interop.toKString
+import io.realm.kotlin.internal.interop.toKotlinString
 import kotlinx.cinterop.BooleanVar
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CPointerVarOf
@@ -214,7 +214,7 @@ class CinteropTest {
         memScoped {
             val s = alloc<realm_string_t>()
             s.set(memScope, "")
-            r = s.toKString()
+            r = s.toKotlinString()
         }
         assertEquals("", r)
     }
@@ -226,7 +226,7 @@ class CinteropTest {
         memScoped {
             val s = alloc<realm_string_t>()
             s.set(memScope, value)
-            r = s.toKString()
+            r = s.toKotlinString()
         }
         assertEquals(value, r)
     }

--- a/packages/cinterop/src/jvm/jni/utils.h
+++ b/packages/cinterop/src/jvm/jni/utils.h
@@ -21,6 +21,8 @@
 
 #include <realm/table.hpp>
 #include "env_utils.h"
+#include "realm.h"
+
 
 using namespace realm;
 
@@ -63,6 +65,21 @@ public:
             return std::string();
         }
         return std::string(m_data.get(), m_size);
+    }
+
+    operator realm_string_t() const noexcept
+    {
+        return realm_string_t {m_data.get(), m_size };
+    }
+
+    inline const char* data() const noexcept
+    {
+        return m_data.get();
+    };
+
+    inline size_t size() const noexcept
+    {
+        return m_size;
     }
 
 private:

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -200,7 +200,6 @@ typedef jstring realm_string_t;
 }
 // Clean up of jstring buffers are managed by the lifetime of the `tmp` JStringAccessor
 %typemap(freearg) realm_string_t ""
-
 // Typemap used for passing realm_string_t into the C-API in situations where the string buffer
 // needs to be kept alive after returning from C-API call. This will copy the string buffer to the
 // heap and this has to be explicitly freed at a later point.

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -191,39 +191,28 @@ std::string rlm_stdstr(realm_string_t val)
     };
 }
 
-// Primitive/built in type handling
+// String handling
 typedef jstring realm_string_t;
-// TODO OPTIMIZATION Optimize...maybe port JStringAccessor from realm-java
-//%typemap(jtype) realm_string_t "String"
-//%typemap(jstype) realm_string_t "String"
-
 // Typemap used for passing realm_string_t into the C-API in situations where the string buffer
-// only have to be live across the C-API call
-%typemap(in) realm_string_t (char* buf) {
-    buf = (char*)jenv->GetStringUTFChars($arg,0);
-    $1.size = strlen(buf);
-    $1.data = buf;
+// only have to be live across the C-API call. The lifetime is controlled by the `tmp` JStringAccessor.
+%typemap(in) realm_string_t (JStringAccessor tmp(jenv, NULL)){
+    $1 = tmp = JStringAccessor(jenv, $arg);
 }
-%typemap(freearg) realm_string_t {
-    if ($1.data) jenv->ReleaseStringUTFChars($arg, (const char *)$1.data);
-}
+// Clean up of jstring buffers are managed by the lifetime of the `tmp` JStringAccessor
+%typemap(freearg) realm_string_t ""
 
 // Typemap used for passing realm_string_t into the C-API in situations where the string buffer
 // needs to be kept alive after returning from C-API call. This will copy the string buffer to the
 // heap and this has to be explicitly freed at a later point.
 // Currently just matching 'realm_string_t string' arguments to match realm_value_t.string = $input
-%typemap(in) realm_string_t string (char* buf) {
-    buf = (char*)jenv->GetStringUTFChars($arg,0);
-    $1.size = strlen(buf);
-    $1.data = (char const *) (new char[$1.size]);
-    strncpy((char *)$1.data, (const char *)buf, $1.size);
-    if (buf) jenv->ReleaseStringUTFChars($arg, (const char *)buf);
+%typemap(in) realm_string_t string {
+    auto s = JStringAccessor(jenv, $arg);
+    auto size = s.size();
+    $1.size = size;
+    $1.data = (char const *) (new char[size]);
+    memcpy((char *)$1.data, (const char *)s.data(), size);
 }
-// We already release the buffer with ReleaseStringUTFChars. Theoretically we could maybe have
-// reused the above generic freearg typemap for realm_string_t, but couldn't find a way to reference
-// the temporary buf variable from the in typemap
-%typemap(freearg) realm_string_t string { }
-%typemap(out) (realm_string_t) "$result = ($1.data) ? jenv->NewStringUTF(std::string($1.data, 0, $1.size).c_str()) : nullptr;"
+%typemap(out) (realm_string_t) "$result = to_jstring(jenv, StringData{$1.data, $1.size});"
 
 %typemap(jstype) void* "long"
 %typemap(javain) void* "$javainput"

--- a/test/base/src/androidTest/kotlin/io/realm/kotlin/test/shared/nonlatin/NonLatinTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/kotlin/test/shared/nonlatin/NonLatinTests.kt
@@ -1,0 +1,193 @@
+package io.realm.kotlin.test.shared.nonlatin
+
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+import io.realm.kotlin.entities.Sample
+import io.realm.kotlin.entities.link.Child
+import io.realm.kotlin.entities.link.Parent
+import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.use
+import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmObject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NonLatinFieldNames : RealmObject {
+    var 베타: String = "베타" // Korean
+    var Βήτα: String = "Βήτα" // Greek
+    var ЙйКкЛл: String = "ЙйКкЛл" // Cyrillic
+    var 山水要: String = "山水要" // Chinese
+    var ععسنملل: String = "ععسنملل" // Arabic
+    var `😊🙈`: String = "😊🙈" // Emojii
+}
+
+class NonLatinClassёжф : RealmObject {
+    var prop: String = "property"
+    var list: RealmList<String> = realmListOf()
+    var nullList: RealmList<String?> = realmListOf()
+}
+
+class NonLatinTests {
+
+    lateinit var tmpDir: String
+    lateinit var realm: Realm
+
+    @BeforeTest
+    fun setup() {
+        tmpDir = PlatformUtils.createTempDir()
+        val configuration =
+            RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class, Sample::class))
+                .directory(tmpDir)
+                .build()
+        realm = Realm.open(configuration)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        PlatformUtils.deleteTempDir(tmpDir)
+    }
+
+    @Test
+    fun nonLatinClassNames() {
+        val config = RealmConfiguration.Builder(setOf(NonLatinClassёжф::class))
+            .directory(tmpDir)
+            .build()
+
+        Realm.open(config).use {
+            val schema = it.schema()[NonLatinClassёжф::class.simpleName.toString()]!!
+            assertEquals(3, schema.properties.size)
+            assertEquals("NonLatinClassёжф", schema.name)
+        }
+    }
+
+    @Test
+    fun nonLatinProperties() {
+        val config = RealmConfiguration.Builder(setOf(NonLatinFieldNames::class))
+            .directory(tmpDir)
+            .build()
+
+        Realm.open(config).use {
+            val schema = it.schema()[NonLatinFieldNames::class.simpleName.toString()]!!
+            assertEquals(6, schema.properties.size)
+            schema.properties.forEach {
+                println(it.name)
+            }
+            assertNotNull(schema[NonLatinFieldNames().베타])
+            assertNotNull(schema[NonLatinFieldNames().Βήτα])
+            assertNotNull(schema[NonLatinFieldNames().ЙйКкЛл])
+            assertNotNull(schema[NonLatinFieldNames().山水要])
+            assertNotNull(schema[NonLatinFieldNames().ععسنملل])
+            assertNotNull(schema[NonLatinFieldNames().`😊🙈`])
+        }
+    }
+
+    @Test
+    fun roundtripNonLatinValues() {
+        val config = RealmConfiguration.Builder(setOf(NonLatinClassёжф::class))
+            .directory(tmpDir)
+            .build()
+
+        Realm.open(config).use { realm ->
+            val values = listOf(
+                "베타",
+                "Βήτα",
+                "ЙйКкЛл",
+                "山水要",
+                "ععسنملل",
+                "😊🙈"
+            )
+
+            val obj = realm.writeBlocking {
+                copyToRealm(
+                    NonLatinClassёжф().apply {
+                        list.addAll(values)
+                        nullList.addAll(values)
+                    }
+                )
+            }
+            assertTrue(obj.list.containsAll(values))
+            assertTrue(obj.nullList.containsAll(values))
+        }
+    }
+
+    @Test
+    fun roundTripProblematicUTF8Chars() {
+        // Our UTF8 handling code optimizes short strings, so make some test strings longer than
+        // the short buffer of 48 chars.
+        val prefix = "abcdefghijklmnopqrstuvwxyz"
+        val suffix = "abcdefghijklmnopqrstuvwxyz"
+
+        val values = listOf(
+            "\uC000",
+            "\u0000",
+            0xC0.toByte().toInt().toChar().toString(),
+            0x00.toByte().toInt().toChar().toString(),
+        )
+        val config = RealmConfiguration.Builder(setOf(NonLatinClassёжф::class))
+            .directory(tmpDir)
+            .build()
+
+        Realm.open(config).use { realm ->
+            realm.writeBlocking {
+                values.forEach { str ->
+                    val obj = copyToRealm(
+                        NonLatinClassёжф().apply {
+                            prop = str
+                        }
+                    )
+                    println("'$str' vs. '${obj.prop}'")
+                    assertEquals(str, obj.prop)
+                }
+            }
+        }
+    }
+
+    // \0 has special semantics both in C++ and in Java, so ensure we can roundtrip
+    // it correctly.
+    @Test
+    fun roundtripNullCharacter() {
+        val config = RealmConfiguration.Builder(setOf(NonLatinClassёжф::class))
+            .directory(tmpDir)
+            .build()
+
+        Realm.open(config).use { realm ->
+            val nullChar = "\u0000"
+            val shortNullCharOddLength = "foo\u0000ba"
+            val shortNullCharEvenLength = "foo\u0000bar"
+            val mediumNullString = "abcdefghijklmnopqrstuvwxyz-\u0000-abcdefghijklmnopqrstuvwxyz"
+            val obj = realm.writeBlocking {
+                copyToRealm(
+                    NonLatinClassёжф().apply {
+                        prop = nullChar
+                        list.addAll(listOf(nullChar, shortNullCharEvenLength, shortNullCharOddLength, mediumNullString))
+                        nullList.addAll(listOf(nullChar, shortNullCharEvenLength, shortNullCharOddLength, mediumNullString))
+                    }
+                )
+            }
+            println("'$nullChar' vs '${obj.list[0]}'")
+            println("'$shortNullCharEvenLength' vs '${obj.list[1]}'")
+            println("'$shortNullCharOddLength' vs '${obj.list[2]}'")
+            println("'$mediumNullString' vs '${obj.list[3]}'")
+
+            assertEquals(nullChar, obj.prop)
+            assertEquals(1, obj.prop.length)
+
+            assertEquals(4, obj.list.size)
+            assertEquals(nullChar, obj.list[0])
+            assertEquals(shortNullCharEvenLength, obj.list[1])
+            assertEquals(shortNullCharOddLength, obj.list[2])
+            assertEquals(mediumNullString, obj.list[3])
+
+            assertEquals(4, obj.nullList.size)
+            assertEquals(nullChar, obj.nullList[0])
+            assertEquals(shortNullCharEvenLength, obj.nullList[1])
+            assertEquals(shortNullCharOddLength, obj.nullList[2])
+            assertEquals(mediumNullString, obj.nullList[3])
+        }
+    }
+}

--- a/test/base/src/androidTest/kotlin/io/realm/kotlin/test/shared/nonlatin/NonLatinTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/kotlin/test/shared/nonlatin/NonLatinTests.kt
@@ -2,12 +2,8 @@ package io.realm.kotlin.test.shared.nonlatin
 
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
-import io.realm.kotlin.entities.Sample
-import io.realm.kotlin.entities.link.Child
-import io.realm.kotlin.entities.link.Parent
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.test.platform.PlatformUtils
-import io.realm.kotlin.test.util.use
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import kotlin.test.AfterTest
@@ -41,7 +37,7 @@ class NonLatinTests {
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
         val configuration =
-            RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class, Sample::class))
+            RealmConfiguration.Builder(setOf(NonLatinFieldNames::class, NonLatinClassёжф::class))
                 .directory(tmpDir)
                 .build()
         realm = Realm.open(configuration)
@@ -49,145 +45,82 @@ class NonLatinTests {
 
     @AfterTest
     fun tearDown() {
+        if (!realm.isClosed()) {
+            realm.close()
+        }
         PlatformUtils.deleteTempDir(tmpDir)
     }
 
     @Test
     fun nonLatinClassNames() {
-        val config = RealmConfiguration.Builder(setOf(NonLatinClassёжф::class))
-            .directory(tmpDir)
-            .build()
-
-        Realm.open(config).use {
-            val schema = it.schema()[NonLatinClassёжф::class.simpleName.toString()]!!
-            assertEquals(3, schema.properties.size)
-            assertEquals("NonLatinClassёжф", schema.name)
-        }
+        val schema = realm.schema()[NonLatinClassёжф::class.simpleName.toString()]!!
+        assertEquals(3, schema.properties.size)
+        assertEquals("NonLatinClassёжф", schema.name)
     }
 
     @Test
     fun nonLatinProperties() {
-        val config = RealmConfiguration.Builder(setOf(NonLatinFieldNames::class))
-            .directory(tmpDir)
-            .build()
-
-        Realm.open(config).use {
-            val schema = it.schema()[NonLatinFieldNames::class.simpleName.toString()]!!
-            assertEquals(6, schema.properties.size)
-            schema.properties.forEach {
-                println(it.name)
-            }
-            assertNotNull(schema[NonLatinFieldNames().베타])
-            assertNotNull(schema[NonLatinFieldNames().Βήτα])
-            assertNotNull(schema[NonLatinFieldNames().ЙйКкЛл])
-            assertNotNull(schema[NonLatinFieldNames().山水要])
-            assertNotNull(schema[NonLatinFieldNames().ععسنملل])
-            assertNotNull(schema[NonLatinFieldNames().`😊🙈`])
-        }
+        val schema = realm.schema()[NonLatinFieldNames::class.simpleName.toString()]!!
+        assertEquals(6, schema.properties.size)
+        assertNotNull(schema[NonLatinFieldNames().베타])
+        assertNotNull(schema[NonLatinFieldNames().Βήτα])
+        assertNotNull(schema[NonLatinFieldNames().ЙйКкЛл])
+        assertNotNull(schema[NonLatinFieldNames().山水要])
+        assertNotNull(schema[NonLatinFieldNames().ععسنملل])
+        assertNotNull(schema[NonLatinFieldNames().`😊🙈`])
     }
 
     @Test
     fun roundtripNonLatinValues() {
-        val config = RealmConfiguration.Builder(setOf(NonLatinClassёжф::class))
-            .directory(tmpDir)
-            .build()
-
-        Realm.open(config).use { realm ->
-            val values = listOf(
-                "베타",
-                "Βήτα",
-                "ЙйКкЛл",
-                "山水要",
-                "ععسنملل",
-                "😊🙈"
-            )
-
-            val obj = realm.writeBlocking {
-                copyToRealm(
-                    NonLatinClassёжф().apply {
-                        list.addAll(values)
-                        nullList.addAll(values)
-                    }
-                )
-            }
-            assertTrue(obj.list.containsAll(values))
-            assertTrue(obj.nullList.containsAll(values))
-        }
-    }
-
-    @Test
-    fun roundTripProblematicUTF8Chars() {
-        // Our UTF8 handling code optimizes short strings, so make some test strings longer than
-        // the short buffer of 48 chars.
-        val prefix = "abcdefghijklmnopqrstuvwxyz"
-        val suffix = "abcdefghijklmnopqrstuvwxyz"
-
         val values = listOf(
-            "\uC000",
-            "\u0000",
-            0xC0.toByte().toInt().toChar().toString(),
-            0x00.toByte().toInt().toChar().toString(),
+            "베타",
+            "Βήτα",
+            "ЙйКкЛл",
+            "山水要",
+            "ععسنملل",
+            "😊🙈"
         )
-        val config = RealmConfiguration.Builder(setOf(NonLatinClassёжф::class))
-            .directory(tmpDir)
-            .build()
 
-        Realm.open(config).use { realm ->
-            realm.writeBlocking {
-                values.forEach { str ->
-                    val obj = copyToRealm(
-                        NonLatinClassёжф().apply {
-                            prop = str
-                        }
-                    )
-                    println("'$str' vs. '${obj.prop}'")
-                    assertEquals(str, obj.prop)
+        val obj = realm.writeBlocking {
+            copyToRealm(
+                NonLatinClassёжф().apply {
+                    list.addAll(values)
+                    nullList.addAll(values)
                 }
-            }
+            )
         }
+        assertTrue(obj.list.containsAll(values))
+        assertTrue(obj.nullList.containsAll(values))
     }
 
     // \0 has special semantics both in C++ and in Java, so ensure we can roundtrip
     // it correctly.
     @Test
     fun roundtripNullCharacter() {
-        val config = RealmConfiguration.Builder(setOf(NonLatinClassёжф::class))
-            .directory(tmpDir)
-            .build()
-
-        Realm.open(config).use { realm ->
-            val nullChar = "\u0000"
-            val shortNullCharOddLength = "foo\u0000ba"
-            val shortNullCharEvenLength = "foo\u0000bar"
-            val mediumNullString = "abcdefghijklmnopqrstuvwxyz-\u0000-abcdefghijklmnopqrstuvwxyz"
-            val obj = realm.writeBlocking {
-                copyToRealm(
-                    NonLatinClassёжф().apply {
-                        prop = nullChar
-                        list.addAll(listOf(nullChar, shortNullCharEvenLength, shortNullCharOddLength, mediumNullString))
-                        nullList.addAll(listOf(nullChar, shortNullCharEvenLength, shortNullCharOddLength, mediumNullString))
-                    }
-                )
-            }
-            println("'$nullChar' vs '${obj.list[0]}'")
-            println("'$shortNullCharEvenLength' vs '${obj.list[1]}'")
-            println("'$shortNullCharOddLength' vs '${obj.list[2]}'")
-            println("'$mediumNullString' vs '${obj.list[3]}'")
-
-            assertEquals(nullChar, obj.prop)
-            assertEquals(1, obj.prop.length)
-
-            assertEquals(4, obj.list.size)
-            assertEquals(nullChar, obj.list[0])
-            assertEquals(shortNullCharEvenLength, obj.list[1])
-            assertEquals(shortNullCharOddLength, obj.list[2])
-            assertEquals(mediumNullString, obj.list[3])
-
-            assertEquals(4, obj.nullList.size)
-            assertEquals(nullChar, obj.nullList[0])
-            assertEquals(shortNullCharEvenLength, obj.nullList[1])
-            assertEquals(shortNullCharOddLength, obj.nullList[2])
-            assertEquals(mediumNullString, obj.nullList[3])
+        val nullChar = "\u0000"
+        val shortNullString = "foo\u0000bar"
+        val mediumNullString = "abcdefghijklmnopqrstuvwxyz-\u0000-abcdefghijklmnopqrstuvwxyz"
+        val obj = realm.writeBlocking {
+            copyToRealm(
+                NonLatinClassёжф().apply {
+                    prop = nullChar
+                    list.addAll(listOf(nullChar, shortNullString, mediumNullString))
+                    nullList.addAll(listOf(nullChar, shortNullString, mediumNullString))
+                }
+            )
         }
+
+        assertEquals(nullChar, obj.prop)
+        assertEquals(1, obj.prop.length)
+
+        assertEquals(3, obj.list.size)
+        assertEquals(nullChar, obj.list[0])
+        assertEquals(shortNullString, obj.list[1])
+        assertEquals(mediumNullString, obj.list[2])
+
+        assertEquals(3, obj.nullList.size)
+        assertEquals(nullChar, obj.nullList[0])
+        assertEquals(shortNullString, obj.nullList[1])
+        assertEquals(mediumNullString, obj.nullList[2])
     }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
@@ -1,22 +1,17 @@
 package io.realm.kotlin.test.mongodb.shared.nonlatin
 
 import io.realm.kotlin.Realm
-import io.realm.kotlin.RealmConfiguration
-import io.realm.kotlin.entities.Sample
-import io.realm.kotlin.entities.link.Child
-import io.realm.kotlin.entities.link.Parent
 import io.realm.kotlin.entities.sync.ObjectIdPk
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
-import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestHelper
-import io.realm.kotlin.test.util.use
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
@@ -27,9 +22,9 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class NonLatinFieldNames : RealmObject {
     var 베타: String = "베타" // Korean
@@ -68,7 +63,6 @@ class NonLatinTests {
             app.close()
         }
     }
-
 
     /**
      * - Insert a string with the null character in MongoDB using the command server
@@ -114,7 +108,4 @@ class NonLatinTests {
             job.cancel()
         }
     }
-
-
-
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
@@ -5,7 +5,6 @@ import io.realm.kotlin.entities.sync.ObjectIdPk
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.internal.platform.runBlocking
-import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.test.mongodb.TestApp

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
@@ -3,7 +3,6 @@ package io.realm.kotlin.test.mongodb.shared.nonlatin
 import io.realm.kotlin.Realm
 import io.realm.kotlin.entities.sync.ObjectIdPk
 import io.realm.kotlin.ext.query
-import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
@@ -12,8 +11,6 @@ import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.types.ObjectId
-import io.realm.kotlin.types.RealmList
-import io.realm.kotlin.types.RealmObject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.serialization.json.JsonObject
@@ -24,21 +21,6 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-
-class NonLatinFieldNames : RealmObject {
-    var 베타: String = "베타" // Korean
-    var Βήτα: String = "Βήτα" // Greek
-    var ЙйКкЛл: String = "ЙйКкЛл" // Cyrillic
-    var 山水要: String = "山水要" // Chinese
-    var ععسنملل: String = "ععسنملل" // Arabic
-    var `😊🙈`: String = "😊🙈" // Emojii
-}
-
-class NonLatinClassёжф : RealmObject {
-    var prop: String = "property"
-    var list: RealmList<String> = realmListOf()
-    var nullList: RealmList<String?> = realmListOf()
-}
 
 class NonLatinTests {
 

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
@@ -1,0 +1,120 @@
+package io.realm.kotlin.test.mongodb.shared.nonlatin
+
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+import io.realm.kotlin.entities.Sample
+import io.realm.kotlin.entities.link.Child
+import io.realm.kotlin.entities.link.Parent
+import io.realm.kotlin.entities.sync.ObjectIdPk
+import io.realm.kotlin.ext.query
+import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.mongodb.sync.SyncConfiguration
+import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.asTestApp
+import io.realm.kotlin.test.mongodb.createUserAndLogIn
+import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestHelper
+import io.realm.kotlin.test.util.use
+import io.realm.kotlin.types.ObjectId
+import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmObject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NonLatinFieldNames : RealmObject {
+    var 베타: String = "베타" // Korean
+    var Βήτα: String = "Βήτα" // Greek
+    var ЙйКкЛл: String = "ЙйКкЛл" // Cyrillic
+    var 山水要: String = "山水要" // Chinese
+    var ععسنملل: String = "ععسنملل" // Arabic
+    var `😊🙈`: String = "😊🙈" // Emojii
+}
+
+class NonLatinClassёжф : RealmObject {
+    var prop: String = "property"
+    var list: RealmList<String> = realmListOf()
+    var nullList: RealmList<String?> = realmListOf()
+}
+
+class NonLatinTests {
+
+    private lateinit var partitionValue: String
+    private lateinit var user: User
+    private lateinit var app: TestApp
+
+    @BeforeTest
+    fun setup() {
+        partitionValue = TestHelper.randomPartitionValue()
+        app = TestApp()
+        val (email, password) = TestHelper.randomEmail() to "password1234"
+        user = runBlocking {
+            app.createUserAndLogIn(email, password)
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (this::app.isInitialized) {
+            app.close()
+        }
+    }
+
+
+    /**
+     * - Insert a string with the null character in MongoDB using the command server
+     */
+    @Test
+    fun readNullCharacterFromMongoDB() {
+        val adminApi = app.asTestApp
+        runBlocking {
+            val config =
+                SyncConfiguration.Builder(user, partitionValue, schema = setOf(ObjectIdPk::class))
+                    .build()
+            val realm = Realm.open(config)
+
+            val json: JsonObject = adminApi.insertDocument(
+                ObjectIdPk::class.simpleName!!,
+                """
+                    {
+                        "name": "foo\u0000bar",
+                        "realm_id" : "$partitionValue"
+                    }
+                """.trimIndent()
+            )
+            val oid = json["insertedId"]?.jsonPrimitive?.content
+            assertNotNull(oid)
+
+            val channel = Channel<ObjectIdPk>(1)
+            val job = async {
+                realm.query<ObjectIdPk>("_id = $0", ObjectId.from(oid)).first()
+                    .asFlow().collect {
+                        if (it.obj != null) {
+                            channel.trySend(it.obj!!)
+                        }
+                    }
+            }
+
+            val insertedObject = channel.receive()
+            assertEquals(oid, insertedObject._id.toString())
+            val char1 = "foo\u0000bar".toCharArray()
+            val char2 = insertedObject.name.toCharArray()
+            assertEquals("foo\u0000bar", insertedObject.name)
+            assertContentEquals(char1, char2)
+            realm.close()
+            job.cancel()
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
Attempting to reproduce https://github.com/realm/realm-kotlin/issues/895 and also verify that we correctly roundtrip special strings, especially on the JVM which uses modified UTF8.

*Update:* This PR was initially created to investigate #895, but since the tests revealed issues around handling of strings with null-characters and the original issue of #895 is now handled by #909, this PR is now only targeting issues with strings containing null-characters.