### PR TITLE
Client Reset - automatic recover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 1.1.0 (YYYY-MM-DD)
+
+### Breaking Changes
+* [Sync] Changed default recovery mode from `DiscardUnsyncedChangesStrategy` to `RecoverOrDiscardUnsyncedChangesStrategy`
+
+### Enhancements
+* [Sync] Introduced `RecoverUnsyncedChangesStrategy`, an alternative automatic client reset strategy that tries to automatically recover any unsynced data from the client.
+* [Sync] Introduced `RecoverOrDiscardUnsyncedChangesStrategy`, an alternative automatic client reset strategy that tries to automatically recover any unsynced data from the client, and discards any unsynced data if recovery is not possible. This is now the default policy.
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10 and above.
+  * Coroutines 1.6.0-native-mt. Also compatible with Coroutines 1.6.0 but requires enabling of the new memory model and disabling of freezing, see https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility for details on that.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* Updated to Realm Core 12.3.0, commit c4e3f87fe6a93171590462ad985b4974bb5a9c26.
+
+
 ## 1.0.1 (2022-07-07)
 
 ### Breaking Changes

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,11 +1,11 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2022-05-21
+MONGODB_REALM_SERVER=2022-06-10
 
 # `BAAS` and `BAAS-UI` projects commit hashes matching MONGODB_REALM_SERVER image version
 # note that the MONGODB_REALM_SERVER image is a nightly build, find the matching commits
-# for that date within the following repositories: 
-# https://github.com/10gen/baas/ 
+# for that date within the following repositories:
+# https://github.com/10gen/baas/
 # https://github.com/10gen/baas-ui/
-REALM_BAAS_GIT_HASH=87e4edf99a6510aa8468450e87af69dcfc74abe7
-REALM_BAAS_UI_GIT_HASH=57c5b89882d5492bc0f4971c376e25ba50b65b5f
+REALM_BAAS_GIT_HASH=ba172f8dd37c3102499ab7d728e7c0dcb9e52ae8
+REALM_BAAS_UI_GIT_HASH=1fc10a6e04f87247790662d825500c9e21dbfbc7

--- a/packages/cinterop/src/androidTest/java/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/androidTest/java/io/realm/kotlin/test/CinteropTest.kt
@@ -61,7 +61,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("12.1.0", realmc.realm_get_library_version())
+        assertEquals("12.3.0", realmc.realm_get_library_version())
     }
 
     // Test various schema migration with automatic flag:

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/SyncSessionResyncMode.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/SyncSessionResyncMode.kt
@@ -22,7 +22,9 @@ package io.realm.kotlin.internal.interop.sync
  */
 expect enum class SyncSessionResyncMode {
     RLM_SYNC_SESSION_RESYNC_MODE_MANUAL,
-    RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL;
+    RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL,
+    RLM_SYNC_SESSION_RESYNC_MODE_RECOVER,
+    RLM_SYNC_SESSION_RESYNC_MODE_RECOVER_OR_DISCARD;
 
     companion object {
         fun fromInt(nativeValue: Int): SyncSessionResyncMode

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/sync/SyncSessionResyncMode.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/sync/SyncSessionResyncMode.kt
@@ -21,7 +21,9 @@ import realm_wrapper.realm_sync_session_resync_mode
 
 actual enum class SyncSessionResyncMode(override val nativeValue: UInt) : NativeEnumerated {
     RLM_SYNC_SESSION_RESYNC_MODE_MANUAL(realm_sync_session_resync_mode.RLM_SYNC_SESSION_RESYNC_MODE_MANUAL.value),
-    RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL(realm_sync_session_resync_mode.RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL.value);
+    RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL(realm_sync_session_resync_mode.RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL.value),
+    RLM_SYNC_SESSION_RESYNC_MODE_RECOVER(realm_sync_session_resync_mode.RLM_SYNC_SESSION_RESYNC_MODE_RECOVER.value),
+    RLM_SYNC_SESSION_RESYNC_MODE_RECOVER_OR_DISCARD(realm_sync_session_resync_mode.RLM_SYNC_SESSION_RESYNC_MODE_RECOVER_OR_DISCARD.value);
 
     actual companion object {
         actual fun fromInt(nativeValue: Int): SyncSessionResyncMode {

--- a/packages/cinterop/src/darwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/darwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -93,7 +93,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("12.1.0", realm_get_library_version()!!.toKString())
+        assertEquals("12.3.0", realm_get_library_version()!!.toKString())
     }
 
     @Test

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/sync/SyncSessionResyncMode.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/sync/SyncSessionResyncMode.kt
@@ -21,7 +21,9 @@ import io.realm.kotlin.internal.interop.realm_sync_session_resync_mode_e
 
 actual enum class SyncSessionResyncMode(override val nativeValue: Int) : NativeEnumerated {
     RLM_SYNC_SESSION_RESYNC_MODE_MANUAL(realm_sync_session_resync_mode_e.RLM_SYNC_SESSION_RESYNC_MODE_MANUAL),
-    RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL(realm_sync_session_resync_mode_e.RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL);
+    RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL(realm_sync_session_resync_mode_e.RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL),
+    RLM_SYNC_SESSION_RESYNC_MODE_RECOVER(realm_sync_session_resync_mode_e.RLM_SYNC_SESSION_RESYNC_MODE_RECOVER),
+    RLM_SYNC_SESSION_RESYNC_MODE_RECOVER_OR_DISCARD(realm_sync_session_resync_mode_e.RLM_SYNC_SESSION_RESYNC_MODE_RECOVER_OR_DISCARD);
 
     actual companion object {
         actual fun fromInt(nativeValue: Int): SyncSessionResyncMode {

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -112,26 +112,13 @@ std::string rlm_stdstr(realm_string_t val)
     };
 }
 
-// reuse void callback type as template for `realm_sync_download_completion_func_t`
+// reuse void callback type as template for `realm_sync_wait_for_completion_func_t`
 %apply (realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
-(realm_sync_download_completion_func_t, void* userdata, realm_free_userdata_func_t)
+(realm_sync_wait_for_completion_func_t, void* userdata, realm_free_userdata_func_t)
 };
-%typemap(in) (realm_sync_download_completion_func_t, void* userdata, realm_free_userdata_func_t) {
+%typemap(in) (realm_sync_wait_for_completion_func_t, void* userdata, realm_free_userdata_func_t) {
     auto jenv = get_env(true);
-    $1 = reinterpret_cast<realm_sync_download_completion_func_t>(transfer_completion_callback);
-    $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
-    $3 = [](void *userdata) {
-        get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
-    };
-}
-
-// reuse void callback type as template for `realm_sync_upload_completion_func_t`
-%apply (realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
-(realm_sync_upload_completion_func_t, void* userdata, realm_free_userdata_func_t)
-};
-%typemap(in) (realm_sync_upload_completion_func_t, void* userdata, realm_free_userdata_func_t) {
-    auto jenv = get_env(true);
-    $1 = reinterpret_cast<realm_sync_upload_completion_func_t>(transfer_completion_callback);
+    $1 = reinterpret_cast<realm_sync_wait_for_completion_func_t>(transfer_completion_callback);
     $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
     $3 = [](void *userdata) {
         get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -75,14 +75,15 @@ void
 transfer_completion_callback(void* userdata, realm_sync_error_code_t* error);
 
 void
-realm_subscriptionset_changed_callback(void* userdata, realm_flx_sync_subscription_set_state_e state);
+realm_subscriptionset_changed_callback(void* userdata,
+                                       realm_flx_sync_subscription_set_state_e state);
 
-void
+bool
 before_client_reset(void* userdata, realm_t* before_realm);
 
-void
-after_client_reset(void* userdata, realm_t* before_realm, realm_t* after_realm,
-                   bool did_recover);
+bool
+after_client_reset(void* userdata, realm_t* before_realm,
+                   realm_thread_safe_reference_t* after_realm, bool did_recover);
 
 void
 sync_before_client_reset_handler(realm_sync_config_t* config, jobject before_handler);

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicRealm.kt
@@ -17,6 +17,8 @@
 package io.realm.kotlin.dynamic
 
 import io.realm.kotlin.BaseRealm
+import io.realm.kotlin.Realm
+import io.realm.kotlin.migration.RealmMigration
 import io.realm.kotlin.query.RealmQuery
 
 /**

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -87,10 +87,8 @@ internal class SyncConfigurationImpl(
 
                 // Notify before/after callbacks too if error is client reset
                 if (error.isClientResetRequested) {
-                    println("-----------------> 0")
                     initializerHelper.onSyncError(session, frozenAppPointer, error)
                 } else {
-                    println("-----------------> 1")
                     userErrorHandler.onError(session, syncError)
                 }
             }.freeze()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -94,10 +94,9 @@ internal class SyncConfigurationImpl(
             }.freeze()
 
         syncInitializer = { nativeConfig: RealmConfigurationPointer ->
-            val nativeSyncConfig: RealmSyncConfigurationPointer = if (partitionValue == null) {
-                RealmInterop.realm_flx_sync_config_new(user.nativePointer)
-            } else {
-                RealmInterop.realm_sync_config_new(
+            val nativeSyncConfig: RealmSyncConfigurationPointer = when (partitionValue) {
+                null -> RealmInterop.realm_flx_sync_config_new(user.nativePointer)
+                else -> RealmInterop.realm_sync_config_new(
                     user.nativePointer,
                     partitionValue.asSyncPartition()
                 )

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -87,8 +87,10 @@ internal class SyncConfigurationImpl(
 
                 // Notify before/after callbacks too if error is client reset
                 if (error.isClientResetRequested) {
+                    println("-----------------> 0")
                     initializerHelper.onSyncError(session, frozenAppPointer, error)
                 } else {
+                    println("-----------------> 1")
                     userErrorHandler.onError(session, syncError)
                 }
             }.freeze()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncClientResetStrategy.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncClientResetStrategy.kt
@@ -121,3 +121,60 @@ public interface ManuallyRecoverUnsyncedChangesStrategy : SyncClientResetStrateg
      */
     public fun onClientReset(session: SyncSession, exception: ClientResetRequiredException)
 }
+
+/**
+ * TODO
+ */
+public interface RecoverUnsyncedChangesStrategy : SyncClientResetStrategy {
+    /**
+     * Callback that indicates a Client Reset is about to happen. It receives a frozen instance
+     * of the realm that will be reset.
+     *
+     * @param realm frozen [TypedRealm] in its state before the reset.
+     */
+    public fun onBeforeReset(realm: TypedRealm)
+
+    /**
+     * Callback invoked once the Client Reset happens. It receives two Realm instances: a frozen one
+     * displaying the state before the reset and a regular one with the current state that can be
+     * used to recover objects from the reset.
+     *
+     * @param before [TypedRealm] frozen realm before the reset.
+     * @param after [MutableRealm] a realm after the reset.
+     */
+    public fun onAfterReset(before: TypedRealm, after: MutableRealm)
+
+    /**
+     * Callback that indicates the seamless Client reset couldn't complete. It should be handled
+     * as in [ManuallyRecoverUnsyncedChangesStrategy.onClientReset].
+     *
+     * @param session [SyncSession] during which this error happened.
+     * @param exception [ClientResetRequiredException] the specific Client Reset error.
+     */
+    public fun onError(session: SyncSession, exception: ClientResetRequiredException)
+}
+
+/**
+ * TODO
+ */
+public interface RecoverOrDiscardUnsyncedChangesStrategy : SyncClientResetStrategy {
+    /**
+     * TODO
+     */
+    public fun onBeforeReset(realm: TypedRealm)
+
+    /**
+     * TODO
+     */
+    public fun onAfterRecovery(before: TypedRealm, after: MutableRealm)
+
+    /**
+     * TODO
+     */
+    public fun onAfterDiscard(before: TypedRealm, after: MutableRealm)
+
+    /**
+     * TODO
+     */
+    public fun onError(session: SyncSession, exception: ClientResetRequiredException)
+}

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncClientResetStrategy.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncClientResetStrategy.kt
@@ -61,8 +61,8 @@ public interface DiscardUnsyncedChangesStrategy : SyncClientResetStrategy {
      * displaying the state before the reset and a regular one with the current state that can be
      * used to recover objects from the reset.
      *
-     * @param before [TypedRealm] frozen realm before the reset.
-     * @param after [MutableRealm] a realm after the reset.
+     * @param before frozen [TypedRealm] realm before the reset.
+     * @param after [MutableRealm] realm after the reset.
      */
     public fun onAfterReset(before: TypedRealm, after: MutableRealm)
 
@@ -139,8 +139,8 @@ public interface RecoverUnsyncedChangesStrategy : SyncClientResetStrategy {
      * displaying the state before the reset and a regular one with the current state that can be
      * used to recover objects from the reset.
      *
-     * @param before [TypedRealm] frozen realm before the reset.
-     * @param after [MutableRealm] a realm after the reset.
+     * @param before frozen [TypedRealm] realm before the reset.
+     * @param after [MutableRealm] realm after the reset.
      */
     public fun onAfterReset(before: TypedRealm, after: MutableRealm)
 
@@ -159,22 +159,40 @@ public interface RecoverUnsyncedChangesStrategy : SyncClientResetStrategy {
  */
 public interface RecoverOrDiscardUnsyncedChangesStrategy : SyncClientResetStrategy {
     /**
-     * TODO
+     * Callback that indicates a Client Reset is about to happen. It receives a frozen instance
+     * of the realm that will be reset.
+     *
+     * @param realm
      */
     public fun onBeforeReset(realm: TypedRealm)
 
     /**
-     * TODO
+     * Callback invoked once the Client Reset has recovered the unsynced changes successfully.
+     * It provides two Realm instances, a frozen one displaying the state before the reset and a
+     * mutable Realm with the current state.
+     *
+     * @param before frozen [TypedRealm] realm before the reset.
+     * @param after [MutableRealm] realm after the reset.
      */
     public fun onAfterRecovery(before: TypedRealm, after: MutableRealm)
 
     /**
-     * TODO
+     * Callback invoked once the Client Reset has discarded the unsynced changes because it couldn't
+     * recover them. It provides two Realm instances, a frozen one displaying the state before the
+     * reset and a regular Realm displaying the current state that can be used to recover objects
+     * from the reset.
+     *
+     * @param before frozen [TypedRealm] realm before the reset.
+     * @param after [MutableRealm] realm after the reset.
      */
     public fun onAfterDiscard(before: TypedRealm, after: MutableRealm)
 
     /**
-     * TODO
+     * Callback that indicates the seamless Client reset couldn't complete. It should be handled
+     * as in [ManuallyRecoverUnsyncedChangesStrategy.onClientReset].
+     *
+     * @param session [SyncSession] during which this error happened.
+     * @param exception [ClientResetRequiredException] the specific Client Reset error.
      */
     public fun onError(session: SyncSession, exception: ClientResetRequiredException)
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
@@ -347,6 +347,12 @@ public interface SyncConfiguration : Configuration {
                 if (partitionValue == null && resetStrategy is DiscardUnsyncedChangesStrategy) {
                     throw IllegalArgumentException("DiscardUnsyncedChangesStrategy is not supported on Flexible Sync")
                 }
+                if (partitionValue == null && resetStrategy is RecoverUnsyncedChangesStrategy) {
+                    throw IllegalArgumentException("RecoverUnsyncedChangesStrategy is not supported on Flexible Sync")
+                }
+                if (partitionValue == null && resetStrategy is RecoverOrDiscardUnsyncedChangesStrategy) {
+                    throw IllegalArgumentException("RecoverOrDiscardUnsyncedChangesStrategy is not supported on Flexible Sync")
+                }
                 if (partitionValue != null && resetStrategy is ManuallyRecoverUnsyncedChangesStrategy) {
                     throw IllegalArgumentException("ManuallyRecoverUnsyncedChangesStrategy is not supported on Partition-based Sync")
                 }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/SyncClientResetIntegrationJVMTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/SyncClientResetIntegrationJVMTests.kt
@@ -1,178 +1,177 @@
-/*
- * Copyright 2022 Realm Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-@file:Suppress("invisible_member", "invisible_reference") // Needed to call session.simulateError()
-
-package io.realm.kotlin.test
-
-import io.realm.kotlin.MutableRealm
-import io.realm.kotlin.Realm
-import io.realm.kotlin.TypedRealm
-import io.realm.kotlin.entities.sync.flx.FlexParentObject
-import io.realm.kotlin.internal.platform.runBlocking
-import io.realm.kotlin.log.LogLevel
-import io.realm.kotlin.mongodb.User
-import io.realm.kotlin.mongodb.exceptions.ClientResetRequiredException
-import io.realm.kotlin.mongodb.sync.DiscardUnsyncedChangesStrategy
-import io.realm.kotlin.mongodb.sync.SyncConfiguration
-import io.realm.kotlin.mongodb.sync.SyncSession
-import io.realm.kotlin.mongodb.syncSession
-import io.realm.kotlin.test.mongodb.TestApp
-import io.realm.kotlin.test.mongodb.createUserAndLogIn
-import io.realm.kotlin.test.util.TestHelper
-import io.realm.kotlin.test.util.use
-import kotlinx.coroutines.channels.Channel
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-
-// TODO move to shared SyncClientResetIntegrationTests once this is fixed
-// https://github.com/realm/realm-kotlin/issues/867
-class SyncClientResetIntegrationJVMTests {
-
-    private enum class ClientResetEvents {
-        ON_BEFORE_RESET,
-        ON_AFTER_RESET,
-        ON_ERROR
-    }
-
-    private lateinit var partitionValue: String
-    private lateinit var user: User
-    private lateinit var app: TestApp
-
-    @BeforeTest
-    fun setup() {
-        partitionValue = TestHelper.randomPartitionValue()
-        app = TestApp(
-            logLevel = LogLevel.INFO
-        )
-        val (email, password) = TestHelper.randomEmail() to "password1234"
-        user = runBlocking {
-            app.createUserAndLogIn(email, password)
-        }
-    }
-
-    @AfterTest
-    fun tearDown() {
-        if (this::app.isInitialized) {
-            app.close()
-        }
-    }
-
-    @Test
-    fun discardUnsyncedLocalChanges_userExceptionCaptured_onBeforeReset() {
-        // Validates that any user exception during the automatic client reset is properly captured.
-
-        val channel = Channel<ClientResetEvents>(2)
-
-        val config = SyncConfiguration.Builder(
-            user,
-            partitionValue,
-            schema = setOf(FlexParentObject::class) // Use a class that is present in the server schema
-        ).syncClientResetStrategy(
-            object : DiscardUnsyncedChangesStrategy {
-                override fun onBeforeReset(realm: TypedRealm) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
-                    throw IllegalStateException("User exception")
-                }
-
-                override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_AFTER_RESET)
-                }
-
-                override fun onError(session: SyncSession, exception: ClientResetRequiredException) {
-                    // Notify that this callback has been invoked
-                    assertEquals("[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed", exception.message)
-                    channel.trySend(ClientResetEvents.ON_ERROR)
-                }
-            }
-        ).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                with(realm.syncSession) {
-                    downloadAllServerChanges()
-
-                    // Pause the session to avoid receiving any network interrupted error
-                    pause()
-
-                    app.triggerClientReset(user.identity) // Removes the client file triggering a Client reset
-
-                    // Resuming the session would trigger the client reset
-                    resume()
-                }
-
-                // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
-            }
-        }
-    }
-
-    @Test
-    fun discardUnsyncedLocalChanges_userExceptionCaptured_onAfterReset() {
-        // Validates that any user exception during the automatic client reset is properly captured.
-        val channel = Channel<ClientResetEvents>(2)
-
-        val config = SyncConfiguration.Builder(
-            user,
-            partitionValue,
-            schema = setOf(FlexParentObject::class) // Use a class that is present in the server schema
-        ).syncClientResetStrategy(
-            object : DiscardUnsyncedChangesStrategy {
-                override fun onBeforeReset(realm: TypedRealm) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
-                }
-
-                override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_AFTER_RESET)
-                    throw IllegalStateException("User exception")
-                }
-
-                override fun onError(session: SyncSession, exception: ClientResetRequiredException) {
-                    // Notify that this callback has been invoked
-                    assertEquals("[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed", exception.message)
-                    channel.trySend(ClientResetEvents.ON_ERROR)
-                }
-            }
-        ).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                with(realm.syncSession) {
-                    downloadAllServerChanges()
-
-                    // Pause the session to avoid receiving any network interrupted error
-                    pause()
-
-                    app.triggerClientReset(user.identity) // Removes the client file triggering a Client reset
-
-                    // Resuming the session would trigger the client reset
-                    resume()
-                }
-
-                // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
-            }
-        }
-    }
-}
+// /*
+//  * Copyright 2022 Realm Inc.
+//  *
+//  * Licensed under the Apache License, Version 2.0 (the "License");
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  *
+//  * http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an "AS IS" BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  */
+// @file:Suppress("invisible_member", "invisible_reference") // Needed to call session.simulateError()
+//
+// package io.realm.kotlin.test
+//
+// import io.realm.kotlin.MutableRealm
+// import io.realm.kotlin.Realm
+// import io.realm.kotlin.TypedRealm
+// import io.realm.kotlin.entities.sync.flx.FlexParentObject
+// import io.realm.kotlin.internal.platform.runBlocking
+// import io.realm.kotlin.log.LogLevel
+// import io.realm.kotlin.mongodb.User
+// import io.realm.kotlin.mongodb.exceptions.ClientResetRequiredException
+// import io.realm.kotlin.mongodb.sync.DiscardUnsyncedChangesStrategy
+// import io.realm.kotlin.mongodb.sync.SyncConfiguration
+// import io.realm.kotlin.mongodb.sync.SyncSession
+// import io.realm.kotlin.mongodb.syncSession
+// import io.realm.kotlin.test.mongodb.TestApp
+// import io.realm.kotlin.test.mongodb.createUserAndLogIn
+// import io.realm.kotlin.test.util.TestHelper
+// import io.realm.kotlin.test.util.use
+// import kotlinx.coroutines.channels.Channel
+// import kotlin.test.AfterTest
+// import kotlin.test.BeforeTest
+// import kotlin.test.Test
+// import kotlin.test.assertEquals
+//
+// // TODO move to shared SyncClientResetIntegrationTests once this is fixed
+// // https://github.com/realm/realm-kotlin/issues/867
+// class SyncClientResetIntegrationJVMTests {
+//
+//     private enum class ClientResetEvents {
+//         ON_BEFORE_RESET,
+//         ON_AFTER_RESET,
+//         ON_ERROR
+//     }
+//
+//     private lateinit var partitionValue: String
+//     private lateinit var user: User
+//     private lateinit var app: TestApp
+//
+//     @BeforeTest
+//     fun setup() {
+//         partitionValue = TestHelper.randomPartitionValue()
+//         app = TestApp(
+//             logLevel = LogLevel.INFO
+//         )
+//         val (email, password) = TestHelper.randomEmail() to "password1234"
+//         user = runBlocking {
+//             app.createUserAndLogIn(email, password)
+//         }
+//     }
+//
+//     @AfterTest
+//     fun tearDown() {
+//         if (this::app.isInitialized) {
+//             app.close()
+//         }
+//     }
+//
+//     @Test
+//     fun discardUnsyncedLocalChanges_userExceptionCaptured_onBeforeReset() {
+//         // Validates that any user exception during the automatic client reset is properly captured.
+//         val channel = Channel<ClientResetEvents>(2)
+//
+//         val config = SyncConfiguration.Builder(
+//             user,
+//             partitionValue,
+//             schema = setOf(FlexParentObject::class) // Use a class that is present in the server schema
+//         ).syncClientResetStrategy(
+//             object : DiscardUnsyncedChangesStrategy {
+//                 override fun onBeforeReset(realm: TypedRealm) {
+//                     // Notify that this callback has been invoked
+//                     channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+//                     throw IllegalStateException("User exception")
+//                 }
+//
+//                 override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+//                     // Notify that this callback has been invoked
+//                     channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+//                 }
+//
+//                 override fun onError(session: SyncSession, exception: ClientResetRequiredException) {
+//                     // Notify that this callback has been invoked
+//                     assertEquals("[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed", exception.message)
+//                     channel.trySend(ClientResetEvents.ON_ERROR)
+//                 }
+//             }
+//         ).build()
+//
+//         Realm.open(config).use { realm ->
+//             runBlocking {
+//                 with(realm.syncSession) {
+//                     downloadAllServerChanges()
+//
+//                     // Pause the session to avoid receiving any network interrupted error
+//                     pause()
+//
+//                     app.triggerClientReset(user.identity,) // Removes the client file triggering a Client reset
+//
+//                     // Resuming the session would trigger the client reset
+//                     resume()
+//                 }
+//
+//                 // Validate that the client reset was triggered successfully
+//                 assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+//                 assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
+//             }
+//         }
+//     }
+//
+//     @Test
+//     fun discardUnsyncedLocalChanges_userExceptionCaptured_onAfterReset() {
+//         // Validates that any user exception during the automatic client reset is properly captured.
+//         val channel = Channel<ClientResetEvents>(2)
+//
+//         val config = SyncConfiguration.Builder(
+//             user,
+//             partitionValue,
+//             schema = setOf(FlexParentObject::class) // Use a class that is present in the server schema
+//         ).syncClientResetStrategy(
+//             object : DiscardUnsyncedChangesStrategy {
+//                 override fun onBeforeReset(realm: TypedRealm) {
+//                     // Notify that this callback has been invoked
+//                     channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+//                 }
+//
+//                 override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+//                     // Notify that this callback has been invoked
+//                     channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+//                     throw IllegalStateException("User exception")
+//                 }
+//
+//                 override fun onError(session: SyncSession, exception: ClientResetRequiredException) {
+//                     // Notify that this callback has been invoked
+//                     assertEquals("[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed", exception.message)
+//                     channel.trySend(ClientResetEvents.ON_ERROR)
+//                 }
+//             }
+//         ).build()
+//
+//         Realm.open(config).use { realm ->
+//             runBlocking {
+//                 with(realm.syncSession) {
+//                     downloadAllServerChanges()
+//
+//                     // Pause the session to avoid receiving any network interrupted error
+//                     pause()
+//
+//                     app.triggerClientReset(user.identity,) // Removes the client file triggering a Client reset
+//
+//                     // Resuming the session would trigger the client reset
+//                     resume()
+//                 }
+//
+//                 // Validate that the client reset was triggered successfully
+//                 assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+//                 assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+//                 assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
+//             }
+//         }
+//     }
+// }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncConfigurationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncConfigurationTests.kt
@@ -212,7 +212,6 @@ class FlexibleSyncConfigurationTests {
         assertTrue(config.path.endsWith("${app.configuration.appId}/${user.identity}/custom.realm"), "Path is: ${config.path}")
     }
 
-
     @Test
     fun clientResetStrategy_default() {
         val user: User = app.asTestApp.createUserAndLogin()

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncConfigurationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncConfigurationTests.kt
@@ -15,13 +15,21 @@
  */
 package io.realm.kotlin.test.mongodb.shared
 
+import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
+import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.mongodb.exceptions.ClientResetRequiredException
+import io.realm.kotlin.mongodb.sync.DiscardUnsyncedChangesStrategy
 import io.realm.kotlin.mongodb.sync.InitialSubscriptionsCallback
+import io.realm.kotlin.mongodb.sync.ManuallyRecoverUnsyncedChangesStrategy
+import io.realm.kotlin.mongodb.sync.RecoverOrDiscardUnsyncedChangesStrategy
+import io.realm.kotlin.mongodb.sync.RecoverUnsyncedChangesStrategy
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncMode
+import io.realm.kotlin.mongodb.sync.SyncSession
 import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
@@ -195,16 +203,6 @@ class FlexibleSyncConfigurationTests {
         TODO()
     }
 
-    // @Test
-    // fun defaultClientResetStrategy() {
-    //     val user: User = createTestUser(app)
-    //     val handler = SyncConfiguration.InitialFlexibleSyncSubscriptions { realm, subscriptions ->
-    //         // Do nothing
-    //     }
-    //     val config: SyncConfiguration = SyncConfiguration.defaultConfig(user)
-    //     assertTrue(config.syncClientResetStrategy is ManuallyRecoverUnsyncedChangesStrategy)
-    // }
-
     @Test
     fun overrideDefaultPath() {
         val user: User = app.asTestApp.createUserAndLogin()
@@ -212,5 +210,102 @@ class FlexibleSyncConfigurationTests {
             .name("custom.realm")
             .build()
         assertTrue(config.path.endsWith("${app.configuration.appId}/${user.identity}/custom.realm"), "Path is: ${config.path}")
+    }
+
+
+    @Test
+    fun clientResetStrategy_default() {
+        val user: User = app.asTestApp.createUserAndLogin()
+        val config: SyncConfiguration = SyncConfiguration.Builder(user, setOf())
+            .build()
+        assertTrue(config.syncClientResetStrategy is ManuallyRecoverUnsyncedChangesStrategy)
+    }
+
+    @Test
+    fun clientResetStrategy_manual() {
+        val user: User = app.asTestApp.createUserAndLogin()
+        val config: SyncConfiguration = SyncConfiguration.Builder(user, setOf())
+            .syncClientResetStrategy(object : ManuallyRecoverUnsyncedChangesStrategy {
+                override fun onClientReset(
+                    session: SyncSession,
+                    exception: ClientResetRequiredException
+                ) {
+                    // will not be called
+                }
+            }).build()
+        assertTrue(config.syncClientResetStrategy is ManuallyRecoverUnsyncedChangesStrategy)
+    }
+
+    @Test
+    fun clientResetStrategy_discardLocal() {
+        val user: User = app.asTestApp.createUserAndLogin()
+        val config: SyncConfiguration = SyncConfiguration.Builder(user, setOf())
+            .syncClientResetStrategy(object : DiscardUnsyncedChangesStrategy {
+                override fun onBeforeReset(realm: TypedRealm) {
+                    // will not be called
+                }
+
+                override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                    // will not be called
+                }
+
+                override fun onError(
+                    session: SyncSession,
+                    exception: ClientResetRequiredException
+                ) {
+                    // will not be called
+                }
+            }).build()
+        assertTrue(config.syncClientResetStrategy is DiscardUnsyncedChangesStrategy)
+    }
+
+    @Test
+    fun clientResetStrategy_recover() {
+        val user: User = app.asTestApp.createUserAndLogin()
+        val config: SyncConfiguration = SyncConfiguration.Builder(user, setOf())
+            .syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
+                override fun onBeforeReset(realm: TypedRealm) {
+                    // will not be called
+                }
+
+                override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                    // will not be called
+                }
+
+                override fun onError(
+                    session: SyncSession,
+                    exception: ClientResetRequiredException
+                ) {
+                    // will not be called
+                }
+            }).build()
+        assertTrue(config.syncClientResetStrategy is RecoverUnsyncedChangesStrategy)
+    }
+
+    @Test
+    fun clientResetStrategy_recoverOrDiscard() {
+        val user: User = app.asTestApp.createUserAndLogin()
+        val config: SyncConfiguration = SyncConfiguration.Builder(user, setOf())
+            .syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
+                override fun onBeforeReset(realm: TypedRealm) {
+                    // will not be called
+                }
+
+                override fun onAfterRecovery(before: TypedRealm, after: MutableRealm) {
+                    // will not be called
+                }
+
+                override fun onAfterDiscard(before: TypedRealm, after: MutableRealm) {
+                    // will not be called
+                }
+
+                override fun onError(
+                    session: SyncSession,
+                    exception: ClientResetRequiredException
+                ) {
+                    // will not be called
+                }
+            }).build()
+        assertTrue(config.syncClientResetStrategy is RecoverOrDiscardUnsyncedChangesStrategy)
     }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncIntegrationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncIntegrationTests.kt
@@ -43,7 +43,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.minutes

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
@@ -20,8 +20,6 @@ package io.realm.kotlin.test.mongodb.shared
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.TypedRealm
-import io.realm.kotlin.entities.sync.ChildPk
-import io.realm.kotlin.entities.sync.ParentPk
 import io.realm.kotlin.entities.sync.SyncPerson
 import io.realm.kotlin.entities.sync.flx.FlexChildObject
 import io.realm.kotlin.entities.sync.flx.FlexParentObject
@@ -53,8 +51,6 @@ import io.realm.kotlin.test.util.use
 import io.realm.kotlin.types.RealmObject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import kotlin.random.Random
 import kotlin.reflect.KClass
 import kotlin.test.AfterTest
@@ -67,113 +63,133 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.minutes
 
-@RunWith(Parameterized::class)
-class SyncClientResetIntegrationTests(
-    val parameterGenerator: () -> TestParameterGenerator<*>
-) {
+class SyncClientResetIntegrationTests {
 
-    class TestParameterGenerator<T : RealmObject>(
-        private val clazz: KClass<T>,
+    class TestEnvironment<T : RealmObject>(
+        val clazz: KClass<T>,
         val appName: String,
         val configBuilderGenerator: (user: User) -> SyncConfiguration.Builder,
         val insertElement: (realm: Realm) -> Unit,
         val recoverData: (before: TypedRealm, after: MutableRealm) -> Unit,
     ) {
-        fun channel(capacity: Int): Channel<ResultsChange<T>> = Channel(capacity)
-        fun query(realm: TypedRealm): RealmQuery<T> = realm.query(clazz)
-        fun countElements(realm: TypedRealm): Long = query(realm).count().find()
+        private fun newChannel(): Channel<ResultsChange<out RealmObject>> = Channel(1)
+        private fun getObjects(realm: TypedRealm): RealmQuery<T> = realm.query(clazz)
+        private fun countObjects(realm: TypedRealm): Long = getObjects(realm).count().find()
+        private val logChannel: Channel<ClientResetLogEvents> = Channel(5)
+
+        fun performTest(
+            block: TestEnvironment<T>.(
+                app: TestApp,
+                user: User,
+                builder: SyncConfiguration.Builder
+            ) -> Unit
+        ) {
+
+            val app = TestApp(
+                appName = appName,
+                logLevel = LogLevel.INFO,
+                customLogger = ClientResetLoggerInspector(logChannel)
+            )
+            try {
+                val (email, password) = TestHelper.randomEmail() to "password1234"
+                val user = runBlocking {
+                    app.createUserAndLogIn(email, password)
+                }
+
+                block(app, user, configBuilderGenerator(user))
+            } finally {
+                app.close()
+            }
+        }
     }
 
     companion object {
-        @JvmStatic
-        @Parameterized.Parameters
         @Suppress("LongMethod")
-        fun data(): List<Array<() -> TestParameterGenerator<*>>> {
-            return listOf(
-                arrayOf(
-                    {
-                        val partition = TestHelper.randomPartitionValue()
+        fun performTests(
+            block: TestEnvironment<out RealmObject>.(
+                app: TestApp,
+                user: User,
+                builder: SyncConfiguration.Builder
+            ) -> Unit
+        ) {
+            val section: Int = Random.nextInt()
+            val partition: String = TestHelper.randomPartitionValue()
 
-                        TestParameterGenerator(
-                            clazz = SyncPerson::class,
-                            appName = TEST_APP_1,
-                            configBuilderGenerator = { user ->
-                                return@TestParameterGenerator SyncConfiguration.Builder(
-                                    user,
-                                    partition,
-                                    schema = setOf(SyncPerson::class)
-                                )
-                            },
-                            insertElement = { realm: Realm ->
-                                realm.writeBlocking {
-                                    copyToRealm(SyncPerson())
+            arrayOf(
+                TestEnvironment(
+                    clazz = SyncPerson::class,
+                    appName = TEST_APP_1,
+                    configBuilderGenerator = { user ->
+                        return@TestEnvironment SyncConfiguration.Builder(
+                            user,
+                            partition,
+                            schema = setOf(SyncPerson::class)
+                        )
+                    },
+                    insertElement = { realm: Realm ->
+                        realm.writeBlocking {
+                            copyToRealm(SyncPerson())
+                        }
+                    },
+                    recoverData = { before: TypedRealm, after: MutableRealm ->
+                        after.copyToRealm(
+                            SyncPerson().apply {
+                                assertNotNull(
+                                    before.query<SyncPerson>().first().find()
+                                ).let {
+                                    // Perform manual copy
+                                    // see https://github.com/realm/realm-kotlin/issues/868
+                                    this._id = it._id
+                                    this.age = it.age
+                                    this.firstName = it.firstName
+                                    this.lastName = it.lastName
                                 }
-                            },
-                            recoverData = { before: TypedRealm, after: MutableRealm ->
-                                after.copyToRealm(
-                                    SyncPerson().apply {
-                                        assertNotNull(
-                                            before.query<SyncPerson>().first().find()
-                                        ).let {
-                                            // Perform manual copy
-                                            // see https://github.com/realm/realm-kotlin/issues/868
-                                            this._id = it._id
-                                            this.age = it.age
-                                            this.firstName = it.firstName
-                                            this.lastName = it.lastName
-                                        }
-                                    }
-                                )
                             }
                         )
                     }
                 ),
-                arrayOf(
-                    {
-                        val section = Random.nextInt()
-
-                        TestParameterGenerator(
-                            clazz = FlexParentObject::class,
-                            appName = TEST_APP_FLEX,
-                            configBuilderGenerator = { user ->
-                                return@TestParameterGenerator SyncConfiguration.Builder(
-                                    user,
-                                    setOf(FlexParentObject::class, FlexChildObject::class)
-                                ).initialSubscriptions { realm ->
-                                    realm.query<FlexParentObject>(
-                                        "section = $0 AND name = $1",
-                                        section,
-                                        "blue"
-                                    ).also { add(it) }
-                                }.waitForInitialRemoteData(timeout = 1.minutes)
-                            },
-                            insertElement = { realm: Realm ->
-                                realm.writeBlocking {
-                                    copyToRealm(FlexParentObject())
+                TestEnvironment(
+                    clazz = FlexParentObject::class,
+                    appName = TEST_APP_FLEX,
+                    configBuilderGenerator = { user ->
+                        return@TestEnvironment SyncConfiguration.Builder(
+                            user,
+                            setOf(FlexParentObject::class, FlexChildObject::class)
+                        ).initialSubscriptions { realm ->
+                            realm.query<FlexParentObject>(
+                                "section = $0 AND name = $1",
+                                section,
+                                "blue"
+                            ).also { add(it) }
+                        }.waitForInitialRemoteData(timeout = 1.minutes)
+                    },
+                    insertElement = { realm: Realm ->
+                        realm.writeBlocking {
+                            copyToRealm(FlexParentObject())
+                        }
+                    },
+                    recoverData = { before: TypedRealm, after: MutableRealm ->
+                        // Perform manual copy
+                        // see https://github.com/realm/realm-kotlin/issues/868
+                        after.copyToRealm(
+                            FlexParentObject().apply {
+                                assertNotNull(
+                                    before.query<FlexParentObject>().first().find()
+                                ).let {
+                                    // Perform manual copy
+                                    // see https://github.com/realm/realm-kotlin/issues/868
+                                    this._id = it._id
+                                    this.section = it.section
+                                    this.name = it.name
+                                    this.age = it.age
                                 }
-                            },
-                            recoverData = { before: TypedRealm, after: MutableRealm ->
-                                // Perform manual copy
-                                // see https://github.com/realm/realm-kotlin/issues/868
-                                after.copyToRealm(
-                                    FlexParentObject().apply {
-                                        assertNotNull(
-                                            before.query<FlexParentObject>().first().find()
-                                        ).let {
-                                            // Perform manual copy
-                                            // see https://github.com/realm/realm-kotlin/issues/868
-                                            this._id = it._id
-                                            this.section = it.section
-                                            this.name = it.name
-                                            this.age = it.age
-                                        }
-                                    }
-                                )
                             }
                         )
                     }
-                ),
-            )
+                )
+            ).forEach {
+                it.performTest(block)
+            }
         }
     }
 
@@ -230,33 +246,15 @@ class SyncClientResetIntegrationTests(
         }
     }
 
-    private lateinit var parameters: TestParameterGenerator<*>
     private lateinit var partitionValue: String
-    private lateinit var user: User
-    private lateinit var app: TestApp
-    private lateinit var logChannel: Channel<ClientResetLogEvents>
 
     @BeforeTest
     fun setup() {
         partitionValue = TestHelper.randomPartitionValue()
-        logChannel = Channel(5)
-        parameters = parameterGenerator()
-        app = TestApp(
-            appName = parameters.appName,
-            logLevel = LogLevel.INFO,
-            customLogger = ClientResetLoggerInspector(logChannel)
-        )
-        val (email, password) = TestHelper.randomEmail() to "password1234"
-        user = runBlocking {
-            app.createUserAndLogIn(email, password)
-        }
     }
 
     @AfterTest
     fun tearDown() {
-        if (this::app.isInitialized) {
-            app.close()
-        }
     }
 
     // ---------------------------------------------------------------------------------------
@@ -265,452 +263,27 @@ class SyncClientResetIntegrationTests(
 
     @Test
     fun discardUnsyncedChangesStrategy_discards() {
-        // Validate that the discard local strategy onBeforeReset and onAfterReset callbacks
-        // are invoked successfully when a client reset is triggered.
-        val channel = Channel<ClientResetEvents>(2)
-        val config = parameters.configBuilderGenerator(user).syncClientResetStrategy(
-            object : DiscardUnsyncedChangesStrategy {
-                override fun onBeforeReset(realm: TypedRealm) {
-                    // This realm contains something as we wrote an object while the session was paused
-                    assertEquals(1, parameters.countElements(realm))
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
-                }
-
-                override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                    // The before-Realm contains the object we wrote while the session was paused
-                    assertEquals(1, parameters.countElements(before))
-
-                    // The after-Realm contains no objects
-                    assertEquals(0, parameters.countElements(after))
-
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_AFTER_RESET)
-                }
-
-                override fun onError(
-                    session: SyncSession,
-                    exception: ClientResetRequiredException
-                ) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_ERROR)
-                }
-            }
-        ).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                // This channel helps to validate that the Realm gets updated
-                val objectChannel: Channel<ResultsChange<out RealmObject>> =
-                    parameters.channel(1) as Channel<ResultsChange<out RealmObject>>
-
-                val job = async {
-                    parameters.query(realm).asFlow()
-                        .collect {
-                            objectChannel.trySend(it)
-                        }
-                }
-
-                // No initial data
-                assertEquals(0, objectChannel.receive().list.size)
-
-                app.triggerClientReset(user.identity, realm.syncSession) {
-                    parameters.insertElement(realm)
-                    assertEquals(1, objectChannel.receive().list.size)
-                }
-
-                // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
-
-                // TODO We must not need this. Force updating the instance pointer.
-                realm.write { }
-
-                // Validate Realm instance has been correctly updated
-                assertEquals(0, objectChannel.receive().list.size)
-
-                job.cancel()
-            }
-        }
-    }
-
-    @Test
-    fun discardUnsyncedChangesStrategy_discards_attemptRecover() {
-        // Attempts to recover data if a client reset is triggered.
-        val channel = Channel<ClientResetEvents>(2)
-        val config = parameters.configBuilderGenerator(user).syncClientResetStrategy(
-            object : DiscardUnsyncedChangesStrategy {
-                override fun onBeforeReset(realm: TypedRealm) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
-                }
-
-                override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                    // The before-Realm contains the object we wrote while the session was paused
-                    assertEquals(1, parameters.countElements(before))
-
-                    parameters.recoverData(before, after)
-
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_AFTER_RESET)
-                }
-
-                override fun onError(
-                    session: SyncSession,
-                    exception: ClientResetRequiredException
-                ) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_ERROR)
-                }
-            }
-        ).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                // This channel helps to validate that the Realm gets updated
-                val objectChannel: Channel<ResultsChange<out RealmObject>> =
-                    parameters.channel(1) as Channel<ResultsChange<out RealmObject>>
-
-                val job = async {
-                    parameters.query(realm).asFlow()
-                        .collect {
-                            objectChannel.trySend(it)
-                        }
-                }
-
-                // No initial data
-                assertEquals(0, objectChannel.receive().list.size)
-
-                app.triggerClientReset(user.identity, realm.syncSession) {
-                    // Write something while the session is paused to make sure the before realm contains something
-                    parameters.insertElement(realm)
-                    assertEquals(1, objectChannel.receive().list.size)
-                }
-
-                // Validate that the client reset was triggered successfuly
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
-
-                // TODO We must not need this. Force updating the instance pointer.
-                realm.write { }
-
-                // Validate Realm instance has been correctly updated
-                assertEquals(1, objectChannel.receive().list.size)
-
-                job.cancel()
-            }
-        }
-    }
-
-    @Test
-    fun discardUnsyncedChangesStrategy_failure() {
-        // Validate that the discard local strategy onError callback is invoked successfully if
-        // a client reset fails.
-        val channel = Channel<ClientResetEvents>(1)
-        val config =
-            parameters.configBuilderGenerator(user)
-                .syncClientResetStrategy(object : DiscardUnsyncedChangesStrategy {
+        performTests { app, user, builder ->
+            // Validate that the discard local strategy onBeforeReset and onAfterReset callbacks
+            // are invoked successfully when a client reset is triggered.
+            val channel = Channel<ClientResetEvents>(2)
+            val config = builder.syncClientResetStrategy(
+                object : DiscardUnsyncedChangesStrategy {
                     override fun onBeforeReset(realm: TypedRealm) {
-                        fail("Should not call onBeforeReset")
-                    }
-
-                    override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                        fail("Should not call onAfterReset")
-                    }
-
-                    override fun onError(
-                        session: SyncSession,
-                        exception: ClientResetRequiredException
-                    ) {
-                        val originalFilePath = assertNotNull(exception.originalFilePath)
-                        val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
-                        assertTrue(fileExists(originalFilePath))
-                        assertFalse(fileExists(recoveryFilePath))
-                        // Note, this error message is just the one created by ObjectStore for
-                        // testing the server will send a different message. This just ensures that
-                        // we don't accidentally modify or remove the message.
-                        assertEquals(
-                            "[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed",
-                            exception.message
-                        )
-
+                        // This realm contains something as we wrote an object while the session was paused
+                        assertEquals(1, countObjects(realm))
                         // Notify that this callback has been invoked
-                        channel.trySend(ClientResetEvents.ON_ERROR)
-                    }
-                }).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                with(realm.syncSession as SyncSessionImpl) {
-                    simulateError(
-                        ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
-                        SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
-                    )
-
-                    assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
-                }
-            }
-        }
-    }
-
-    @Test
-    fun discardUnsyncedChangesStrategy_executeClientReset() = runBlocking {
-        val channel = Channel<ClientResetEvents>(1)
-        val config =
-            parameters.configBuilderGenerator(user)
-                .syncClientResetStrategy(object : DiscardUnsyncedChangesStrategy {
-                    override fun onBeforeReset(realm: TypedRealm) {
-                        fail("Should not call onBeforeReset")
-                    }
-
-                    override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                        fail("Should not call onAfterReset")
-                    }
-
-                    override fun onError(
-                        session: SyncSession,
-                        exception: ClientResetRequiredException
-                    ) {
-                        val originalFilePath = assertNotNull(exception.originalFilePath)
-                        val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
-                        assertTrue(fileExists(originalFilePath))
-                        assertFalse(fileExists(recoveryFilePath))
-
-                        exception.executeClientReset()
-
-                        // Validate that files have been moved after explicit reset
-                        assertFalse(fileExists(originalFilePath))
-                        assertTrue(fileExists(recoveryFilePath))
-
-                        channel.trySend(ClientResetEvents.ON_ERROR)
-                    }
-                }).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                with(realm.syncSession as SyncSessionImpl) {
-                    simulateError(
-                        ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
-                        SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
-                    )
-
-                    assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
-                }
-            }
-        }
-    }
-
-    @Test
-    fun discardUnsyncedChangesStrategy_userExceptionCaptured_onBeforeReset() {
-        // Validates that any user exception during the automatic client reset is properly captured.
-        val channel = Channel<ClientResetEvents>(3)
-        val config = parameters.configBuilderGenerator(user).syncClientResetStrategy(
-            object : DiscardUnsyncedChangesStrategy {
-                override fun onBeforeReset(realm: TypedRealm) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
-                    throw IllegalStateException("User exception")
-                }
-
-                override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                    // Send event anyways so that the asserts outside would fail
-                    channel.trySend(ClientResetEvents.ON_AFTER_RESET)
-                }
-
-                override fun onError(
-                    session: SyncSession,
-                    exception: ClientResetRequiredException
-                ) {
-                    // Notify that this callback has been invoked
-                    assertEquals(
-                        "[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed",
-                        exception.message
-                    )
-                    channel.trySend(ClientResetEvents.ON_ERROR)
-                }
-            }
-        ).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                app.triggerClientReset(user.identity, realm.syncSession)
-
-                // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
-            }
-        }
-    }
-
-    @Test
-    fun discardUnsyncedChangesStrategy_userExceptionCaptured_onAfterReset() {
-        // Validates that any user exception during the automatic client reset is properly captured.
-        val channel = Channel<ClientResetEvents>(3)
-        val config = parameters.configBuilderGenerator(user).syncClientResetStrategy(
-            object : DiscardUnsyncedChangesStrategy {
-                override fun onBeforeReset(realm: TypedRealm) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
-                }
-
-                override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                    // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_AFTER_RESET)
-                    throw IllegalStateException("User exception")
-                }
-
-                override fun onError(
-                    session: SyncSession,
-                    exception: ClientResetRequiredException
-                ) {
-                    // Notify that this callback has been invoked
-                    assertEquals(
-                        "[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed",
-                        exception.message
-                    )
-                    channel.trySend(ClientResetEvents.ON_ERROR)
-                }
-            }
-        ).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                app.triggerClientReset(user.identity, realm.syncSession)
-
-                // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
-            }
-        }
-    }
-
-    // ---------------------------------------------------------------------------------------
-    // Default from config: RecoverOrDiscardUnsyncedChangesStrategy
-    // ---------------------------------------------------------------------------------------
-
-    @Test
-    fun defaultRecoverOrDiscardUnsyncedChangesStrategy_logsReported() {
-        val config = parameters.configBuilderGenerator(user).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                app.triggerClientReset(user.identity, realm.syncSession)
-
-                // Validate we receive logs on the regular path
-                assertEquals(
-                    ClientResetLogEvents.DISCARD_LOCAL_ON_BEFORE_RESET,
-                    logChannel.receive()
-                )
-                assertEquals(
-                    ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RECOVERY,
-                    logChannel.receive()
-                )
-                // assertEquals(ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RESET, logChannel.receive())
-
-                (realm.syncSession as SyncSessionImpl).simulateError(
-                    ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
-                    SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
-                )
-                // Validate that we receive logs on the error callback
-                val actual = logChannel.receive()
-                assertEquals(ClientResetLogEvents.DISCARD_LOCAL_ON_ERROR, actual)
-            }
-        }
-    }
-
-    // ---------------------------------------------------------------------------------------
-    // ManuallyRecoverUnsyncedChangesStrategy
-    // ---------------------------------------------------------------------------------------
-
-    @Test
-    fun manuallyRecoverUnsyncedChangesStrategy_reported() = runBlocking {
-        val channel = Channel<ClientResetRequiredException>(1)
-
-        val config = parameters.configBuilderGenerator(user)
-            .syncClientResetStrategy(object : ManuallyRecoverUnsyncedChangesStrategy {
-                override fun onClientReset(
-                    session: SyncSession,
-                    exception: ClientResetRequiredException
-                ) {
-                    channel.trySend(exception)
-                }
-            }).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                with((realm.syncSession as SyncSessionImpl)) {
-                    simulateError(
-                        ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
-                        SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
-                    )
-
-                    val exception = channel.receive()
-                    val originalFilePath = assertNotNull(exception.originalFilePath)
-                    val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
-                    assertTrue(fileExists(originalFilePath))
-                    assertFalse(fileExists(recoveryFilePath))
-                    assertEquals(
-                        "[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed",
-                        exception.message
-                    )
-                }
-            }
-        }
-    }
-
-    @Test
-    fun manuallyRecoverUnsyncedChangesStrategy_executeClientReset() = runBlocking {
-        val channel = Channel<ClientResetRequiredException>(1)
-
-        val config = parameters.configBuilderGenerator(user)
-            .syncClientResetStrategy(object : ManuallyRecoverUnsyncedChangesStrategy {
-                override fun onClientReset(
-                    session: SyncSession,
-                    exception: ClientResetRequiredException
-                ) {
-                    channel.trySend(exception)
-                }
-            }).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                with(realm.syncSession as SyncSessionImpl) {
-                    simulateError(
-                        ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
-                        SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
-                    )
-
-                    val exception = channel.receive()
-
-                    val originalFilePath = assertNotNull(exception.originalFilePath)
-                    val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
-                    assertTrue(fileExists(originalFilePath))
-                    assertFalse(fileExists(recoveryFilePath))
-
-                    exception.executeClientReset()
-                    assertFalse(fileExists(originalFilePath))
-                    assertTrue(fileExists(recoveryFilePath))
-                }
-            }
-        }
-    }
-
-    // ---------------------------------------------------------------------------------------
-    // RecoverUnsyncedChangesStrategy
-    // ---------------------------------------------------------------------------------------
-
-    @Test
-    fun recoverUnsyncedChangesStrategy_recover() = runBlocking {
-        val channel = Channel<ClientResetEvents>(2)
-        val config =
-            parameters.configBuilderGenerator(user)
-                .syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
-                    override fun onBeforeReset(realm: TypedRealm) {
                         channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
                     }
 
                     override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                        // The before-Realm contains the object we wrote while the session was paused
+                        assertEquals(1, countObjects(before))
+
+                        // The after-Realm contains no objects
+                        assertEquals(0, countObjects(after))
+
+                        // Notify that this callback has been invoked
                         channel.trySend(ClientResetEvents.ON_AFTER_RESET)
                     }
 
@@ -718,65 +291,228 @@ class SyncClientResetIntegrationTests(
                         session: SyncSession,
                         exception: ClientResetRequiredException
                     ) {
-                        fail("This test case was not supposed to trigger RecoverUnsyncedChangesStrategy::onError()")
+                        // Notify that this callback has been invoked
+                        channel.trySend(ClientResetEvents.ON_ERROR)
                     }
-                }).build()
-
-        Realm.open(config).use { realm ->
-            runBlocking {
-                app.triggerClientReset(user.identity, realm.syncSession) {
-                    parameters.insertElement(realm)
-                    assertEquals(1, parameters.countElements(realm))
                 }
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+            ).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    // This channel helps to validate that the Realm gets updated
+                    val objectChannel: Channel<ResultsChange<out RealmObject>> = newChannel()
+
+                    val job = async {
+                        getObjects(realm).asFlow()
+                            .collect {
+                                objectChannel.trySend(it)
+                            }
+                    }
+
+                    // No initial data
+                    assertEquals(0, objectChannel.receive().list.size)
+
+                    app.triggerClientReset(user.identity, realm.syncSession) {
+                        insertElement(realm)
+                        assertEquals(1, objectChannel.receive().list.size)
+                    }
+
+                    // Validate that the client reset was triggered successfully
+                    assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+
+                    // TODO We must not need this. Force updating the instance pointer.
+                    realm.write { }
+
+                    // Validate Realm instance has been correctly updated
+                    assertEquals(0, objectChannel.receive().list.size)
+
+                    job.cancel()
+                }
             }
         }
     }
 
     @Test
-    fun recoverUnsyncedChangesStrategy_resetErrorHandled() = runBlocking {
-        val channel = Channel<ClientResetRequiredException>(1)
-        val config = SyncConfiguration.Builder(
-            user,
-            partitionValue,
-            schema = setOf(ParentPk::class, ChildPk::class)
-        ).syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
-            override fun onBeforeReset(realm: TypedRealm) {
-                fail("This test case was not supposed to trigger RecoverUnsyncedChangesStrategy::onBeforeReset()")
-            }
-
-            override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
-                fail("This test case was not supposed to trigger RecoverUnsyncedChangesStrategy::onAfterReset()")
-            }
-
-            override fun onError(session: SyncSession, exception: ClientResetRequiredException) {
-                channel.trySend(exception)
-            }
-        }).build()
-
-        Realm.open(config).use { realm ->
-            (realm.syncSession as SyncSessionImpl).simulateError(
-                ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
-                SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
-            )
-            val exception = channel.receive()
-
-            assertNotNull(exception.recoveryFilePath)
-            assertNotNull(exception.originalFilePath)
-            assertFalse(fileExists(exception.recoveryFilePath))
-            assertTrue(fileExists(exception.originalFilePath))
-            assertTrue(exception.message!!.contains("Automatic recovery from client reset failed"))
-        }
-    }
-
-    @Test
-    fun recoverUnsyncedChangesStrategy_recoverFails() = runBlocking {
-        val channel = Channel<ClientResetEvents>(2)
-        val config =
-            parameters.configBuilderGenerator(user)
-                .syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
+    fun discardUnsyncedChangesStrategy_discards_attemptRecover() {
+        performTests { app, user, builder ->
+            // Attempts to recover data if a client reset is triggered.
+            val channel = Channel<ClientResetEvents>(2)
+            val config = builder.syncClientResetStrategy(
+                object : DiscardUnsyncedChangesStrategy {
                     override fun onBeforeReset(realm: TypedRealm) {
+                        // Notify that this callback has been invoked
+                        channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                    }
+
+                    override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                        // The before-Realm contains the object we wrote while the session was paused
+                        assertEquals(1, countObjects(before))
+
+                        recoverData(before, after)
+
+                        // Notify that this callback has been invoked
+                        channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                    }
+
+                    override fun onError(
+                        session: SyncSession,
+                        exception: ClientResetRequiredException
+                    ) {
+                        // Notify that this callback has been invoked
+                        channel.trySend(ClientResetEvents.ON_ERROR)
+                    }
+                }
+            ).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    // This channel helps to validate that the Realm gets updated
+                    val objectChannel: Channel<ResultsChange<out RealmObject>> = newChannel()
+
+                    val job = async {
+                        getObjects(realm).asFlow()
+                            .collect {
+                                objectChannel.trySend(it)
+                            }
+                    }
+
+                    // No initial data
+                    assertEquals(0, objectChannel.receive().list.size)
+
+                    app.triggerClientReset(user.identity, realm.syncSession) {
+                        // Write something while the session is paused to make sure the before realm contains something
+                        insertElement(realm)
+                        assertEquals(1, objectChannel.receive().list.size)
+                    }
+
+                    // Validate that the client reset was triggered successfuly
+                    assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+
+                    // TODO We must not need this. Force updating the instance pointer.
+                    realm.write { }
+
+                    // Validate Realm instance has been correctly updated
+                    assertEquals(1, objectChannel.receive().list.size)
+
+                    job.cancel()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun discardUnsyncedChangesStrategy_failure() {
+        performTests { app, user, builder ->
+            // Validate that the discard local strategy onError callback is invoked successfully if
+            // a client reset fails.
+            val channel = Channel<ClientResetEvents>(1)
+            val config =
+                builder
+                    .syncClientResetStrategy(object : DiscardUnsyncedChangesStrategy {
+                        override fun onBeforeReset(realm: TypedRealm) {
+                            fail("Should not call onBeforeReset")
+                        }
+
+                        override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                            fail("Should not call onAfterReset")
+                        }
+
+                        override fun onError(
+                            session: SyncSession,
+                            exception: ClientResetRequiredException
+                        ) {
+                            val originalFilePath = assertNotNull(exception.originalFilePath)
+                            val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
+                            assertTrue(fileExists(originalFilePath))
+                            assertFalse(fileExists(recoveryFilePath))
+                            // Note, this error message is just the one created by ObjectStore for
+                            // testing the server will send a different message. This just ensures that
+                            // we don't accidentally modify or remove the message.
+                            assertEquals(
+                                "[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed",
+                                exception.message
+                            )
+
+                            // Notify that this callback has been invoked
+                            channel.trySend(ClientResetEvents.ON_ERROR)
+                        }
+                    }).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    with(realm.syncSession as SyncSessionImpl) {
+                        simulateError(
+                            ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
+                            SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
+                        )
+
+                        assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun discardUnsyncedChangesStrategy_executeClientReset() = runBlocking {
+        performTests { app, user, builder ->
+            val channel = Channel<ClientResetEvents>(1)
+            val config =
+                builder
+                    .syncClientResetStrategy(object : DiscardUnsyncedChangesStrategy {
+                        override fun onBeforeReset(realm: TypedRealm) {
+                            fail("Should not call onBeforeReset")
+                        }
+
+                        override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                            fail("Should not call onAfterReset")
+                        }
+
+                        override fun onError(
+                            session: SyncSession,
+                            exception: ClientResetRequiredException
+                        ) {
+                            val originalFilePath = assertNotNull(exception.originalFilePath)
+                            val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
+                            assertTrue(fileExists(originalFilePath))
+                            assertFalse(fileExists(recoveryFilePath))
+
+                            exception.executeClientReset()
+
+                            // Validate that files have been moved after explicit reset
+                            assertFalse(fileExists(originalFilePath))
+                            assertTrue(fileExists(recoveryFilePath))
+
+                            channel.trySend(ClientResetEvents.ON_ERROR)
+                        }
+                    }).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    with(realm.syncSession as SyncSessionImpl) {
+                        simulateError(
+                            ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
+                            SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
+                        )
+
+                        assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun discardUnsyncedChangesStrategy_userExceptionCaptured_onBeforeReset() {
+        performTests { app, user, builder ->
+            // Validates that any user exception during the automatic client reset is properly captured.
+            val channel = Channel<ClientResetEvents>(3)
+            val config = builder.syncClientResetStrategy(
+                object : DiscardUnsyncedChangesStrategy {
+                    override fun onBeforeReset(realm: TypedRealm) {
+                        // Notify that this callback has been invoked
                         channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
                         throw IllegalStateException("User exception")
                     }
@@ -797,15 +533,301 @@ class SyncClientResetIntegrationTests(
                         )
                         channel.trySend(ClientResetEvents.ON_ERROR)
                     }
+                }
+            ).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    app.triggerClientReset(user.identity, realm.syncSession)
+
+                    // Validate that the client reset was triggered successfully
+                    assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun discardUnsyncedChangesStrategy_userExceptionCaptured_onAfterReset() {
+        performTests { app, user, builder ->
+            // Validates that any user exception during the automatic client reset is properly captured.
+            val channel = Channel<ClientResetEvents>(3)
+            val config = builder.syncClientResetStrategy(
+                object : DiscardUnsyncedChangesStrategy {
+                    override fun onBeforeReset(realm: TypedRealm) {
+                        // Notify that this callback has been invoked
+                        channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                    }
+
+                    override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                        // Notify that this callback has been invoked
+                        channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                        throw IllegalStateException("User exception")
+                    }
+
+                    override fun onError(
+                        session: SyncSession,
+                        exception: ClientResetRequiredException
+                    ) {
+                        // Notify that this callback has been invoked
+                        assertEquals(
+                            "[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed",
+                            exception.message
+                        )
+                        channel.trySend(ClientResetEvents.ON_ERROR)
+                    }
+                }
+            ).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    app.triggerClientReset(user.identity, realm.syncSession)
+
+                    // Validate that the client reset was triggered successfully
+                    assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Default from config: RecoverOrDiscardUnsyncedChangesStrategy
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun defaultRecoverOrDiscardUnsyncedChangesStrategy_logsReported() {
+        performTests { app, user, builder ->
+            val config = builder.build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    app.triggerClientReset(user.identity, realm.syncSession)
+
+                    // Validate we receive logs on the regular path
+                    assertEquals(
+                        ClientResetLogEvents.DISCARD_LOCAL_ON_BEFORE_RESET,
+                        logChannel.receive()
+                    )
+                    assertEquals(
+                        ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RECOVERY,
+                        logChannel.receive()
+                    )
+                    // assertEquals(ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RESET, logChannel.receive())
+
+                    (realm.syncSession as SyncSessionImpl).simulateError(
+                        ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
+                        SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
+                    )
+                    // Validate that we receive logs on the error callback
+                    val actual = logChannel.receive()
+                    assertEquals(ClientResetLogEvents.DISCARD_LOCAL_ON_ERROR, actual)
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // ManuallyRecoverUnsyncedChangesStrategy
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun manuallyRecoverUnsyncedChangesStrategy_reported() = runBlocking {
+        performTests { app, user, builder ->
+            val channel = Channel<ClientResetRequiredException>(1)
+
+            val config = builder
+                .syncClientResetStrategy(object : ManuallyRecoverUnsyncedChangesStrategy {
+                    override fun onClientReset(
+                        session: SyncSession,
+                        exception: ClientResetRequiredException
+                    ) {
+                        channel.trySend(exception)
+                    }
                 }).build()
 
-        Realm.open(config).use { realm ->
-            runBlocking {
-                app.triggerClientReset(user.identity, realm.syncSession)
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    with((realm.syncSession as SyncSessionImpl)) {
+                        simulateError(
+                            ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
+                            SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
+                        )
 
-                // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
+                        val exception = channel.receive()
+                        val originalFilePath = assertNotNull(exception.originalFilePath)
+                        val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
+                        assertTrue(fileExists(originalFilePath))
+                        assertFalse(fileExists(recoveryFilePath))
+                        assertEquals(
+                            "[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed",
+                            exception.message
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun manuallyRecoverUnsyncedChangesStrategy_executeClientReset() = runBlocking {
+        performTests { app, user, builder ->
+            val channel = Channel<ClientResetRequiredException>(1)
+
+            val config = builder
+                .syncClientResetStrategy(object : ManuallyRecoverUnsyncedChangesStrategy {
+                    override fun onClientReset(
+                        session: SyncSession,
+                        exception: ClientResetRequiredException
+                    ) {
+                        channel.trySend(exception)
+                    }
+                }).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    with(realm.syncSession as SyncSessionImpl) {
+                        simulateError(
+                            ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
+                            SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
+                        )
+
+                        val exception = channel.receive()
+
+                        val originalFilePath = assertNotNull(exception.originalFilePath)
+                        val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
+                        assertTrue(fileExists(originalFilePath))
+                        assertFalse(fileExists(recoveryFilePath))
+
+                        exception.executeClientReset()
+                        assertFalse(fileExists(originalFilePath))
+                        assertTrue(fileExists(recoveryFilePath))
+                    }
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // RecoverUnsyncedChangesStrategy
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun recoverUnsyncedChangesStrategy_recover() = runBlocking {
+        performTests { app, user, builder ->
+            val channel = Channel<ClientResetEvents>(2)
+            val config =
+                builder
+                    .syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
+                        override fun onBeforeReset(realm: TypedRealm) {
+                            channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                        }
+
+                        override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                            channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                        }
+
+                        override fun onError(
+                            session: SyncSession,
+                            exception: ClientResetRequiredException
+                        ) {
+                            fail("This test case was not supposed to trigger RecoverUnsyncedChangesStrategy::onError()")
+                        }
+                    }).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    app.triggerClientReset(user.identity, realm.syncSession) {
+                        insertElement(realm)
+                        assertEquals(1, countObjects(realm))
+                    }
+                    assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun recoverUnsyncedChangesStrategy_resetErrorHandled() {
+        performTests { _, _, builder ->
+            val channel = Channel<ClientResetRequiredException>(1)
+            val config = builder
+                .syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
+                    override fun onBeforeReset(realm: TypedRealm) {
+                        fail("This test case was not supposed to trigger RecoverUnsyncedChangesStrategy::onBeforeReset()")
+                    }
+
+                    override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                        fail("This test case was not supposed to trigger RecoverUnsyncedChangesStrategy::onAfterReset()")
+                    }
+
+                    override fun onError(
+                        session: SyncSession,
+                        exception: ClientResetRequiredException
+                    ) {
+                        channel.trySend(exception)
+                    }
+                }).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    (realm.syncSession as SyncSessionImpl).simulateError(
+                        ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
+                        SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
+                    )
+                    val exception = channel.receive()
+
+                    assertNotNull(exception.recoveryFilePath)
+                    assertNotNull(exception.originalFilePath)
+                    assertFalse(fileExists(exception.recoveryFilePath))
+                    assertTrue(fileExists(exception.originalFilePath))
+                    assertTrue(exception.message!!.contains("Automatic recovery from client reset failed"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun recoverUnsyncedChangesStrategy_recoverFails() = runBlocking {
+        performTests { app, user, builder ->
+            val channel = Channel<ClientResetEvents>(2)
+            val config =
+                builder
+                    .syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
+                        override fun onBeforeReset(realm: TypedRealm) {
+                            channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                            throw IllegalStateException("User exception")
+                        }
+
+                        override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
+                            // Send event anyways so that the asserts outside would fail
+                            channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                        }
+
+                        override fun onError(
+                            session: SyncSession,
+                            exception: ClientResetRequiredException
+                        ) {
+                            // Notify that this callback has been invoked
+                            assertEquals(
+                                "[Client][AutoClientResetFailure(132)] Automatic recovery from client reset failed",
+                                exception.message
+                            )
+                            channel.trySend(ClientResetEvents.ON_ERROR)
+                        }
+                    }).build()
+
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    app.triggerClientReset(user.identity, realm.syncSession)
+
+                    // Validate that the client reset was triggered successfully
+                    assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_ERROR, channel.receive())
+                }
             }
         }
     }
@@ -816,78 +838,82 @@ class SyncClientResetIntegrationTests(
 
     @Test
     fun recoverOrDiscardUnsyncedChangesStrategy_recover() = runBlocking {
-        val channel = Channel<ClientResetEvents>(2)
-        val config = parameters.configBuilderGenerator(user)
-            .syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
-                override fun onBeforeReset(realm: TypedRealm) {
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
-                }
+        performTests { app, user, builder ->
+            val channel = Channel<ClientResetEvents>(2)
+            val config = builder
+                .syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
+                    override fun onBeforeReset(realm: TypedRealm) {
+                        channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                    }
 
-                override fun onAfterRecovery(before: TypedRealm, after: MutableRealm) {
-                    channel.trySend(ClientResetEvents.ON_AFTER_RECOVERY)
-                }
+                    override fun onAfterRecovery(before: TypedRealm, after: MutableRealm) {
+                        channel.trySend(ClientResetEvents.ON_AFTER_RECOVERY)
+                    }
 
-                override fun onAfterDiscard(before: TypedRealm, after: MutableRealm) {
-                    fail("This test case was not supposed to trigger AutomaticRecoveryStrategy::onAfterDiscard()")
-                }
+                    override fun onAfterDiscard(before: TypedRealm, after: MutableRealm) {
+                        fail("This test case was not supposed to trigger AutomaticRecoveryStrategy::onAfterDiscard()")
+                    }
 
-                override fun onError(
-                    session: SyncSession,
-                    exception: ClientResetRequiredException
-                ) {
-                    fail("This test case was not supposed to trigger AutomaticRecoveryStrategy::onError()")
-                }
-            }).build()
+                    override fun onError(
+                        session: SyncSession,
+                        exception: ClientResetRequiredException
+                    ) {
+                        fail("This test case was not supposed to trigger AutomaticRecoveryStrategy::onError()")
+                    }
+                }).build()
 
-        Realm.open(config).use { realm ->
-            runBlocking {
-                app.triggerClientReset(user.identity, realm.syncSession) {
-                    parameters.insertElement(realm)
-                    assertEquals(1, parameters.countElements(realm))
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    app.triggerClientReset(user.identity, realm.syncSession) {
+                        insertElement(realm)
+                        assertEquals(1, countObjects(realm))
+                    }
+                    assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_AFTER_RECOVERY, channel.receive())
                 }
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RECOVERY, channel.receive())
             }
         }
     }
 
     @Test
     fun recoverOrDiscardUnsyncedChangesStrategy_discards() = runBlocking {
-        val channel = Channel<ClientResetEvents>(2)
-        val config = parameters.configBuilderGenerator(user)
-            .syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
-                override fun onBeforeReset(realm: TypedRealm) {
-                    assertEquals(1, parameters.countElements(realm))
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
-                }
+        performTests { app, user, builder ->
+            val channel = Channel<ClientResetEvents>(2)
+            val config = builder
+                .syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
+                    override fun onBeforeReset(realm: TypedRealm) {
+                        assertEquals(1, countObjects(realm))
+                        channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                    }
 
-                override fun onAfterRecovery(before: TypedRealm, after: MutableRealm) {
-                    fail("This test case was not supposed to trigger RecoverOrDiscardUnsyncedChangesStrategy::onAfterRecovery()")
-                }
+                    override fun onAfterRecovery(before: TypedRealm, after: MutableRealm) {
+                        fail("This test case was not supposed to trigger RecoverOrDiscardUnsyncedChangesStrategy::onAfterRecovery()")
+                    }
 
-                override fun onAfterDiscard(before: TypedRealm, after: MutableRealm) {
-                    assertEquals(1, parameters.countElements(before))
-                    assertEquals(0, parameters.countElements(after))
-                    channel.trySend(ClientResetEvents.ON_AFTER_DISCARD)
-                }
+                    override fun onAfterDiscard(before: TypedRealm, after: MutableRealm) {
+                        assertEquals(1, countObjects(before))
+                        assertEquals(0, countObjects(after))
+                        channel.trySend(ClientResetEvents.ON_AFTER_DISCARD)
+                    }
 
-                override fun onError(
-                    session: SyncSession,
-                    exception: ClientResetRequiredException
-                ) {
-                    fail("This test case was not supposed to trigger RecoverOrDiscardUnsyncedChangesStrategy::onError()")
-                }
-            }).build()
+                    override fun onError(
+                        session: SyncSession,
+                        exception: ClientResetRequiredException
+                    ) {
+                        fail("This test case was not supposed to trigger RecoverOrDiscardUnsyncedChangesStrategy::onError()")
+                    }
+                }).build()
 
-        Realm.open(config).use { realm ->
-            runBlocking {
-                // Disable recovery mode on the server
-                app.triggerClientReset(user.identity, realm.syncSession, true) {
-                    parameters.insertElement(realm)
-                    assertEquals(1, parameters.countElements(realm))
+            Realm.open(config).use { realm ->
+                runBlocking {
+                    // Disable recovery mode on the server
+                    app.triggerClientReset(user.identity, realm.syncSession, true) {
+                        insertElement(realm)
+                        assertEquals(1, countObjects(realm))
+                    }
+                    assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
+                    assertEquals(ClientResetEvents.ON_AFTER_DISCARD, channel.receive())
                 }
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_DISCARD, channel.receive())
             }
         }
     }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
@@ -545,10 +545,8 @@ class SyncClientResetIntegrationTests {
     }
 
     @Test
-    @Ignore // https://github.com/realm/realm-kotlin/issues/867
     fun discardUnsyncedLocalChanges_userExceptionCaptured_onBeforeReset() {
         // Validates that any user exception during the automatic client reset is properly captured.
-
         val channel = Channel<ClientResetEvents>(2)
 
         val config = SyncConfiguration.Builder(
@@ -598,7 +596,6 @@ class SyncClientResetIntegrationTests {
     }
 
     @Test
-    @Ignore // https://github.com/realm/realm-kotlin/issues/867
     fun discardUnsyncedLocalChanges_userExceptionCaptured_onAfterReset() {
         // Validates that any user exception during the automatic client reset is properly captured.
         val channel = Channel<ClientResetEvents>(2)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
@@ -34,8 +34,8 @@ import io.realm.kotlin.mongodb.exceptions.ClientResetRequiredException
 import io.realm.kotlin.mongodb.exceptions.SyncException
 import io.realm.kotlin.mongodb.sync.DiscardUnsyncedChangesStrategy
 import io.realm.kotlin.mongodb.sync.ManuallyRecoverUnsyncedChangesStrategy
-import io.realm.kotlin.mongodb.sync.RecoverUnsyncedChangesStrategy
 import io.realm.kotlin.mongodb.sync.RecoverOrDiscardUnsyncedChangesStrategy
+import io.realm.kotlin.mongodb.sync.RecoverUnsyncedChangesStrategy
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncMode
 import io.realm.kotlin.mongodb.sync.SyncSession
@@ -310,7 +310,8 @@ class SyncConfigTests {
 
     private fun verifyName(builder: SyncConfiguration.Builder, expectedFileName: String) {
         val config = builder.build()
-        val suffix = "/mongodb-realm/${config.user.app.configuration.appId}/${config.user.identity}/$expectedFileName"
+        val suffix =
+            "/mongodb-realm/${config.user.app.configuration.appId}/${config.user.identity}/$expectedFileName"
         assertTrue(config.path.contains(suffix), "${config.path} failed.")
         assertEquals(expectedFileName, config.name)
     }
@@ -394,7 +395,7 @@ class SyncConfigTests {
         assertFailsWith<IllegalArgumentException> { builder.encryptionKey(byteArrayOf(1, 2, 3)) }
     }
 
-//    @Test
+    //    @Test
 //    fun initialData() {
 //        val user: User = createTestUser(app)
 //        val config = configFactory.createSyncConfigurationBuilder(user)
@@ -447,7 +448,7 @@ class SyncConfigTests {
         }
     }
 
-//
+    //
 //    // Check that it is possible for multiple users to reference the same Realm URL while each user still use their
 //    // own copy on the filesystem. This is e.g. what happens if a Realm is shared using a PermissionOffer.
 //    @Test
@@ -474,8 +475,20 @@ class SyncConfigTests {
     fun with_throwsIfNotLoggedIn() = runBlocking {
         val user: User = createTestUser()
         user.logOut()
-        assertFailsWith<IllegalArgumentException> { SyncConfiguration.create(user, "string", setOf()) }
-        assertFailsWith<IllegalArgumentException> { SyncConfiguration.create(user, 123 as Int, setOf()) }
+        assertFailsWith<IllegalArgumentException> {
+            SyncConfiguration.create(
+                user,
+                "string",
+                setOf()
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            SyncConfiguration.create(
+                user,
+                123 as Int,
+                setOf()
+            )
+        }
         assertFailsWith<IllegalArgumentException> { SyncConfiguration.create(user, 123L, setOf()) }
         Unit
     }
@@ -848,7 +861,10 @@ class SyncConfigTests {
     @Test
     fun syncClientResetStrategy_partitionBased_throwsManual() {
         val resetHandler = object : ManuallyRecoverUnsyncedChangesStrategy {
-            override fun onClientReset(session: SyncSession, exception: ClientResetRequiredException) {
+            override fun onClientReset(
+                session: SyncSession,
+                exception: ClientResetRequiredException
+            ) {
                 fail("Should not be called")
             }
         }
@@ -866,7 +882,10 @@ class SyncConfigTests {
     @Test
     fun syncClientResetStrategy_flexibleBased() {
         val resetHandler = object : ManuallyRecoverUnsyncedChangesStrategy {
-            override fun onClientReset(session: SyncSession, exception: ClientResetRequiredException) {
+            override fun onClientReset(
+                session: SyncSession,
+                exception: ClientResetRequiredException
+            ) {
                 fail("Should not be called")
             }
         }
@@ -915,7 +934,7 @@ class SyncConfigTests {
 
     @Test
     fun syncClientResetStrategy_automatic() {
-        val strategy = object: RecoverUnsyncedChangesStrategy {
+        val strategy = object : RecoverUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
                 fail("Callback should not be reachable")
             }
@@ -937,7 +956,7 @@ class SyncConfigTests {
 
     @Test
     fun syncClientResetStrategy_automaticOrDiscard() {
-        val strategy = object: RecoverOrDiscardUnsyncedChangesStrategy {
+        val strategy = object : RecoverOrDiscardUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
                 fail("Callback should not be reachable")
             }
@@ -965,7 +984,7 @@ class SyncConfigTests {
     fun recoverUnsyncedChangesStrategyMode() {
         val user = createTestUser()
         val config = SyncConfiguration.Builder(user, setOf())
-            .syncClientResetStrategy(object: RecoverUnsyncedChangesStrategy{
+            .syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
                 override fun onBeforeReset(realm: TypedRealm) {
                     fail("Should not be called")
                 }
@@ -974,7 +993,10 @@ class SyncConfigTests {
                     fail("Should not be called")
                 }
 
-                override fun onError(session: SyncSession, exception: ClientResetRequiredException) {
+                override fun onError(
+                    session: SyncSession,
+                    exception: ClientResetRequiredException
+                ) {
                     fail("Should not be called")
                 }
             })
@@ -986,7 +1008,7 @@ class SyncConfigTests {
     fun recoverOrDiscardUnsyncedChangesStrategyMode() {
         val user = createTestUser()
         val config = SyncConfiguration.Builder(user, setOf())
-            .syncClientResetStrategy(object: RecoverOrDiscardUnsyncedChangesStrategy{
+            .syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
                 override fun onBeforeReset(realm: TypedRealm) {
                     fail("Should not be called")
                 }
@@ -999,7 +1021,10 @@ class SyncConfigTests {
                     fail("Should not be called")
                 }
 
-                override fun onError(session: SyncSession, exception: ClientResetRequiredException) {
+                override fun onError(
+                    session: SyncSession,
+                    exception: ClientResetRequiredException
+                ) {
                     fail("Should not be called")
                 }
             })

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
@@ -948,7 +948,7 @@ class SyncConfigTests {
             }
         }
         val user = createTestUser()
-        val config = SyncConfiguration.Builder(user, setOf())
+        val config = SyncConfiguration.Builder(user, partitionValue, setOf())
             .syncClientResetStrategy(strategy)
             .build()
         assertEquals(strategy, config.syncClientResetStrategy)
@@ -974,7 +974,7 @@ class SyncConfigTests {
             }
         }
         val user = createTestUser()
-        val config = SyncConfiguration.Builder(user, setOf())
+        val config = SyncConfiguration.Builder(user, partitionValue, setOf())
             .syncClientResetStrategy(strategy)
             .build()
         assertEquals(strategy, config.syncClientResetStrategy)
@@ -983,7 +983,7 @@ class SyncConfigTests {
     @Test
     fun recoverUnsyncedChangesStrategyMode() {
         val user = createTestUser()
-        val config = SyncConfiguration.Builder(user, setOf())
+        val config = SyncConfiguration.Builder(user, partitionValue, setOf())
             .syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
                 override fun onBeforeReset(realm: TypedRealm) {
                     fail("Should not be called")
@@ -1007,7 +1007,7 @@ class SyncConfigTests {
     @Test
     fun recoverOrDiscardUnsyncedChangesStrategyMode() {
         val user = createTestUser()
-        val config = SyncConfiguration.Builder(user, setOf())
+        val config = SyncConfiguration.Builder(user, partitionValue, setOf())
             .syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
                 override fun onBeforeReset(realm: TypedRealm) {
                     fail("Should not be called")

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
@@ -411,10 +411,7 @@ class SyncSessionTests {
 
         assertNotNull(exception.recoveryFilePath)
         assertNotNull(exception.originalFilePath)
-        // Note, this error message is just the one created by ObjectStore for testing
-        // The server will send a different message. This just ensures that we don't
-        // accidentially modify or remove the message.
-        assertEquals("Simulate Client Reset", exception.message)
+        assertTrue(exception.message!!.contains("Automatic recovery from client reset failed"))
     }
 
     @Test

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
@@ -93,6 +93,7 @@ class SyncSessionTests {
 
     @Test
     fun session() {
+        println("---> session")
         val config = createSyncConfig(user)
         Realm.open(config).use { realm: Realm ->
             val session: SyncSession = realm.syncSession
@@ -102,6 +103,7 @@ class SyncSessionTests {
 
     @Test
     fun sessionPauseAndResume() {
+        println("---> sessionPauseAndResume")
         val config = createSyncConfig(user)
         Realm.open(config).use { realm: Realm ->
             runBlocking {
@@ -121,6 +123,7 @@ class SyncSessionTests {
 
     @Test
     fun sessionResumeMultipleTimes() {
+        println("---> sessionResumeMultipleTimes")
         val config = createSyncConfig(user)
         Realm.open(config).use { realm: Realm ->
             runBlocking {
@@ -140,6 +143,7 @@ class SyncSessionTests {
 
     @Test
     fun sessionPauseMultipleTimes() {
+        println("---> sessionPauseMultipleTimes")
         val config = createSyncConfig(user)
         Realm.open(config).use { realm: Realm ->
             runBlocking {
@@ -160,6 +164,7 @@ class SyncSessionTests {
     // The same object is returned for each call to `Realm.session`
     @Test
     fun session_identity() {
+        println("---> session_identity")
         val config = createSyncConfig(user)
         Realm.open(config).use { realm: Realm ->
             val session1: SyncSession = realm.syncSession
@@ -172,6 +177,7 @@ class SyncSessionTests {
     // differ, but they point to the same underlying Core Sync Session.
     @Test
     fun session_sharedStateBetweenRealms() {
+        println("---> session_sharedStateBetweenRealms")
         val config1 = createSyncConfig(user, "realm1.realm")
         val config2 = createSyncConfig(user, "realm2.realm")
         val realm1 = Realm.open(config1)
@@ -186,6 +192,7 @@ class SyncSessionTests {
 
     @Test
     fun session_localRealmThrows() {
+        println("---> session_localRealmThrows")
         val config = RealmConfiguration.Builder(schema = setOf(ParentPk::class, ChildPk::class))
             .build()
         Realm.open(config).use { realm ->
@@ -195,6 +202,7 @@ class SyncSessionTests {
 
     @Test
     fun downloadAllServerChanges_illegalArgumentThrows() {
+        println("---> downloadAllServerChanges_illegalArgumentThrows")
         openSyncRealm { realm ->
             val session: SyncSession = realm.syncSession
             assertFailsWith<IllegalArgumentException> {
@@ -208,6 +216,7 @@ class SyncSessionTests {
 
     @Test
     fun downloadAllServerChanges_returnFalseOnTimeOut() {
+        println("---> downloadAllServerChanges_returnFalseOnTimeOut")
         openSyncRealmWithPreconditions({ realm ->
             // Write a large ByteArray so that we increase the chance the timeout works
             realm.writeBlocking {
@@ -222,6 +231,7 @@ class SyncSessionTests {
 
     @Test
     fun uploadAllLocalChanges_illegalArgumentThrows() {
+        println("---> uploadAllLocalChanges_illegalArgumentThrows")
         openSyncRealm { realm ->
             val session: SyncSession = realm.syncSession
             assertFailsWith<IllegalArgumentException> {
@@ -235,6 +245,7 @@ class SyncSessionTests {
 
     @Test
     fun uploadAllLocalChanges_returnFalseOnTimeOut() {
+        println("---> uploadAllLocalChanges_returnFalseOnTimeOut")
         openSyncRealmWithPreconditions({ realm ->
             // Write a large ByteArray so that we increase the chance the timeout works
             realm.writeBlocking {
@@ -315,7 +326,9 @@ class SyncSessionTests {
     // Realm instance and some APIs could have a difficult time understanding semantics. For now, we
     // just disallow calling these APIs from these instances.
     @Test
+    // @Ignore // TODO remove ignore when the this is fixed https://github.com/realm/realm-kotlin/issues/867
     fun syncSessionFromErrorHandlerCannotUploadAndDownloadChanges() = runBlocking {
+        println("---> syncSessionFromErrorHandlerCannotUploadAndDownloadChanges")
         val channel = Channel<SyncSession>(1)
         var wrongSchemaRealm: Realm? = null
         val job = async {
@@ -362,7 +375,8 @@ class SyncSessionTests {
     }
 
     @Test
-    fun errorHandler_automaticRecoveryOrDiscard_resetErrorHandled() = runBlocking {
+    fun automaticRecoveryOrDiscard_resetErrorHandled() = runBlocking {
+        println("---> automaticRecoveryOrDiscard_resetErrorHandled")
         val channel = Channel<ClientResetRequiredException>(1)
         val config = SyncConfiguration.Builder(
             user,
@@ -399,7 +413,8 @@ class SyncSessionTests {
     }
 
     @Test
-    fun errorHandler_automaticRecoverFailureClientResetReported() = runBlocking {
+    fun automaticRecoverFailureClientResetReported() = runBlocking {
+        println("---> automaticRecoverFailureClientResetReported")
         val channel = Channel<ClientResetRequiredException>(1)
         val config = SyncConfiguration.Builder(
             user,
@@ -434,7 +449,8 @@ class SyncSessionTests {
     }
 
     @Test
-    fun errorHandler_recoverOrDiscardUnsyncedChangesStrategy_resetErrorHandled() = runBlocking {
+    fun recoverOrDiscardUnsyncedChangesStrategy_resetErrorHandled() = runBlocking {
+        println("---> recoverOrDiscardUnsyncedChangesStrategy_resetErrorHandled")
         val channel = Channel<ClientResetRequiredException>(1)
         val config = SyncConfiguration.Builder(
             user,
@@ -474,7 +490,8 @@ class SyncSessionTests {
 
     // Check that a Client Reset is correctly reported.
     @Test
-    fun errorHandler_manuallyRecoverUnsyncedChangesStrategy_errorHandled() = runBlocking {
+    fun manuallyRecoverUnsyncedChangesStrategy_errorHandled() = runBlocking {
+        println("---> manuallyRecoverUnsyncedChangesStrategy_errorHandled")
         val channel = Channel<ClientResetRequiredException>(1)
         val config = SyncConfiguration.Builder(
             user,
@@ -503,8 +520,8 @@ class SyncSessionTests {
 
     // Check that a Client Reset is correctly reported.
     @Test
-    fun errorHandler_manuallyRecoverUnsyncedChangesStrategy_executeClientReset() = runBlocking {
-        var realm: Realm? = null
+    fun manuallyRecoverUnsyncedChangesStrategy_executeClientReset() = runBlocking {
+        println("---> manuallyRecoverUnsyncedChangesStrategy_executeClientReset")
         val channel = Channel<ClientResetRequiredException>(1)
         val config = SyncConfiguration.Builder(
             user,
@@ -515,20 +532,20 @@ class SyncSessionTests {
                 session: SyncSession,
                 exception: ClientResetRequiredException
             ) {
-                runBlocking {
-                    realm!!.close()
-                }
-                exception.executeClientReset()
                 channel.trySend(exception)
             }
         }).build()
 
-        realm = Realm.open(config)
+        val realm = Realm.open(config)
         (realm.syncSession as io.realm.kotlin.mongodb.internal.SyncSessionImpl).simulateError(
             ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
             SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
         )
         val exception = channel.receive()
+
+        realm.close()
+        exception.executeClientReset()
+
         assertNotNull(exception.recoveryFilePath)
         assertNotNull(exception.originalFilePath)
         assertFalse(fileExists(exception.originalFilePath))
@@ -536,7 +553,8 @@ class SyncSessionTests {
     }
 
     @Test
-    fun errorHandler_recoverUnsyncedChangesStrategy_resetErrorHandled() = runBlocking {
+    fun recoverUnsyncedChangesStrategy_resetErrorHandled() = runBlocking {
+        println("---> recoverUnsyncedChangesStrategy_resetErrorHandled")
         val channel = Channel<ClientResetRequiredException>(1)
         val config = SyncConfiguration.Builder(
             user,
@@ -599,6 +617,7 @@ class SyncSessionTests {
      */
     @Test
     fun syncingObjectIdFromMongoDB() {
+        println("---> syncingObjectIdFromMongoDB")
         val adminApi = app.asTestApp
         runBlocking {
             val config =
@@ -642,6 +661,7 @@ class SyncSessionTests {
      */
     @Test
     fun syncingObjectIdFromRealm() {
+        println("---> syncingObjectIdFromRealm")
         val adminApi = app.asTestApp
         val objectId = ObjectId.create()
         val oid = objectId.toString()

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
@@ -384,7 +384,7 @@ class SyncSessionTests {
             user,
             partitionValue,
             schema = setOf(ParentPk::class, ChildPk::class)
-        ).syncClientResetStrategy(object: RecoverOrDiscardUnsyncedChangesStrategy {
+        ).syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
                 fail("This test case was not supposed to trigger RecoverOrDiscardUnsyncedChangesStrategy::onBeforeReset()")
             }
@@ -425,7 +425,7 @@ class SyncSessionTests {
             user,
             partitionValue,
             schema = setOf(ParentPk::class, ChildPk::class)
-        ).syncClientResetStrategy(object: RecoverUnsyncedChangesStrategy {
+        ).syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
                 fail("This test case was not supposed to trigger RecoverUnsyncedChangesStrategy::onBeforeReset()")
             }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
@@ -253,19 +253,17 @@ class SyncedRealmTests {
         // This way we assert we don't read wrong data from the user_info field
         runBlocking {
             app.asTestApp.changeSyncPermissions(SyncPermissions(read = false, write = false)) {
-                runBlocking {
-                    val deferred = async { Realm.open(config) }
+                val deferred = async { Realm.open(config) }
 
-                    val error = channel.receive()
-                    assertTrue(error is UnrecoverableSyncException)
-                    val message = error.message
-                    assertNotNull(message)
-                    assertTrue(
-                        message.toLowerCase().contains("permission denied"),
-                        "The error should be 'PermissionDenied' but it was: $message"
-                    )
-                    deferred.cancel()
-                }
+                val error = channel.receive()
+                assertTrue(error is UnrecoverableSyncException)
+                val message = error.message
+                assertNotNull(message)
+                assertTrue(
+                    message.toLowerCase().contains("permission denied"),
+                    "The error should be 'PermissionDenied' but it was: $message"
+                )
+                deferred.cancel()
             }
         }
     }

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AdminApi.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AdminApi.kt
@@ -269,7 +269,6 @@ open class AdminApiImpl internal constructor(
         }.let {
             it.first().jsonObject["_id"]!!.jsonPrimitive.content
         }
-        val kajhsdkjh = 0
         return result
     }
 
@@ -429,8 +428,8 @@ open class AdminApiImpl internal constructor(
                 block?.invoke()
 
                 // 5 - trigger client reset
-                // TODO test adding "__realm_sync_${appId}"
                 deleteMDBDocumentByQuery("__realm_sync", "clientfiles", "{ownerId: \"$userId\"}")
+                deleteMDBDocumentByQuery("__realm_sync_${appId}", "clientfiles", "{ownerId: \"$userId\"}")
 
                 // 6 - resume session
                 session.resume()

--- a/tools/sync_test_server/stop_local_server.sh
+++ b/tools/sync_test_server/stop_local_server.sh
@@ -14,12 +14,14 @@ fi
 if [[ -n "$BAAS_PID" ]]; then
     echo "Stopping baas $BAAS_PID"
     kill -9 "$BAAS_PID"
+    rm "$WORK_PATH/baas_server.pid"
 fi
 
 
 if [[ -n "$MONGOD_PID" ]]; then
     echo "Killing mongod $MONGOD_PID"
     kill -9 "$MONGOD_PID"
+    rm "$WORK_PATH/mongod.pid"
 fi
 
 docker stop mongodb-realm-command-server -t0


### PR DESCRIPTION
Added `RecoverUnsycedChangesStrategy` and `RecoverOrDiscardUnsyncedChangesStrategy` and lifted restrictions on strategies depending on the Sync mode.

Similarly to the Java implementation (https://github.com/realm/realm-java/pull/7698) the API for `RecoverOrDiscardUnsyncedChangesStrategy` has
```
    public fun onAfterRecovery(before: TypedRealm, after: MutableRealm)
    public fun onAfterDiscard(before: TypedRealm, after: MutableRealm)
```
instead of the standard `onAfter` callback.

TODO:
- [x] decide whether we should change the default strategy to be `RecoverOrDiscardUnsycedChanges` to avoid breaking changes? Ask other SDKs about this.