### PR TITLE
SyncError - fix assumption that recovery path should always be present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
 * Fixed crash present on release-mode apps using Sync due to missing Proguard exception for `ResponseCallback`.
 * The compiler plugin did not set the generic parameter correctly for an internal field inside model classes. This could result in other libraries that operated on the source code throwing an error of the type: `undeclared type variable: T`. (Issue [#901](https://github.com/realm/realm-kotlin/issues/901))
+* Sync error events not requiring a Client Reset incorrectly assumed they had to include a path to a recovery Realm file.
 
 ### Compatibility
 * This release is compatible with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed JVM memory leak when passing string to C-API. (Issue [#890](https://github.com/realm/realm-kotlin/issues/890))
 * Fixed crash present on release-mode apps using Sync due to missing Proguard exception for `ResponseCallback`.
 * The compiler plugin did not set the generic parameter correctly for an internal field inside model classes. This could result in other libraries that operated on the source code throwing an error of the type: `undeclared type variable: T`. (Issue [#901](https://github.com/realm/realm-kotlin/issues/901))
-* Sync error events not requiring a Client Reset incorrectly assumed they had to include a path to a recovery Realm file.
+* [Sync] Sync error events not requiring a Client Reset incorrectly assumed they had to include a path to a recovery Realm file. (Issue [#895](https://github.com/realm/realm-kotlin/issues/895))
 
 ### Compatibility
 * This release is compatible with:

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -564,6 +564,10 @@ jobject convert_to_jvm_sync_error(JNIEnv* jenv, const realm_sync_error_t& error)
         user_info_map->insert(std::make_pair(user_info.key, user_info.value));
     }
 
+    // We can't only rely on 'error.is_client_reset_requested' (even though we should) to extract
+    // user info from the error since 'PermissionDenied' are fatal (non-client-reset) errors that
+    // mark the file for deletion. Having 'original path' in the user_info_map is a side effect of
+    // using the same code for client reset.
     if (error.user_info_length > 0) {
         auto end_it = user_info_map->end();
 

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -563,13 +563,18 @@ jobject convert_to_jvm_sync_error(JNIEnv* jenv, const realm_sync_error_t& error)
         realm_sync_error_user_info_t user_info = error.user_info_map[i];
         user_info_map->insert(std::make_pair(user_info.key, user_info.value));
     }
+
     if (error.user_info_length > 0) {
         auto original_it = user_info_map->find(error.c_original_file_path_key);
-        auto recovery_it = user_info_map->find(error.c_recovery_file_path_key);
         auto original_file_path = original_it->second;
-        auto recovery_file_path = recovery_it->second;
         joriginal_file_path = to_jstring(jenv, original_file_path);
-        jrecovery_file_path = to_jstring(jenv, recovery_file_path);
+
+        // Sync errors may not have the path to the recovery file unless a Client Reset is requested
+        if (error.is_client_reset_requested) {
+            auto recovery_it = user_info_map->find(error.c_recovery_file_path_key);
+            auto recovery_file_path = recovery_it->second;
+            jrecovery_file_path = to_jstring(jenv, recovery_file_path);
+        }
     }
 
     return jenv->NewObject(JavaClassGlobalDef::sync_error(),

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -565,13 +565,17 @@ jobject convert_to_jvm_sync_error(JNIEnv* jenv, const realm_sync_error_t& error)
     }
 
     if (error.user_info_length > 0) {
+        auto end_it = user_info_map->end();
+
         auto original_it = user_info_map->find(error.c_original_file_path_key);
-        auto original_file_path = original_it->second;
-        joriginal_file_path = to_jstring(jenv, original_file_path);
+        if (end_it != original_it) {
+            auto original_file_path = original_it->second;
+            joriginal_file_path = to_jstring(jenv, original_file_path);
+        }
 
         // Sync errors may not have the path to the recovery file unless a Client Reset is requested
-        if (error.is_client_reset_requested) {
-            auto recovery_it = user_info_map->find(error.c_recovery_file_path_key);
+        auto recovery_it = user_info_map->find(error.c_recovery_file_path_key);
+        if (error.is_client_reset_requested && (end_it != recovery_it)) {
             auto recovery_file_path = recovery_it->second;
             jrecovery_file_path = to_jstring(jenv, recovery_file_path);
         }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/ClientResetRequiredException.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/ClientResetRequiredException.kt
@@ -33,7 +33,15 @@ public class ClientResetRequiredException constructor(
     error: SyncError
 ) : Throwable(message = createMessageFromSyncError(error.errorCode)) {
 
+    /**
+     * Path to the original (local) copy of the realm when the Client Reset event was triggered.
+     * This realm may contain unsynced changes.
+     */
     public val originalFilePath: String = error.originalFilePath!!
+
+    /**
+     * Path to the recovery (remote) copy of the realm downloaded from the backend.
+     */
     public val recoveryFilePath: String = error.recoveryFilePath!!
 
     /**

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/RealmSyncUtils.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/RealmSyncUtils.kt
@@ -91,6 +91,10 @@ internal fun convertSyncErrorCode(error: SyncErrorCode): SyncException {
                 ProtocolSessionErrorCode.RLM_SYNC_ERR_SESSION_BAD_QUERY -> { // Flexible Sync Query was rejected by the server
                     BadFlexibleSyncQueryException(message)
                 }
+                ProtocolSessionErrorCode.RLM_SYNC_ERR_SESSION_PERMISSION_DENIED ->
+                    // Permission denied errors should be unrecoverable according to Core, i.e. the
+                    // client will disconnect sync and transition to the "inactive" state
+                    UnrecoverableSyncException(message)
                 else -> SyncException(message)
             }
         }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
@@ -30,6 +30,7 @@ import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.exceptions.DownloadingRealmTimeOutException
 import io.realm.kotlin.mongodb.exceptions.SyncException
+import io.realm.kotlin.mongodb.exceptions.UnrecoverableSyncException
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncSession
 import io.realm.kotlin.mongodb.sync.SyncSession.ErrorHandler
@@ -256,6 +257,7 @@ class SyncedRealmTests {
                     val deferred = async { Realm.open(config) }
 
                     val error = channel.receive()
+                    assertTrue(error is UnrecoverableSyncException)
                     val message = error.message
                     assertNotNull(message)
                     assertTrue(

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AdminApi.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AdminApi.kt
@@ -88,8 +88,8 @@ interface AdminApi {
     suspend fun triggerClientReset(userId: String)
 
     /**
-     * Changes the permissions for sync. Receives a lambda block which with your test logic which,
-     * in case it fails, will failsafe to reverting the original server permissions.
+     * Changes the permissions for sync. Receives a lambda block which with your test logic.
+     * It will safely revert to the original permissions even when an exception was thrown.
      */
     suspend fun changeSyncPermissions(permissions: SyncPermissions, block: () -> Unit)
 


### PR DESCRIPTION
Continuation from https://github.com/realm/realm-kotlin/pull/909 pointing to `releases`.

Fixed logic that wrongly assumed a recovery path should always exist when processing sync errors.
See https://github.com/realm/realm-kotlin/pull/898#issuecomment-1166207478

Added test that triggers a "permission denied" error by modifying the server's sync configuration using the Admin API.

Modified the mapping of sync errors to include permission denied and mark it as an `UnrecoverableSyncException` for users to gracefully handle app restart.

Closes https://github.com/realm/realm-kotlin/issues/895