### PR TITLE
Updated credentials key

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,7 @@ pipeline {
                     steps {
                         testWithServer([
                             // This will overwrite previous test results, but should be ok as we would not get here
-                            // if previous stages failed. 
+                            // if previous stages failed.
                             {
                                 testAndCollect("test", "macosTest -Pkotlin.native.binary.memoryModel=experimental")
                             },
@@ -429,7 +429,7 @@ def runPublishReleaseOnMavenCentral() {
             [$class: 'StringBinding', credentialsId: 'gradle-plugin-portal-secret', variable: 'GRADLE_PORTAL_SECRET'],
             [$class: 'UsernamePasswordMultiBinding', credentialsId: 'maven-central-credentials', passwordVariable: 'MAVEN_CENTRAL_PASSWORD', usernameVariable: 'MAVEN_CENTRAL_USER'],
             [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'DOCS_S3_ACCESS_KEY', credentialsId: 'mongodb-realm-docs-s3', secretKeyVariable: 'DOCS_S3_SECRET_KEY'],
-            [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'REALM_S3_ACCESS_KEY', credentialsId: 'realm-s3', secretKeyVariable: 'REALM_S3_SECRET_KEY']
+            [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'REALM_S3_ACCESS_KEY', credentialsId: 'tightdb-s3-ci', secretKeyVariable: 'REALM_S3_SECRET_KEY']
     ]) {
       sh """
         set +x


### PR DESCRIPTION
Updated `REALM_S3_ACCESS_KEY` since it was already present in master but not in releases. This caused the upload debug symbols and documentation tasks to fail while releasing 1.0.1.