### PR TITLE
Added proguard exception for `ResponseCallback`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 * None.
 
 ### Fixed
-* Fix JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
+* Fixed JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
+* Fixed crash present on release-mode apps using Sync due to missing Proguard exception for `ResponseCallback`.
 
 ### Compatibility
 * This release is compatible with:

--- a/packages/library-base/proguard-rules-consumer-common.pro
+++ b/packages/library-base/proguard-rules-consumer-common.pro
@@ -60,6 +60,9 @@
 -keep class io.realm.kotlin.internal.interop.sync.JVMSyncSessionTransferCompletionCallback {
     *;
 }
+-keep class io.realm.kotlin.internal.interop.sync.ResponseCallback {
+    *;
+}
 -keep class io.realm.kotlin.internal.interop.sync.ResponseCallbackImpl {
     *;
 }


### PR DESCRIPTION
Running an app that uses sync in release mode produces the following crash:
```
2022-06-20 15:47:51.156 8259-8259/io.realm.example.kmmsample.androidApp E/REALM: /Users/eduardo.lopez/git/realm-kotlin/packages/cinterop/src/jvm/jni/java_method.cpp:33: [realm-core-12.1.0] Assertion failed: m_method_id != nullptr with (method_name, signature) =  ["sendRequest", "(Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lio/realm/kotlin/internal/interop/sync/ResponseCallback;)V"]
    <backtrace not supported on this platform>!!! IMPORTANT: Please report this at https://github.com/realm/realm-core/issues/new/choose
2022-06-20 15:47:51.156 8259-8259/io.realm.example.kmmsample.androidApp A/libc: Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 8259 (mple.androidApp), pid 8259 (mple.androidApp)
```
A closer inspection revealed there was an exception for `ResponseCallbackImpl` but not for `ResponseCallback`. After adding it the problem is gone.