### PR TITLE
Update Core submodule remote

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external/core"]
 	path = packages/external/core
-	url = https://github.com/realm/realm-core.git
+	url = git@github.com:realm/realm-core.git
 	branch = su/c-api


### PR DESCRIPTION
Changed Core submodule's remote to use ssh instead to allow pushing branches to origin directly from submodule.