### PR TITLE
Fix Compiler Plugin not setting RealmObjectReference generic argument correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Fixed JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
 * Fixed crash present on release-mode apps using Sync due to missing Proguard exception for `ResponseCallback`.
+* The compiler plugin did not set the generic parameter correctly for an internal field inside model classes. This could result in other libraries that operated on the source code throwing an error of the type: `undeclared type variable: T`. (Issue [#901](https://github.com/realm/realm-kotlin/issues/901))
 
 ### Compatibility
 * This release is compatible with:

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectReference.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectReference.kt
@@ -49,7 +49,7 @@ public class RealmObjectReference<T : BaseRealmObject>(
     public override val objectPointer: RealmObjectPointer,
 ) :
     RealmStateHolder,
-    io.realm.kotlin.internal.interop.RealmObjectInterop,
+    RealmObjectInterop,
     InternalDeleteable,
     Observable<RealmObjectReference<out BaseRealmObject>, ObjectChange<out BaseRealmObject>>,
     Flowable<ObjectChange<out BaseRealmObject>> {

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -84,9 +84,9 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
                 pluginContext.lookupClassOrThrow(REALM_OBJECT_INTERNAL_INTERFACE).symbol
             irClass.superTypes += realmObjectInternalInterface.defaultType
 
-            // Generate RealmObjectInterop properties overrides
+            // Generate RealmObjectInternal properties overrides
             val generator = RealmModelSyntheticPropertiesGeneration(pluginContext)
-            generator.addProperties(irClass)
+            generator.addRealmObjectInternalProperties(irClass)
 
             // Modify properties accessor to generate custom getter/setter
             AccessorModifierIrGeneration(pluginContext).modifyPropertiesAndCollectSchema(irClass)

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -102,7 +102,7 @@ import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
 /**
  * Helper to assisting in modifying classes marked with the [RealmObject] interface according to our
  * needs:
- * - Adding the internal properties of [io.realm.kotlin.internal.interop.RealmObjectInterop]
+ * - Adding the internal properties of [io.realm.kotlin.internal.RealmObjectInternal]
  * - Adding the internal properties and methods of [RealmObjectCompanion] to the associated companion.
  */
 class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPluginContext) {
@@ -112,9 +112,6 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         pluginContext.lookupClassOrThrow(EMBEDDED_OBJECT_INTERFACE)
     private val realmModelInternalInterface: IrClass =
         pluginContext.lookupClassOrThrow(REALM_OBJECT_INTERNAL_INTERFACE)
-    private val nullableNativePointerInterface =
-        pluginContext.lookupClassOrThrow(REALM_NATIVE_POINTER)
-            .symbol.createType(true, emptyList())
     private val realmObjectCompanionInterface =
         pluginContext.lookupClassOrThrow(REALM_MODEL_COMPANION)
     private val classInfoClass = pluginContext.lookupClassOrThrow(CLASS_INFO)
@@ -158,22 +155,26 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         realmObjectPropertyType
     )
 
-    private val listIrClass: IrClass =
-        pluginContext.lookupClassOrThrow(FqNames.KOTLIN_COLLECTIONS_LIST)
     val realmClassImpl = pluginContext.lookupClassOrThrow(FqNames.REALM_CLASS_IMPL)
     private val realmClassCtor = pluginContext.lookupConstructorInClass(FqNames.REALM_CLASS_IMPL) {
         it.owner.valueParameters.size == 2
     }
 
-    fun addProperties(irClass: IrClass): IrClass =
-        irClass.apply {
+    /**
+     * Add fields required to satisfy the `RealmObjectInternal` contract.
+     */
+    fun addRealmObjectInternalProperties(irClass: IrClass): IrClass {
+        // RealmObjectReference<T> should use the model class name as the generic argument.
+        val type: IrType = objectReferenceClass.typeWith(irClass.defaultType).makeNullable()
+        return irClass.apply {
             addVariableProperty(
                 realmModelInternalInterface,
                 OBJECT_REFERENCE,
-                objectReferenceClass.defaultType.makeNullable(),
+                type,
                 ::irNull
             )
         }
+    }
 
     @Suppress("LongMethod")
     fun addCompanionFields(

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -29,7 +29,6 @@ import io.realm.kotlin.compiler.FqNames.PROPERTY_INFO
 import io.realm.kotlin.compiler.FqNames.PROPERTY_TYPE
 import io.realm.kotlin.compiler.FqNames.REALM_INSTANT
 import io.realm.kotlin.compiler.FqNames.REALM_MODEL_COMPANION
-import io.realm.kotlin.compiler.FqNames.REALM_NATIVE_POINTER
 import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_ID
 import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_INTERFACE
 import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_INTERNAL_INTERFACE
@@ -83,7 +82,6 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrSetFieldImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrVarargImpl
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrFail
-import org.jetbrains.kotlin.ir.types.createType
 import org.jetbrains.kotlin.ir.types.isNullable
 import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.types.makeNullable

--- a/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/sample/expected/00_ValidateIrBeforeLowering.ir
@@ -20,13 +20,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-id> (): kotlin.Long declared in sample.input.Sample'
               BLOCK type=kotlin.Long origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Long origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Long origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-id>' type=sample.input.Sample origin=null
@@ -35,7 +35,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-id>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                         propertyName: CONST String type=kotlin.String value="id"
         FUN name:<set-id> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Long) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:id visibility:public modality:FINAL [var]
@@ -43,13 +43,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:id type:kotlin.Long visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-id>' type=sample.input.Sample origin=null
@@ -58,7 +58,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="id"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
@@ -116,13 +116,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-stringField> (): kotlin.String? declared in sample.input.Sample'
               BLOCK type=kotlin.String? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.String? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.String? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringField>' type=sample.input.Sample origin=null
@@ -131,7 +131,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-stringField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                         propertyName: CONST String type=kotlin.String value="stringField"
         FUN name:<set-stringField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.String?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:stringField visibility:public modality:FINAL [var]
@@ -139,13 +139,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringField type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringField>' type=sample.input.Sample origin=null
@@ -154,7 +154,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-stringField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="stringField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Sample.<set-stringField>' type=kotlin.String? origin=null
@@ -168,13 +168,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-byteField> (): kotlin.Byte? declared in sample.input.Sample'
               BLOCK type=kotlin.Byte? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Byte? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Byte? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteField>' type=sample.input.Sample origin=null
@@ -184,7 +184,7 @@ MODULE_FRAGMENT name:<main>
                       value: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                         realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                           $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                          obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                          obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-byteField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                           propertyName: CONST String type=kotlin.String value="byteField"
         FUN name:<set-byteField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Byte?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:byteField visibility:public modality:FINAL [var]
@@ -192,13 +192,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Byte?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteField type:kotlin.Byte? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteField>' type=sample.input.Sample origin=null
@@ -207,7 +207,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-byteField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="byteField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: CALL 'public final fun byteToLong (value: kotlin.Byte?): kotlin.Long? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Long? origin=null
@@ -222,13 +222,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-charField> (): kotlin.Char? declared in sample.input.Sample'
               BLOCK type=kotlin.Char? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Char? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Char? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charField>' type=sample.input.Sample origin=null
@@ -238,7 +238,7 @@ MODULE_FRAGMENT name:<main>
                       value: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                         realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                           $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                          obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                          obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-charField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                           propertyName: CONST String type=kotlin.String value="charField"
         FUN name:<set-charField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Char?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:charField visibility:public modality:FINAL [var]
@@ -246,13 +246,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Char?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charField type:kotlin.Char? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charField>' type=sample.input.Sample origin=null
@@ -261,7 +261,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-charField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="charField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: CALL 'public final fun charToLong (value: kotlin.Char?): kotlin.Long? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Long? origin=null
@@ -276,13 +276,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-shortField> (): kotlin.Short? declared in sample.input.Sample'
               BLOCK type=kotlin.Short? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Short? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Short? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortField>' type=sample.input.Sample origin=null
@@ -292,7 +292,7 @@ MODULE_FRAGMENT name:<main>
                       value: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                         realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                           $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                          obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                          obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-shortField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                           propertyName: CONST String type=kotlin.String value="shortField"
         FUN name:<set-shortField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Short?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:shortField visibility:public modality:FINAL [var]
@@ -300,13 +300,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Short?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortField type:kotlin.Short? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortField>' type=sample.input.Sample origin=null
@@ -315,7 +315,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-shortField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="shortField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: CALL 'public final fun shortToLong (value: kotlin.Short?): kotlin.Long? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Long? origin=null
@@ -332,13 +332,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-intField> (): kotlin.Int? declared in sample.input.Sample'
               BLOCK type=kotlin.Int? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Int? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Int? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intField>' type=sample.input.Sample origin=null
@@ -348,7 +348,7 @@ MODULE_FRAGMENT name:<main>
                       value: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                         realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                           $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                          obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                          obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-intField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                           propertyName: CONST String type=kotlin.String value="intField"
         FUN name:<set-intField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Int?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:intField visibility:public modality:FINAL [var]
@@ -356,13 +356,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intField type:kotlin.Int? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intField>' type=sample.input.Sample origin=null
@@ -371,7 +371,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-intField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="intField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: CALL 'public final fun intToLong (value: kotlin.Int?): kotlin.Long? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Long? origin=null
@@ -386,13 +386,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-longField> (): kotlin.Long? declared in sample.input.Sample'
               BLOCK type=kotlin.Long? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Long? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Long? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longField>' type=sample.input.Sample origin=null
@@ -401,7 +401,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-longField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                         propertyName: CONST String type=kotlin.String value="longField"
         FUN name:<set-longField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Long?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:longField visibility:public modality:FINAL [var]
@@ -409,13 +409,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Long?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longField type:kotlin.Long? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longField>' type=sample.input.Sample origin=null
@@ -424,7 +424,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-longField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="longField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: kotlin.Long? declared in sample.input.Sample.<set-longField>' type=kotlin.Long? origin=null
@@ -438,13 +438,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-booleanField> (): kotlin.Boolean? declared in sample.input.Sample'
               BLOCK type=kotlin.Boolean? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Boolean? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Boolean? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanField>' type=sample.input.Sample origin=null
@@ -453,7 +453,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-booleanField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                         propertyName: CONST String type=kotlin.String value="booleanField"
         FUN name:<set-booleanField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Boolean?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:booleanField visibility:public modality:FINAL [var]
@@ -461,13 +461,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Boolean?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanField type:kotlin.Boolean? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanField>' type=sample.input.Sample origin=null
@@ -476,7 +476,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-booleanField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="booleanField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: kotlin.Boolean? declared in sample.input.Sample.<set-booleanField>' type=kotlin.Boolean? origin=null
@@ -490,13 +490,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-floatField> (): kotlin.Float? declared in sample.input.Sample'
               BLOCK type=kotlin.Float? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Float? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Float? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatField>' type=sample.input.Sample origin=null
@@ -505,7 +505,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-floatField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                         propertyName: CONST String type=kotlin.String value="floatField"
         FUN name:<set-floatField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Float?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:floatField visibility:public modality:FINAL [var]
@@ -513,13 +513,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Float?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatField type:kotlin.Float? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatField>' type=sample.input.Sample origin=null
@@ -528,7 +528,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-floatField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="floatField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: kotlin.Float? declared in sample.input.Sample.<set-floatField>' type=kotlin.Float? origin=null
@@ -542,13 +542,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-doubleField> (): kotlin.Double? declared in sample.input.Sample'
               BLOCK type=kotlin.Double? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
                 WHEN type=kotlin.Double? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Double? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleField>' type=sample.input.Sample origin=null
@@ -557,7 +557,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-doubleField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                         propertyName: CONST String type=kotlin.String value="doubleField"
         FUN name:<set-doubleField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:kotlin.Double?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:doubleField visibility:public modality:FINAL [var]
@@ -565,13 +565,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Double?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleField type:kotlin.Double? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleField>' type=sample.input.Sample origin=null
@@ -580,7 +580,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-doubleField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="doubleField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: kotlin.Double? declared in sample.input.Sample.<set-doubleField>' type=kotlin.Double? origin=null
@@ -597,13 +597,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-timestampField> (): io.realm.kotlin.types.RealmInstant? declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmInstant? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmInstant? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.kotlin.types.RealmInstant? visibility:private' type=io.realm.kotlin.types.RealmInstant? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampField>' type=sample.input.Sample origin=null
@@ -612,7 +612,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToRealmInstant (realmValue: io.realm.kotlin.internal.interop.RealmValue): io.realm.kotlin.types.RealmInstant? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.types.RealmInstant? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-timestampField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                         propertyName: CONST String type=kotlin.String value="timestampField"
         FUN name:<set-timestampField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmInstant?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:timestampField visibility:public modality:FINAL [var]
@@ -620,13 +620,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmInstant?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampField type:io.realm.kotlin.types.RealmInstant? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampField>' type=sample.input.Sample origin=null
@@ -635,7 +635,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-timestampField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="timestampField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: io.realm.kotlin.types.RealmInstant? declared in sample.input.Sample.<set-timestampField>' type=io.realm.kotlin.types.RealmInstant? origin=null
@@ -650,13 +650,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-objectIdField> (): io.realm.kotlin.types.ObjectId? declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.ObjectId? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectIdField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.ObjectId? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-objectIdField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-objectIdField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectIdField type:io.realm.kotlin.types.ObjectId? visibility:private' type=io.realm.kotlin.types.ObjectId? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectIdField>' type=sample.input.Sample origin=null
@@ -665,7 +665,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToObjectId (realmValue: io.realm.kotlin.internal.interop.RealmValue): io.realm.kotlin.types.ObjectId? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.types.ObjectId? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-objectIdField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-objectIdField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                         propertyName: CONST String type=kotlin.String value="objectIdField"
         FUN name:<set-objectIdField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.ObjectId?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:objectIdField visibility:public modality:FINAL [var]
@@ -673,13 +673,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.ObjectId?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectIdField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectIdField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-objectIdField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectIdField type:io.realm.kotlin.types.ObjectId? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectIdField>' type=sample.input.Sample origin=null
@@ -688,7 +688,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectIdField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-objectIdField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="objectIdField"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: io.realm.kotlin.types.ObjectId? declared in sample.input.Sample.<set-objectIdField>' type=io.realm.kotlin.types.ObjectId? origin=null
@@ -702,13 +702,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-child> (): sample.input.Child? declared in sample.input.Sample'
               BLOCK type=sample.input.Child? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
                 WHEN type=sample.input.Child? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=sample.input.Child? origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-child>' type=sample.input.Sample origin=null
@@ -718,7 +718,7 @@ MODULE_FRAGMENT name:<main>
                       <R>: sample.input.Child?
                       <U>: <none>
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-child>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="child"
         FUN name:<set-child> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:sample.input.Child?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:child visibility:public modality:FINAL [var]
@@ -726,13 +726,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:sample.input.Child?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.Child? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-child>' type=sample.input.Sample origin=null
@@ -741,7 +741,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setObject (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.types.BaseRealmObject?, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-child>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="child"
                     value: GET_VAR '<set-?>: sample.input.Child? declared in sample.input.Sample.<set-child>' type=sample.input.Child? origin=null
       PROPERTY name:stringListField visibility:public modality:FINAL [var]
@@ -755,13 +755,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-stringListField> (): io.realm.kotlin.types.RealmList<kotlin.String> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.String> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.String> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.kotlin.types.RealmList<kotlin.String> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.String> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-stringListField>' type=sample.input.Sample origin=null
@@ -770,7 +770,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.String
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-stringListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="stringListField"
         FUN name:<set-stringListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.String>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:stringListField visibility:public modality:FINAL [var]
@@ -778,13 +778,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.String>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringListField type:io.realm.kotlin.types.RealmList<kotlin.String> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-stringListField>' type=sample.input.Sample origin=null
@@ -794,7 +794,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.String
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-stringListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="stringListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.String> declared in sample.input.Sample.<set-stringListField>' type=io.realm.kotlin.types.RealmList<kotlin.String> origin=null
       PROPERTY name:byteListField visibility:public modality:FINAL [var]
@@ -808,13 +808,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-byteListField> (): io.realm.kotlin.types.RealmList<kotlin.Byte> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Byte> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Byte> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.kotlin.types.RealmList<kotlin.Byte> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Byte> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-byteListField>' type=sample.input.Sample origin=null
@@ -823,7 +823,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Byte
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-byteListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="byteListField"
         FUN name:<set-byteListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Byte>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:byteListField visibility:public modality:FINAL [var]
@@ -831,13 +831,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Byte>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteListField type:io.realm.kotlin.types.RealmList<kotlin.Byte> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-byteListField>' type=sample.input.Sample origin=null
@@ -847,7 +847,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Byte
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-byteListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="byteListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Byte> declared in sample.input.Sample.<set-byteListField>' type=io.realm.kotlin.types.RealmList<kotlin.Byte> origin=null
       PROPERTY name:charListField visibility:public modality:FINAL [var]
@@ -861,13 +861,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-charListField> (): io.realm.kotlin.types.RealmList<kotlin.Char> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Char> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Char> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.kotlin.types.RealmList<kotlin.Char> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Char> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-charListField>' type=sample.input.Sample origin=null
@@ -876,7 +876,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Char
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-charListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="charListField"
         FUN name:<set-charListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Char>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:charListField visibility:public modality:FINAL [var]
@@ -884,13 +884,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Char>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charListField type:io.realm.kotlin.types.RealmList<kotlin.Char> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-charListField>' type=sample.input.Sample origin=null
@@ -900,7 +900,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Char
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-charListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="charListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Char> declared in sample.input.Sample.<set-charListField>' type=io.realm.kotlin.types.RealmList<kotlin.Char> origin=null
       PROPERTY name:shortListField visibility:public modality:FINAL [var]
@@ -914,13 +914,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-shortListField> (): io.realm.kotlin.types.RealmList<kotlin.Short> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Short> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Short> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.kotlin.types.RealmList<kotlin.Short> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Short> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-shortListField>' type=sample.input.Sample origin=null
@@ -929,7 +929,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Short
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-shortListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="shortListField"
         FUN name:<set-shortListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Short>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:shortListField visibility:public modality:FINAL [var]
@@ -937,13 +937,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Short>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortListField type:io.realm.kotlin.types.RealmList<kotlin.Short> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-shortListField>' type=sample.input.Sample origin=null
@@ -953,7 +953,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Short
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-shortListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="shortListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Short> declared in sample.input.Sample.<set-shortListField>' type=io.realm.kotlin.types.RealmList<kotlin.Short> origin=null
       PROPERTY name:intListField visibility:public modality:FINAL [var]
@@ -967,13 +967,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-intListField> (): io.realm.kotlin.types.RealmList<kotlin.Int> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Int> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Int> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.kotlin.types.RealmList<kotlin.Int> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Int> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-intListField>' type=sample.input.Sample origin=null
@@ -982,7 +982,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Int
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-intListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="intListField"
         FUN name:<set-intListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Int>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:intListField visibility:public modality:FINAL [var]
@@ -990,13 +990,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Int>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intListField type:io.realm.kotlin.types.RealmList<kotlin.Int> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-intListField>' type=sample.input.Sample origin=null
@@ -1006,7 +1006,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Int
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-intListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="intListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Int> declared in sample.input.Sample.<set-intListField>' type=io.realm.kotlin.types.RealmList<kotlin.Int> origin=null
       PROPERTY name:longListField visibility:public modality:FINAL [var]
@@ -1020,13 +1020,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-longListField> (): io.realm.kotlin.types.RealmList<kotlin.Long> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Long> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Long> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.kotlin.types.RealmList<kotlin.Long> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Long> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-longListField>' type=sample.input.Sample origin=null
@@ -1035,7 +1035,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Long
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-longListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="longListField"
         FUN name:<set-longListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Long>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:longListField visibility:public modality:FINAL [var]
@@ -1043,13 +1043,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Long>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longListField type:io.realm.kotlin.types.RealmList<kotlin.Long> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-longListField>' type=sample.input.Sample origin=null
@@ -1059,7 +1059,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Long
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-longListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="longListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Long> declared in sample.input.Sample.<set-longListField>' type=io.realm.kotlin.types.RealmList<kotlin.Long> origin=null
       PROPERTY name:booleanListField visibility:public modality:FINAL [var]
@@ -1073,13 +1073,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-booleanListField> (): io.realm.kotlin.types.RealmList<kotlin.Boolean> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Boolean> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Boolean> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.kotlin.types.RealmList<kotlin.Boolean> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Boolean> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-booleanListField>' type=sample.input.Sample origin=null
@@ -1088,7 +1088,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Boolean
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-booleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="booleanListField"
         FUN name:<set-booleanListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Boolean>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:booleanListField visibility:public modality:FINAL [var]
@@ -1096,13 +1096,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Boolean>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanListField type:io.realm.kotlin.types.RealmList<kotlin.Boolean> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-booleanListField>' type=sample.input.Sample origin=null
@@ -1112,7 +1112,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Boolean
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-booleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="booleanListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Boolean> declared in sample.input.Sample.<set-booleanListField>' type=io.realm.kotlin.types.RealmList<kotlin.Boolean> origin=null
       PROPERTY name:floatListField visibility:public modality:FINAL [var]
@@ -1126,13 +1126,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-floatListField> (): io.realm.kotlin.types.RealmList<kotlin.Float> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Float> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Float> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.kotlin.types.RealmList<kotlin.Float> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Float> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-floatListField>' type=sample.input.Sample origin=null
@@ -1141,7 +1141,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Float
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-floatListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="floatListField"
         FUN name:<set-floatListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Float>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:floatListField visibility:public modality:FINAL [var]
@@ -1149,13 +1149,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Float>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatListField type:io.realm.kotlin.types.RealmList<kotlin.Float> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-floatListField>' type=sample.input.Sample origin=null
@@ -1165,7 +1165,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Float
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-floatListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="floatListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Float> declared in sample.input.Sample.<set-floatListField>' type=io.realm.kotlin.types.RealmList<kotlin.Float> origin=null
       PROPERTY name:doubleListField visibility:public modality:FINAL [var]
@@ -1179,13 +1179,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-doubleListField> (): io.realm.kotlin.types.RealmList<kotlin.Double> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Double> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Double> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.kotlin.types.RealmList<kotlin.Double> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Double> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-doubleListField>' type=sample.input.Sample origin=null
@@ -1194,7 +1194,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Double
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-doubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="doubleListField"
         FUN name:<set-doubleListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Double>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:doubleListField visibility:public modality:FINAL [var]
@@ -1202,13 +1202,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Double>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleListField type:io.realm.kotlin.types.RealmList<kotlin.Double> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-doubleListField>' type=sample.input.Sample origin=null
@@ -1218,7 +1218,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Double
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-doubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="doubleListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Double> declared in sample.input.Sample.<set-doubleListField>' type=io.realm.kotlin.types.RealmList<kotlin.Double> origin=null
       PROPERTY name:timestampListField visibility:public modality:FINAL [var]
@@ -1232,13 +1232,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-timestampListField> (): io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant> visibility:private' type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-timestampListField>' type=sample.input.Sample origin=null
@@ -1247,7 +1247,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: io.realm.kotlin.types.RealmInstant
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-timestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="timestampListField"
         FUN name:<set-timestampListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:timestampListField visibility:public modality:FINAL [var]
@@ -1255,13 +1255,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:timestampListField type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-timestampListField>' type=sample.input.Sample origin=null
@@ -1271,7 +1271,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: io.realm.kotlin.types.RealmInstant
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-timestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="timestampListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant> declared in sample.input.Sample.<set-timestampListField>' type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant> origin=null
       PROPERTY name:objectIdListField visibility:public modality:FINAL [var]
@@ -1285,13 +1285,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-objectIdListField> (): io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectIdListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-objectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-objectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectIdListField type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId> visibility:private' type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectIdListField>' type=sample.input.Sample origin=null
@@ -1300,7 +1300,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: io.realm.kotlin.types.ObjectId
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-objectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-objectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="objectIdListField"
         FUN name:<set-objectIdListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:objectIdListField visibility:public modality:FINAL [var]
@@ -1308,13 +1308,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectIdListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-objectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectIdListField type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectIdListField>' type=sample.input.Sample origin=null
@@ -1324,7 +1324,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: io.realm.kotlin.types.ObjectId
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-objectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="objectIdListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId> declared in sample.input.Sample.<set-objectIdListField>' type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId> origin=null
       PROPERTY name:objectListField visibility:public modality:FINAL [var]
@@ -1338,13 +1338,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-objectListField> (): io.realm.kotlin.types.RealmList<sample.input.Sample> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<sample.input.Sample> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<sample.input.Sample> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.kotlin.types.RealmList<sample.input.Sample> visibility:private' type=io.realm.kotlin.types.RealmList<sample.input.Sample> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-objectListField>' type=sample.input.Sample origin=null
@@ -1353,7 +1353,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: sample.input.Sample
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-objectListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="objectListField"
         FUN name:<set-objectListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<sample.input.Sample>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:objectListField visibility:public modality:FINAL [var]
@@ -1361,13 +1361,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<sample.input.Sample>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:objectListField type:io.realm.kotlin.types.RealmList<sample.input.Sample> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-objectListField>' type=sample.input.Sample origin=null
@@ -1377,7 +1377,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: sample.input.Sample
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-objectListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="objectListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<sample.input.Sample> declared in sample.input.Sample.<set-objectListField>' type=io.realm.kotlin.types.RealmList<sample.input.Sample> origin=null
       PROPERTY name:embeddedRealmObjectListField visibility:public modality:FINAL [var]
@@ -1391,13 +1391,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-embeddedRealmObjectListField> (): io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-embeddedRealmObjectListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-embeddedRealmObjectListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-embeddedRealmObjectListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:embeddedRealmObjectListField type:io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild> visibility:private' type=io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-embeddedRealmObjectListField>' type=sample.input.Sample origin=null
@@ -1406,7 +1406,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: sample.input.EmbeddedChild
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-embeddedRealmObjectListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-embeddedRealmObjectListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="embeddedRealmObjectListField"
         FUN name:<set-embeddedRealmObjectListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:embeddedRealmObjectListField visibility:public modality:FINAL [var]
@@ -1414,13 +1414,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-embeddedRealmObjectListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-embeddedRealmObjectListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-embeddedRealmObjectListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:embeddedRealmObjectListField type:io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-embeddedRealmObjectListField>' type=sample.input.Sample origin=null
@@ -1430,7 +1430,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: sample.input.EmbeddedChild
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-embeddedRealmObjectListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-embeddedRealmObjectListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="embeddedRealmObjectListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild> declared in sample.input.Sample.<set-embeddedRealmObjectListField>' type=io.realm.kotlin.types.RealmList<sample.input.EmbeddedChild> origin=null
       PROPERTY name:nullableStringListField visibility:public modality:FINAL [var]
@@ -1444,13 +1444,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableStringListField> (): io.realm.kotlin.types.RealmList<kotlin.String?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.String?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.String?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.kotlin.types.RealmList<kotlin.String?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.String?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableStringListField>' type=sample.input.Sample origin=null
@@ -1459,7 +1459,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.String?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableStringListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableStringListField"
         FUN name:<set-nullableStringListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.String?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableStringListField visibility:public modality:FINAL [var]
@@ -1467,13 +1467,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.String?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableStringListField type:io.realm.kotlin.types.RealmList<kotlin.String?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableStringListField>' type=sample.input.Sample origin=null
@@ -1483,7 +1483,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.String?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableStringListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.String?> declared in sample.input.Sample.<set-nullableStringListField>' type=io.realm.kotlin.types.RealmList<kotlin.String?> origin=null
       PROPERTY name:nullableByteListField visibility:public modality:FINAL [var]
@@ -1497,13 +1497,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableByteListField> (): io.realm.kotlin.types.RealmList<kotlin.Byte?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Byte?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Byte?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.kotlin.types.RealmList<kotlin.Byte?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Byte?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableByteListField>' type=sample.input.Sample origin=null
@@ -1512,7 +1512,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Byte?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableByteListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableByteListField"
         FUN name:<set-nullableByteListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Byte?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableByteListField visibility:public modality:FINAL [var]
@@ -1520,13 +1520,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Byte?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableByteListField type:io.realm.kotlin.types.RealmList<kotlin.Byte?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableByteListField>' type=sample.input.Sample origin=null
@@ -1536,7 +1536,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Byte?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableByteListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Byte?> declared in sample.input.Sample.<set-nullableByteListField>' type=io.realm.kotlin.types.RealmList<kotlin.Byte?> origin=null
       PROPERTY name:nullableCharListField visibility:public modality:FINAL [var]
@@ -1550,13 +1550,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableCharListField> (): io.realm.kotlin.types.RealmList<kotlin.Char?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Char?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Char?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.kotlin.types.RealmList<kotlin.Char?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Char?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableCharListField>' type=sample.input.Sample origin=null
@@ -1565,7 +1565,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Char?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableCharListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableCharListField"
         FUN name:<set-nullableCharListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Char?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableCharListField visibility:public modality:FINAL [var]
@@ -1573,13 +1573,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Char?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableCharListField type:io.realm.kotlin.types.RealmList<kotlin.Char?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableCharListField>' type=sample.input.Sample origin=null
@@ -1589,7 +1589,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Char?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableCharListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Char?> declared in sample.input.Sample.<set-nullableCharListField>' type=io.realm.kotlin.types.RealmList<kotlin.Char?> origin=null
       PROPERTY name:nullableShortListField visibility:public modality:FINAL [var]
@@ -1603,13 +1603,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableShortListField> (): io.realm.kotlin.types.RealmList<kotlin.Short?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Short?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Short?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.kotlin.types.RealmList<kotlin.Short?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Short?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableShortListField>' type=sample.input.Sample origin=null
@@ -1618,7 +1618,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Short?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableShortListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableShortListField"
         FUN name:<set-nullableShortListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Short?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableShortListField visibility:public modality:FINAL [var]
@@ -1626,13 +1626,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Short?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableShortListField type:io.realm.kotlin.types.RealmList<kotlin.Short?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableShortListField>' type=sample.input.Sample origin=null
@@ -1642,7 +1642,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Short?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableShortListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Short?> declared in sample.input.Sample.<set-nullableShortListField>' type=io.realm.kotlin.types.RealmList<kotlin.Short?> origin=null
       PROPERTY name:nullableIntListField visibility:public modality:FINAL [var]
@@ -1656,13 +1656,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableIntListField> (): io.realm.kotlin.types.RealmList<kotlin.Int?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Int?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Int?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.kotlin.types.RealmList<kotlin.Int?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Int?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableIntListField>' type=sample.input.Sample origin=null
@@ -1671,7 +1671,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Int?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableIntListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableIntListField"
         FUN name:<set-nullableIntListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Int?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableIntListField visibility:public modality:FINAL [var]
@@ -1679,13 +1679,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Int?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableIntListField type:io.realm.kotlin.types.RealmList<kotlin.Int?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableIntListField>' type=sample.input.Sample origin=null
@@ -1695,7 +1695,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Int?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableIntListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Int?> declared in sample.input.Sample.<set-nullableIntListField>' type=io.realm.kotlin.types.RealmList<kotlin.Int?> origin=null
       PROPERTY name:nullableLongListField visibility:public modality:FINAL [var]
@@ -1709,13 +1709,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableLongListField> (): io.realm.kotlin.types.RealmList<kotlin.Long?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Long?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Long?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.kotlin.types.RealmList<kotlin.Long?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Long?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableLongListField>' type=sample.input.Sample origin=null
@@ -1724,7 +1724,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Long?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableLongListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableLongListField"
         FUN name:<set-nullableLongListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Long?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableLongListField visibility:public modality:FINAL [var]
@@ -1732,13 +1732,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Long?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableLongListField type:io.realm.kotlin.types.RealmList<kotlin.Long?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableLongListField>' type=sample.input.Sample origin=null
@@ -1748,7 +1748,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Long?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableLongListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Long?> declared in sample.input.Sample.<set-nullableLongListField>' type=io.realm.kotlin.types.RealmList<kotlin.Long?> origin=null
       PROPERTY name:nullableBooleanListField visibility:public modality:FINAL [var]
@@ -1762,13 +1762,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableBooleanListField> (): io.realm.kotlin.types.RealmList<kotlin.Boolean?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Boolean?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Boolean?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.kotlin.types.RealmList<kotlin.Boolean?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Boolean?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableBooleanListField>' type=sample.input.Sample origin=null
@@ -1777,7 +1777,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Boolean?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableBooleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableBooleanListField"
         FUN name:<set-nullableBooleanListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Boolean?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableBooleanListField visibility:public modality:FINAL [var]
@@ -1785,13 +1785,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Boolean?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableBooleanListField type:io.realm.kotlin.types.RealmList<kotlin.Boolean?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableBooleanListField>' type=sample.input.Sample origin=null
@@ -1801,7 +1801,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Boolean?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableBooleanListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Boolean?> declared in sample.input.Sample.<set-nullableBooleanListField>' type=io.realm.kotlin.types.RealmList<kotlin.Boolean?> origin=null
       PROPERTY name:nullableFloatListField visibility:public modality:FINAL [var]
@@ -1815,13 +1815,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableFloatListField> (): io.realm.kotlin.types.RealmList<kotlin.Float?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Float?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Float?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.kotlin.types.RealmList<kotlin.Float?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Float?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableFloatListField>' type=sample.input.Sample origin=null
@@ -1830,7 +1830,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Float?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableFloatListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableFloatListField"
         FUN name:<set-nullableFloatListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Float?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableFloatListField visibility:public modality:FINAL [var]
@@ -1838,13 +1838,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Float?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableFloatListField type:io.realm.kotlin.types.RealmList<kotlin.Float?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableFloatListField>' type=sample.input.Sample origin=null
@@ -1854,7 +1854,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Float?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableFloatListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Float?> declared in sample.input.Sample.<set-nullableFloatListField>' type=io.realm.kotlin.types.RealmList<kotlin.Float?> origin=null
       PROPERTY name:nullableDoubleListField visibility:public modality:FINAL [var]
@@ -1868,13 +1868,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableDoubleListField> (): io.realm.kotlin.types.RealmList<kotlin.Double?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<kotlin.Double?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<kotlin.Double?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.kotlin.types.RealmList<kotlin.Double?> visibility:private' type=io.realm.kotlin.types.RealmList<kotlin.Double?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableDoubleListField>' type=sample.input.Sample origin=null
@@ -1883,7 +1883,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: kotlin.Double?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableDoubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableDoubleListField"
         FUN name:<set-nullableDoubleListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<kotlin.Double?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableDoubleListField visibility:public modality:FINAL [var]
@@ -1891,13 +1891,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<kotlin.Double?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableDoubleListField type:io.realm.kotlin.types.RealmList<kotlin.Double?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableDoubleListField>' type=sample.input.Sample origin=null
@@ -1907,7 +1907,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: kotlin.Double?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableDoubleListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<kotlin.Double?> declared in sample.input.Sample.<set-nullableDoubleListField>' type=io.realm.kotlin.types.RealmList<kotlin.Double?> origin=null
       PROPERTY name:nullableTimestampListField visibility:public modality:FINAL [var]
@@ -1921,13 +1921,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableTimestampListField> (): io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?> visibility:private' type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableTimestampListField>' type=sample.input.Sample origin=null
@@ -1936,7 +1936,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: io.realm.kotlin.types.RealmInstant?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableTimestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableTimestampListField"
         FUN name:<set-nullableTimestampListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableTimestampListField visibility:public modality:FINAL [var]
@@ -1944,13 +1944,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableTimestampListField type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableTimestampListField>' type=sample.input.Sample origin=null
@@ -1960,7 +1960,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: io.realm.kotlin.types.RealmInstant?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableTimestampListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?> declared in sample.input.Sample.<set-nullableTimestampListField>' type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.RealmInstant?> origin=null
       PROPERTY name:nullableObjectIdListField visibility:public modality:FINAL [var]
@@ -1974,13 +1974,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-nullableObjectIdListField> (): io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?> declared in sample.input.Sample'
               BLOCK type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?> origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableObjectIdListField>' type=sample.input.Sample origin=null
                 WHEN type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?> origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableObjectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableObjectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableObjectIdListField type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?> visibility:private' type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?> origin=null
                       receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-nullableObjectIdListField>' type=sample.input.Sample origin=null
@@ -1989,7 +1989,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'internal final fun getList <R> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.ManagedRealmList<kotlin.Any?> origin=GET_PROPERTY
                       <R>: io.realm.kotlin.types.ObjectId?
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<get-nullableObjectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-nullableObjectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                       propertyName: CONST String type=kotlin.String value="nullableObjectIdListField"
         FUN name:<set-nullableObjectIdListField> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?>) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:nullableObjectIdListField visibility:public modality:FINAL [var]
@@ -1997,13 +1997,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?>
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableObjectIdListField>' type=sample.input.Sample origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableObjectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableObjectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nullableObjectIdListField type:io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?> visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-nullableObjectIdListField>' type=sample.input.Sample origin=null
@@ -2013,7 +2013,7 @@ MODULE_FRAGMENT name:<main>
                   then: CALL 'internal final fun setList <T> (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, col: kotlin.String, list: io.realm.kotlin.types.RealmList<kotlin.Any?>, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     <T>: io.realm.kotlin.types.ObjectId?
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Sample.<set-nullableObjectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-nullableObjectIdListField>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     col: CONST String type=kotlin.String value="nullableObjectIdListField"
                     list: GET_VAR '<set-?>: io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?> declared in sample.input.Sample.<set-nullableObjectIdListField>' type=io.realm.kotlin.types.RealmList<io.realm.kotlin.types.ObjectId?> origin=null
       FUN name:dumpSchema visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:kotlin.String
@@ -2726,28 +2726,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample) returnType:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>?
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>? declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                 receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-io_realm_kotlin_objectReference>' type=sample.input.Sample origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.Sample, <set-?>:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <set-io_realm_kotlin_objectReference> (<set-?>: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>?): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-io_realm_kotlin_objectReference>' type=sample.input.Sample origin=null
-              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Sample.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
     CLASS CLASS name:Child modality:OPEN visibility:public superTypes:[io.realm.kotlin.types.RealmObject; io.realm.kotlin.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
       CONSTRUCTOR visibility:public <> () returnType:sample.input.Child [primary]
@@ -2764,13 +2764,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String? declared in sample.input.Child'
               BLOCK type=kotlin.String? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Child' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? declared in sample.input.Child' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
                 WHEN type=kotlin.String? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Child.<get-name>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? [val] declared in sample.input.Child.<get-name>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.String? origin=null
                       receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-name>' type=sample.input.Child origin=null
@@ -2779,7 +2779,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Child.<get-name>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? [val] declared in sample.input.Child.<get-name>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? origin=null
                         propertyName: CONST String type=kotlin.String value="name"
         FUN name:<set-name> visibility:public modality:FINAL <> ($this:sample.input.Child, <set-?>:kotlin.String?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [var]
@@ -2787,13 +2787,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Child' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? declared in sample.input.Child' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? [val] declared in sample.input.Child.<set-name>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-name>' type=sample.input.Child origin=null
@@ -2802,7 +2802,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.Child.<set-name>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? [val] declared in sample.input.Child.<set-name>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? origin=null
                     propertyName: CONST String type=kotlin.String value="name"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.Child.<set-name>' type=kotlin.String? origin=null
@@ -2933,28 +2933,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child) returnType:io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>?
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>? declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Child'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? declared in sample.input.Child'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? origin=null
                 receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<get-io_realm_kotlin_objectReference>' type=sample.input.Child origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.Child, <set-?>:io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <set-io_realm_kotlin_objectReference> (<set-?>: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>?): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: sample.input.Child declared in sample.input.Child.<set-io_realm_kotlin_objectReference>' type=sample.input.Child origin=null
-              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.Child.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? declared in sample.input.Child.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Child>? origin=null
     CLASS CLASS name:EmbeddedParent modality:OPEN visibility:public superTypes:[io.realm.kotlin.types.RealmObject; io.realm.kotlin.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.EmbeddedParent
       CONSTRUCTOR visibility:public <> () returnType:sample.input.EmbeddedParent [primary]
@@ -2971,13 +2971,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-child> (): sample.input.EmbeddedChild? declared in sample.input.EmbeddedParent'
               BLOCK type=sample.input.EmbeddedChild? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.EmbeddedParent' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? declared in sample.input.EmbeddedParent' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.EmbeddedParent declared in sample.input.EmbeddedParent.<get-child>' type=sample.input.EmbeddedParent origin=null
                 WHEN type=sample.input.EmbeddedChild? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.EmbeddedParent.<get-child>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? [val] declared in sample.input.EmbeddedParent.<get-child>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.EmbeddedChild? visibility:private' type=sample.input.EmbeddedChild? origin=null
                       receiver: GET_VAR '<this>: sample.input.EmbeddedParent declared in sample.input.EmbeddedParent.<get-child>' type=sample.input.EmbeddedParent origin=null
@@ -2987,7 +2987,7 @@ MODULE_FRAGMENT name:<main>
                       <R>: sample.input.EmbeddedChild?
                       <U>: <none>
                       $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.EmbeddedParent.<get-child>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? [val] declared in sample.input.EmbeddedParent.<get-child>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? origin=null
                       propertyName: CONST String type=kotlin.String value="child"
         FUN name:<set-child> visibility:public modality:FINAL <> ($this:sample.input.EmbeddedParent, <set-?>:sample.input.EmbeddedChild?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:child visibility:public modality:FINAL [var]
@@ -2995,13 +2995,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:sample.input.EmbeddedChild?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.EmbeddedParent' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? declared in sample.input.EmbeddedParent' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.EmbeddedParent declared in sample.input.EmbeddedParent.<set-child>' type=sample.input.EmbeddedParent origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.EmbeddedParent.<set-child>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? [val] declared in sample.input.EmbeddedParent.<set-child>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:child type:sample.input.EmbeddedChild? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.EmbeddedParent declared in sample.input.EmbeddedParent.<set-child>' type=sample.input.EmbeddedParent origin=null
@@ -3010,7 +3010,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setEmbeddedRealmObject (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.types.BaseRealmObject?, updatePolicy: io.realm.kotlin.UpdatePolicy, cache: kotlin.collections.MutableMap<io.realm.kotlin.types.BaseRealmObject, io.realm.kotlin.types.BaseRealmObject>{ io.realm.kotlin.internal.RealmUtilsKt.ObjectCache }): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.EmbeddedParent.<set-child>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? [val] declared in sample.input.EmbeddedParent.<set-child>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? origin=null
                     propertyName: CONST String type=kotlin.String value="child"
                     value: GET_VAR '<set-?>: sample.input.EmbeddedChild? declared in sample.input.EmbeddedParent.<set-child>' type=sample.input.EmbeddedChild? origin=null
       CLASS OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any; io.realm.kotlin.internal.RealmObjectCompanion]
@@ -3140,28 +3140,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.EmbeddedParent) returnType:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.EmbeddedParent) returnType:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>?
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>? declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.EmbeddedParent
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.EmbeddedParent'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? declared in sample.input.EmbeddedParent'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? origin=null
                 receiver: GET_VAR '<this>: sample.input.EmbeddedParent declared in sample.input.EmbeddedParent.<get-io_realm_kotlin_objectReference>' type=sample.input.EmbeddedParent origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.EmbeddedParent, <set-?>:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.EmbeddedParent, <set-?>:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <set-io_realm_kotlin_objectReference> (<set-?>: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>?): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.EmbeddedParent
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: sample.input.EmbeddedParent declared in sample.input.EmbeddedParent.<set-io_realm_kotlin_objectReference>' type=sample.input.EmbeddedParent origin=null
-              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.EmbeddedParent.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? declared in sample.input.EmbeddedParent.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedParent>? origin=null
     CLASS CLASS name:EmbeddedChild modality:OPEN visibility:public superTypes:[io.realm.kotlin.types.EmbeddedRealmObject; io.realm.kotlin.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.EmbeddedChild
       CONSTRUCTOR visibility:public <> () returnType:sample.input.EmbeddedChild [primary]
@@ -3178,13 +3178,13 @@ MODULE_FRAGMENT name:<main>
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String? declared in sample.input.EmbeddedChild'
               BLOCK type=kotlin.String? origin=null
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.EmbeddedChild' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? declared in sample.input.EmbeddedChild' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? origin=GET_PROPERTY
                     $this: GET_VAR '<this>: sample.input.EmbeddedChild declared in sample.input.EmbeddedChild.<get-name>' type=sample.input.EmbeddedChild origin=null
                 WHEN type=kotlin.String? origin=null
                   BRANCH
                     if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.EmbeddedChild.<get-name>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? [val] declared in sample.input.EmbeddedChild.<get-name>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? origin=null
                       arg1: CONST Null type=kotlin.Nothing? value=null
                     then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.String? origin=null
                       receiver: GET_VAR '<this>: sample.input.EmbeddedChild declared in sample.input.EmbeddedChild.<get-name>' type=sample.input.EmbeddedChild origin=null
@@ -3193,7 +3193,7 @@ MODULE_FRAGMENT name:<main>
                     then: CALL 'public final fun realmValueToAny (realmValue: io.realm.kotlin.internal.interop.RealmValue): kotlin.Any? [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any? origin=null
                       realmValue: CALL 'internal final fun getValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.internal.interop.RealmValue origin=GET_PROPERTY
                         $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.EmbeddedChild.<get-name>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? [val] declared in sample.input.EmbeddedChild.<get-name>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? origin=null
                         propertyName: CONST String type=kotlin.String value="name"
         FUN name:<set-name> visibility:public modality:FINAL <> ($this:sample.input.EmbeddedChild, <set-?>:kotlin.String?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [var]
@@ -3201,13 +3201,13 @@ MODULE_FRAGMENT name:<main>
           VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String?
           BLOCK_BODY
             BLOCK type=kotlin.Unit origin=null
-              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val]
-                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.EmbeddedChild' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=GET_PROPERTY
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? declared in sample.input.EmbeddedChild' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? origin=GET_PROPERTY
                   $this: GET_VAR '<this>: sample.input.EmbeddedChild declared in sample.input.EmbeddedChild.<set-name>' type=sample.input.EmbeddedChild origin=null
               WHEN type=kotlin.Unit origin=null
                 BRANCH
                   if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.EmbeddedChild.<set-name>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? [val] declared in sample.input.EmbeddedChild.<set-name>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? origin=null
                     arg1: CONST Null type=kotlin.Nothing? value=null
                   then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String? visibility:private' type=kotlin.Unit origin=null
                     receiver: GET_VAR '<this>: sample.input.EmbeddedChild declared in sample.input.EmbeddedChild.<set-name>' type=sample.input.EmbeddedChild origin=null
@@ -3216,7 +3216,7 @@ MODULE_FRAGMENT name:<main>
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: io.realm.kotlin.internal.interop.RealmValue): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
                     $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
-                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? [val] declared in sample.input.EmbeddedChild.<set-name>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? [val] declared in sample.input.EmbeddedChild.<set-name>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? origin=null
                     propertyName: CONST String type=kotlin.String value="name"
                     value: CALL 'public final fun anyToRealmValue (value: kotlin.Any?): io.realm.kotlin.internal.interop.RealmValue [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=io.realm.kotlin.internal.interop.RealmValue origin=null
                       value: GET_VAR '<set-?>: kotlin.String? declared in sample.input.EmbeddedChild.<set-name>' type=kotlin.String? origin=null
@@ -3347,25 +3347,25 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.EmbeddedRealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.EmbeddedChild) returnType:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.EmbeddedChild) returnType:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>?
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>? declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.EmbeddedChild
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.EmbeddedChild'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? declared in sample.input.EmbeddedChild'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? origin=null
                 receiver: GET_VAR '<this>: sample.input.EmbeddedChild declared in sample.input.EmbeddedChild.<get-io_realm_kotlin_objectReference>' type=sample.input.EmbeddedChild origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.EmbeddedChild, <set-?>:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:sample.input.EmbeddedChild, <set-?>:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <set-io_realm_kotlin_objectReference> (<set-?>: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>?): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.EmbeddedChild
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: sample.input.EmbeddedChild declared in sample.input.EmbeddedChild.<set-io_realm_kotlin_objectReference>' type=sample.input.EmbeddedChild origin=null
-              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in sample.input.EmbeddedChild.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? declared in sample.input.EmbeddedChild.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.EmbeddedChild>? origin=null

--- a/packages/plugin-compiler/src/test/resources/schema/expected/00_ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/schema/expected/00_ValidateIrBeforeLowering.ir
@@ -118,28 +118,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.A>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.A) returnType:io.realm.kotlin.internal.RealmObjectReference<schema.input.A>?
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>? declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in schema.input.A'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<schema.input.A>? declared in schema.input.A'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.A>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<schema.input.A>? origin=null
                 receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<get-io_realm_kotlin_objectReference>' type=schema.input.A origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.A, <set-?>:io.realm.kotlin.internal.RealmObjectReference<schema.input.A>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <set-io_realm_kotlin_objectReference> (<set-?>: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>?): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.A
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<schema.input.A>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.A>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: schema.input.A declared in schema.input.A.<set-io_realm_kotlin_objectReference>' type=schema.input.A origin=null
-              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in schema.input.A.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<schema.input.A>? declared in schema.input.A.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<schema.input.A>? origin=null
     CLASS CLASS name:B modality:OPEN visibility:public superTypes:[io.realm.kotlin.types.RealmObject; io.realm.kotlin.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
       CONSTRUCTOR visibility:public <> () returnType:schema.input.B [primary]
@@ -257,28 +257,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.B>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.B) returnType:io.realm.kotlin.internal.RealmObjectReference<schema.input.B>?
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>? declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in schema.input.B'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<schema.input.B>? declared in schema.input.B'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.B>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<schema.input.B>? origin=null
                 receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<get-io_realm_kotlin_objectReference>' type=schema.input.B origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.B, <set-?>:io.realm.kotlin.internal.RealmObjectReference<schema.input.B>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <set-io_realm_kotlin_objectReference> (<set-?>: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>?): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.B
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<schema.input.B>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.B>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: schema.input.B declared in schema.input.B.<set-io_realm_kotlin_objectReference>' type=schema.input.B origin=null
-              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in schema.input.B.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<schema.input.B>? declared in schema.input.B.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<schema.input.B>? origin=null
     CLASS CLASS name:C modality:OPEN visibility:public superTypes:[io.realm.kotlin.types.RealmObject; io.realm.kotlin.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
       CONSTRUCTOR visibility:public <> () returnType:schema.input.C [primary]
@@ -396,28 +396,28 @@ MODULE_FRAGMENT name:<main>
           public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.RealmObject
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
       PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
-        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private
+        FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.C>? visibility:private
           EXPRESSION_BODY
             CONST Null type=kotlin.Nothing? value=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.C) returnType:io.realm.kotlin.internal.RealmObjectReference<schema.input.C>?
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>? declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in schema.input.C'
-              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+            RETURN type=kotlin.Nothing from='public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<schema.input.C>? declared in schema.input.C'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.C>? visibility:private' type=io.realm.kotlin.internal.RealmObjectReference<schema.input.C>? origin=null
                 receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<get-io_realm_kotlin_objectReference>' type=schema.input.C origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?) returnType:kotlin.Unit
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<set-io_realm_kotlin_objectReference> visibility:public modality:OPEN <> ($this:schema.input.C, <set-?>:io.realm.kotlin.internal.RealmObjectReference<schema.input.C>?) returnType:kotlin.Unit
           correspondingProperty: PROPERTY name:io_realm_kotlin_objectReference visibility:public modality:OPEN [var]
           overridden:
             public abstract fun <set-io_realm_kotlin_objectReference> (<set-?>: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>?): kotlin.Unit declared in io.realm.kotlin.internal.RealmObjectInternal
           $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:schema.input.C
-          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>?
+          VALUE_PARAMETER name:<set-?> index:0 type:io.realm.kotlin.internal.RealmObjectReference<schema.input.C>?
           BLOCK_BODY
-            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? visibility:private' type=kotlin.Unit origin=null
+            SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<schema.input.C>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: schema.input.C declared in schema.input.C.<set-io_realm_kotlin_objectReference>' type=schema.input.C origin=null
-              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? declared in schema.input.C.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<T of io.realm.kotlin.internal.RealmObjectReference>? origin=null
+              value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<schema.input.C>? declared in schema.input.C.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<schema.input.C>? origin=null
     PROPERTY name:conf1 visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:conf1 type:io.realm.kotlin.RealmConfiguration visibility:private [final,static]
         EXPRESSION_BODY


### PR DESCRIPTION
Closes #901 

We did not set the correct generic argument for 

```
  @Nullable
  private RealmObjectReference<T> io_realm_kotlin_objectReference;
```

Inside model classes. This accidentally worked because the generic parameter is type-erased at runtime, but if other libraries like Android Hilt also attempted to introspect or work with the source code it would report errors like `bad class file: <xxx> undeclared type variable: T`

This PR changes the compiler plugin so we now use the model class as the generic argument:

```
  @Nullable
  private RealmObjectReference<Sample> io_realm_kotlin_objectReference;
```
  
The fix has been verified to fix the the repro case here: https://github.com/realm/realm-kotlin/issues/901#issuecomment-1160393534