### PR TITLE
Fix local baas server not shut properly

### DIFF
--- a/tools/sync_test_server/stop_local_server.sh
+++ b/tools/sync_test_server/stop_local_server.sh
@@ -14,12 +14,14 @@ fi
 if [[ -n "$BAAS_PID" ]]; then
     echo "Stopping baas $BAAS_PID"
     kill -9 "$BAAS_PID"
+    rm "$WORK_PATH/baas_server.pid"
 fi
 
 
 if [[ -n "$MONGOD_PID" ]]; then
     echo "Killing mongod $MONGOD_PID"
     kill -9 "$MONGOD_PID"
+    rm "$WORK_PATH/mongod.pid"
 fi
 
 docker stop mongodb-realm-command-server -t0


### PR DESCRIPTION
The baas local development server did not boot up correctly after being shut down manually. This PR attempts to fix the issue by removing the PID files during the shutdown process.