### PR TITLE
SyncError - fix assumption that recovery path should always be present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Fix JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
+* Sync error events not requiring a Client Reset incorrectly assumed they had to include a path to a recovery Realm file.
 
 ### Compatibility
 * This release is compatible with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 * Fix JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
-* Sync error events not requiring a Client Reset incorrectly assumed they had to include a path to a recovery Realm file.
+* [Sync] Sync error events not requiring a Client Reset incorrectly assumed they had to include a path to a recovery Realm file. (Issue [#895](https://github.com/realm/realm-kotlin/issues/895))
 
 ### Compatibility
 * This release is compatible with:

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -563,13 +563,18 @@ jobject convert_to_jvm_sync_error(JNIEnv* jenv, const realm_sync_error_t& error)
         realm_sync_error_user_info_t user_info = error.user_info_map[i];
         user_info_map->insert(std::make_pair(user_info.key, user_info.value));
     }
+
     if (error.user_info_length > 0) {
         auto original_it = user_info_map->find(error.c_original_file_path_key);
-        auto recovery_it = user_info_map->find(error.c_recovery_file_path_key);
         auto original_file_path = original_it->second;
-        auto recovery_file_path = recovery_it->second;
         joriginal_file_path = to_jstring(jenv, original_file_path);
-        jrecovery_file_path = to_jstring(jenv, recovery_file_path);
+
+        // Sync errors may not have the path to the recovery file unless a Client Reset is requested
+        if (error.is_client_reset_requested) {
+            auto recovery_it = user_info_map->find(error.c_recovery_file_path_key);
+            auto recovery_file_path = recovery_it->second;
+            jrecovery_file_path = to_jstring(jenv, recovery_file_path);
+        }
     }
 
     return jenv->NewObject(JavaClassGlobalDef::sync_error(),

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -565,13 +565,17 @@ jobject convert_to_jvm_sync_error(JNIEnv* jenv, const realm_sync_error_t& error)
     }
 
     if (error.user_info_length > 0) {
+        auto end_it = user_info_map->end();
+
         auto original_it = user_info_map->find(error.c_original_file_path_key);
-        auto original_file_path = original_it->second;
-        joriginal_file_path = to_jstring(jenv, original_file_path);
+        if (end_it != original_it) {
+            auto original_file_path = original_it->second;
+            joriginal_file_path = to_jstring(jenv, original_file_path);
+        }
 
         // Sync errors may not have the path to the recovery file unless a Client Reset is requested
-        if (error.is_client_reset_requested) {
-            auto recovery_it = user_info_map->find(error.c_recovery_file_path_key);
+        auto recovery_it = user_info_map->find(error.c_recovery_file_path_key);
+        if (error.is_client_reset_requested && (end_it != recovery_it)) {
             auto recovery_file_path = recovery_it->second;
             jrecovery_file_path = to_jstring(jenv, recovery_file_path);
         }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/ClientResetRequiredException.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/ClientResetRequiredException.kt
@@ -33,7 +33,15 @@ public class ClientResetRequiredException constructor(
     error: SyncError
 ) : Throwable(message = createMessageFromSyncError(error.errorCode)) {
 
+    /**
+     * Path to the original (local) copy of the realm when the Client Reset event was triggered.
+     * This realm may contain unsynced changes.
+     */
     public val originalFilePath: String = error.originalFilePath!!
+
+    /**
+     * Path to the recovery (remote) copy of the realm downloaded from the backend.
+     */
     public val recoveryFilePath: String = error.recoveryFilePath!!
 
     /**


### PR DESCRIPTION
Fixed logic that wrongly assumed a recovery path should always exist when processing sync errors.
See https://github.com/realm/realm-kotlin/pull/898#issuecomment-1166207478

Closes #895 