### PR TITLE
Sandbox server apps to each test case

### DIFF
--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/SyncClientResetIntegrationJVMTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/SyncClientResetIntegrationJVMTests.kt
@@ -29,6 +29,7 @@ import io.realm.kotlin.mongodb.sync.DiscardUnsyncedChangesStrategy
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncSession
 import io.realm.kotlin.mongodb.syncSession
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -56,7 +57,7 @@ class SyncClientResetIntegrationJVMTests {
     @BeforeTest
     fun setup() {
         partitionValue = TestHelper.randomPartitionValue()
-        app = TestApp(
+        app = PartitionBasedApp(
             logLevel = LogLevel.INFO
         )
         val (email, password) = TestHelper.randomEmail() to "password1234"

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
@@ -20,7 +20,7 @@ import io.realm.kotlin.internal.platform.appFilesDirectory
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.AppConfiguration
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
-import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -144,7 +144,7 @@ class AppConfigurationTests {
     @Test
     fun syncRootDirectory_appendDirectoryToPath() = runBlocking {
         val expectedRoot = "${appFilesDirectory()}/myCustomDir"
-        val app = TestApp(builder = {
+        val app = PartitionBasedApp(builder = {
             it.syncRootDirectory(expectedRoot)
         })
         val (email, password) = TestHelper.randomEmail() to "password1234"

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
@@ -22,7 +22,7 @@ import io.realm.kotlin.mongodb.AuthenticationProvider
 import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.exceptions.InvalidCredentialsException
-import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -44,7 +44,7 @@ class AppTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp()
+        app = PartitionBasedApp()
     }
 
     @AfterTest

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/CredentialsTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/CredentialsTests.kt
@@ -22,7 +22,7 @@ import io.realm.kotlin.mongodb.AuthenticationProvider
 import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.GoogleAuthType
 import io.realm.kotlin.mongodb.exceptions.AppException
-import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -177,7 +177,7 @@ class CredentialsTests {
 
     @Test
     fun loginUsingCredentials() {
-        app = TestApp()
+        app = PartitionBasedApp()
         runBlocking {
             AuthenticationProvider.values().forEach { provider ->
                 when (provider) {

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
@@ -11,6 +11,8 @@ import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
 import io.realm.kotlin.mongodb.exceptions.UserNotFoundException
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
+import io.realm.kotlin.test.mongodb.util.AdminApi
+import io.realm.kotlin.test.mongodb.util.AppConfigs
 import io.realm.kotlin.test.util.TestHelper
 import kotlin.random.Random
 import kotlin.random.nextULong
@@ -29,7 +31,18 @@ class EmailPasswordAuthTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp()
+        app = TestApp {
+            addFunction(AppConfigs.confirmFunc, AppConfigs.resetFunc)
+
+            val localUserAuthProvider = AppConfigs.localUserAuthProviderBuilder(
+                functions[AppConfigs.confirmFunc.name],
+                functions[AppConfigs.resetFunc.name],
+            )
+
+            addAuthProvider(localUserAuthProvider)
+
+            setPartition()
+        }
         runBlocking {
             app.setCustomConfirmation(false)
             app.setAutomaticConfirmation(true)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
@@ -11,7 +11,6 @@ import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
 import io.realm.kotlin.mongodb.exceptions.UserNotFoundException
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
-import io.realm.kotlin.test.mongodb.util.AdminApi
 import io.realm.kotlin.test.mongodb.util.AppConfigs
 import io.realm.kotlin.test.util.TestHelper
 import kotlin.random.Random
@@ -31,7 +30,7 @@ class EmailPasswordAuthTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp {
+        app = TestApp("email-auth") {
             addFunction(AppConfigs.confirmFunc, AppConfigs.resetFunc)
 
             val localUserAuthProvider = AppConfigs.localUserAuthProviderBuilder(
@@ -42,10 +41,6 @@ class EmailPasswordAuthTests {
             addAuthProvider(localUserAuthProvider)
 
             setPartition()
-        }
-        runBlocking {
-            app.setCustomConfirmation(false)
-            app.setAutomaticConfirmation(true)
         }
     }
 

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncConfigurationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncConfigurationTests.kt
@@ -22,8 +22,7 @@ import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.sync.InitialSubscriptionsCallback
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncMode
-import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
-import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.FlexibleBasedApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -44,7 +43,7 @@ class FlexibleSyncConfigurationTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(appName = TEST_APP_FLEX)
+        app = FlexibleBasedApp()
         val (email, password) = TestHelper.randomEmail() to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncIntegrationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncIntegrationTests.kt
@@ -25,7 +25,7 @@ import io.realm.kotlin.mongodb.exceptions.DownloadingRealmTimeOutException
 import io.realm.kotlin.mongodb.subscriptions
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.syncSession
-import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
+import io.realm.kotlin.test.mongodb.FlexibleBasedApp
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -54,7 +54,7 @@ class FlexibleSyncIntegrationTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(appName = TEST_APP_FLEX)
+        app = FlexibleBasedApp()
         val (email, password) = TestHelper.randomEmail() to "password1234"
         runBlocking {
             app.createUserAndLogIn(email, password)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/MutableSubscriptionSetTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/MutableSubscriptionSetTests.kt
@@ -25,7 +25,7 @@ import io.realm.kotlin.mongodb.subscriptions
 import io.realm.kotlin.mongodb.sync.Subscription
 import io.realm.kotlin.mongodb.sync.SubscriptionSetState
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
-import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
+import io.realm.kotlin.test.mongodb.FlexibleBasedApp
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -53,7 +53,7 @@ class MutableSubscriptionSetTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(appName = TEST_APP_FLEX)
+        app = FlexibleBasedApp()
         val (email, password) = TestHelper.randomEmail() to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SubscriptionSetTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SubscriptionSetTests.kt
@@ -25,8 +25,8 @@ import io.realm.kotlin.mongodb.subscriptions
 import io.realm.kotlin.mongodb.sync.Subscription
 import io.realm.kotlin.mongodb.sync.SubscriptionSetState
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
-import io.realm.kotlin.test.mongodb.TEST_APP_1
-import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
+import io.realm.kotlin.test.mongodb.FlexibleBasedApp
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -55,7 +55,7 @@ class SubscriptionSetTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(appName = TEST_APP_FLEX)
+        app = FlexibleBasedApp()
         val (email, password) = TestHelper.randomEmail() to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)
@@ -88,7 +88,7 @@ class SubscriptionSetTests {
 
     @Test
     fun subscriptions_failOnNonFlexibleSyncRealms() {
-        val app = TestApp(appName = TEST_APP_1)
+        val app = PartitionBasedApp()
         val (email, password) = TestHelper.randomEmail() to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SubscriptionTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SubscriptionTests.kt
@@ -26,6 +26,7 @@ import io.realm.kotlin.mongodb.sync.SubscriptionSet
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.asQuery
 import io.realm.kotlin.query.RealmQuery
+import io.realm.kotlin.test.mongodb.FlexibleBasedApp
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper.randomEmail
@@ -55,7 +56,7 @@ class SubscriptionTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp()
+        app = FlexibleBasedApp()
         val (email, password) = randomEmail() to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
@@ -37,6 +37,7 @@ import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncSession
 import io.realm.kotlin.mongodb.syncSession
 import io.realm.kotlin.notifications.ResultsChange
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -110,7 +111,7 @@ class SyncClientResetIntegrationTests {
     fun setup() {
         partitionValue = TestHelper.randomPartitionValue()
         logChannel = Channel(5)
-        app = TestApp(
+        app = PartitionBasedApp(
             logLevel = LogLevel.INFO,
             customLogger = ClientResetLoggerInspector(logChannel)
         )

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
@@ -37,7 +37,7 @@ import io.realm.kotlin.mongodb.sync.ManuallyRecoverUnsyncedChangesStrategy
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncMode
 import io.realm.kotlin.mongodb.sync.SyncSession
-import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
@@ -70,7 +70,7 @@ class SyncConfigTests {
     @BeforeTest
     fun setup() {
         partitionValue = TestHelper.randomPartitionValue()
-        app = TestApp()
+        app = PartitionBasedApp()
     }
 
     @AfterTest

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
@@ -34,6 +34,7 @@ import io.realm.kotlin.mongodb.sync.DiscardUnsyncedChangesStrategy
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncSession
 import io.realm.kotlin.mongodb.syncSession
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
@@ -70,7 +71,7 @@ class SyncSessionTests {
     @BeforeTest
     fun setup() {
         partitionValue = TestHelper.randomPartitionValue()
-        app = TestApp()
+        app = PartitionBasedApp()
         val (email, password) = TestHelper.randomEmail() to "password1234"
         user = runBlocking {
             app.createUserAndLogIn(email, password)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/UserTests.kt
@@ -20,7 +20,7 @@ import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
-import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.util.TestHelper.randomEmail
 import kotlin.test.AfterTest
@@ -43,7 +43,7 @@ class UserTests {
 
     @BeforeTest
     fun setUp() {
-        app = TestApp()
+        app = PartitionBasedApp()
     }
 
     @AfterTest

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
@@ -6,6 +6,7 @@ import io.realm.kotlin.ext.query
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
@@ -32,7 +33,7 @@ class NonLatinTests {
     @BeforeTest
     fun setup() {
         partitionValue = TestHelper.randomPartitionValue()
-        app = TestApp()
+        app = PartitionBasedApp()
         val (email, password) = TestHelper.randomEmail() to "password1234"
         user = runBlocking {
             app.createUserAndLogIn(email, password)

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
@@ -36,7 +36,7 @@ import io.realm.kotlin.mongodb.sync.SyncSession
 import io.realm.kotlin.mongodb.sync.SyncSession.ErrorHandler
 import io.realm.kotlin.mongodb.syncSession
 import io.realm.kotlin.notifications.ResultsChange
-import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.PartitionBasedApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.mongodb.shared.DEFAULT_NAME
@@ -87,7 +87,7 @@ class SyncedRealmTests {
     @BeforeTest
     fun setup() {
         partitionValue = TestHelper.randomPartitionValue()
-        app = TestApp()
+        app = PartitionBasedApp()
 
         val (email, password) = randomEmail() to "password1234"
         val user = runBlocking {

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
@@ -66,15 +66,17 @@ class TestApp private constructor(
         dispatcher: CoroutineDispatcher = singleThreadDispatcher("test-app-dispatcher"),
         logLevel: LogLevel = LogLevel.WARN,
         builder: (AppConfiguration.Builder) -> AppConfiguration.Builder = { it },
-        debug: Boolean = false,
-        customLogger: RealmLogger? = null
+        debug: Boolean = true,
+        customLogger: RealmLogger? = null,
+        customAdminApiBuilder: suspend AdminApi.Builder.() -> Unit = {},
     ) : this(
         TestAppBuilder(
             adminApi = AdminApiImpl(
                 baseUrl = TEST_SERVER_BASE_URL,
                 appName = appName,
                 debug = debug,
-                dispatcher = dispatcher
+                dispatcher = dispatcher,
+                customBuilder = customAdminApiBuilder
             ),
             logLevel = logLevel,
             customLogger = customLogger,

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
@@ -76,6 +76,8 @@ class TestApp private constructor(
                 debug = debug,
                 dispatcher = dispatcher
             ),
+            logLevel = logLevel,
+            customLogger = customLogger,
             dispatcher = dispatcher,
             builder = builder
         ),
@@ -97,10 +99,7 @@ class TestApp private constructor(
         // This is needed to "properly reset" all sessions across tests since deleting users
         // directly using the REST API doesn't do the trick
         runBlocking {
-            while (currentUser != null) {
-                currentUser.logOut()
-            }
-            deleteAllUsers()
+            deleteApp()
         }
 
         // Close network client resources
@@ -116,17 +115,19 @@ class TestApp private constructor(
 
 class TestAppBuilder(
     val adminApi: AdminApi,
+    val logLevel: LogLevel,
+    val customLogger: RealmLogger?,
     val dispatcher: CoroutineDispatcher,
     val builder: (AppConfiguration.Builder) -> AppConfiguration.Builder,
 ) {
     val app: App by lazy {
         val config = AppConfiguration.Builder(adminApi.getClientAppId())
             .baseUrl(TEST_SERVER_BASE_URL)
-        // .log(
-        //     logLevel,
-        //     if (customLogger == null) emptyList<RealmLogger>()
-        //     else listOf<RealmLogger>(customLogger)
-        // )
+            .log(
+                logLevel,
+                if (customLogger == null) emptyList<RealmLogger>()
+                else listOf<RealmLogger>(customLogger)
+            )
 
         App.create(
             builder(config)

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AdminApi.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AdminApi.kt
@@ -69,9 +69,7 @@ interface AdminApi {
 
     public val dispatcher: CoroutineDispatcher
 
-    val app: App
-
-    suspend fun getClientAppId(appName: String): String
+    fun getClientAppId(): String
 
     /**
      * Deletes all currently registered and pending users on the App Services Application .
@@ -143,7 +141,6 @@ data class SyncPermissions(
 open class AdminApiImpl constructor(
     baseUrl: String,
     private val appName: String,
-    private val builder: (AppConfiguration.Builder) -> AppConfiguration.Builder,
     private val debug: Boolean,
     override val dispatcher: CoroutineDispatcher,
 ) : AdminApi {
@@ -225,21 +222,6 @@ open class AdminApiImpl constructor(
 
             createApp()
         }
-    }
-
-    override val app: App by lazy{
-        val config = AppConfiguration.Builder(serverApp.client_app_id)
-            .baseUrl(TEST_SERVER_BASE_URL)
-            // .log(
-            //     logLevel,
-            //     if (customLogger == null) emptyList<RealmLogger>()
-            //     else listOf<RealmLogger>(customLogger)
-            // )
-
-        App.create(
-            builder(config)
-                .dispatcher(dispatcher)
-                .build())
     }
 
     private suspend fun createApp() {
@@ -435,14 +417,7 @@ open class AdminApiImpl constructor(
         requestBody = Json.parseToJsonElement(userDataConfig).jsonObject
     )
 
-    override suspend fun getClientAppId(appName: String): String = withContext(dispatcher) {
-        // Get app id
-        client.typedRequest<JsonArray>(Get, "$url/groups/$groupId/apps")
-            .firstOrNull {
-                it.jsonObject["name"]?.jsonPrimitive?.content == appName
-            }?.jsonObject?.get("client_app_id")?.jsonPrimitive?.content
-            ?: error("App $appName not found")
-    }
+    override fun getClientAppId(): String = serverApp.client_app_id
 
     /**
      * Deletes all currently registered and pending users on the App Services Application.

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AppConfigs.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AppConfigs.kt
@@ -1,29 +1,108 @@
 package io.realm.kotlin.test.mongodb.util
 
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+
+@Serializable
+data class AppFunction constructor(
+    val name: String,
+    val source: String,
+    val private: Boolean = false,
+)
+
+@Serializable
+data class AppAuthProvider constructor(
+    val name: String,
+    val type: String,
+    val config: Map<String, JsonPrimitive?>? = null,
+    val disabled: Boolean = false
+)
+//
+// @Serializable
+// sealed interface SyncConfig
+//
+// @Serializable
+// class PartitionSync(
+//     val db: String,
+//     enabled: Boolean,
+//     key: String,
+//     type: String,
+//     required: Boolean,
+//     permissions: JsonObject
+// ) : SyncConfig {
+//     val sync = buildJsonObject {
+//         put("state", if (enabled) "enabled" else "disabled")
+//         put("database_name", db)
+//         put("partition", buildJsonObject {
+//             put("key", key)
+//             put("type", type)
+//             put("required", required)
+//             put("permissions", permissions)
+//         })
+//     }
+// }
+// @Serializable
+// class FlexibleSync(
+//     db: String,
+//     enabled: Boolean,
+//     queryableFieldsName: List<String>,
+//     permissions: JsonObject
+// ) : SyncConfig {
+//     @SerialName("flexible_sync")
+//     val flexibleSync = buildJsonObject {
+//         // put("state", if (enabled) "enabled" else "disabled")
+//         // put("database_name", db)
+//         putJsonArray("queryable_fields_names", buildJsonArray {
+//             this.add("")
+//         }
+//         )
+//         // put("permissions", permissions)
+//     }
+//
+//     //"flexible_sync": {
+//     //                     "state": "enabled",
+//     //                     "database_name": "$dbName",
+//     //                     "queryable_fields_names": ["name", "section"],
+//     //                     "permissions": {
+//     //                         "rules": {},
+//     //                         "defaultRoles": [{
+//     //                             "name": "all",
+//     //                             "applyWhen": {},
+//     //                             "read": true,
+//     //                             "write": true
+//     //                         }]
+//     //                     }
+//     //                 }
+// }
 
 object AppConfigs {
-    private fun buildFunction(name: String, function: String) = buildJsonObject {
-        put("name", name)
-        put("private", false)
-        put("source", function)
-    }
+    val forwardAsPatch = AppFunction(
+        name = "forwardAsPatch",
+        source = """
+                    exports = async function (url, body) {
+                        const response = await context.http.patch({
+                            url: url,
+                            body: body,
+                            headers: context.request.requestHeaders,
+                            encodeBodyAsJSON: true
+                        });
+            
+                        return response;
+                    };
+                """
+    )
 
-    val functions = listOf(
-        buildFunction("forwardAsPatch", """
-            exports = async function (url, body) {
-                const response = await context.http.patch({
-                    url: url,
-                    body: body,
-                    headers: context.request.requestHeaders,
-                    encodeBodyAsJSON: true
-                });
-    
-                return response;
-            };
-        """.trimIndent()),
-        buildFunction("insertDocument", """
+    val insertDocument = AppFunction(
+        name = "insertDocument", source = """
             exports = function (service, db, collection, document) {
                 const mongodb = context.services.get(service);
                 const result = mongodb
@@ -33,8 +112,10 @@ object AppConfigs {
             
                 return result;
             };
-        """.trimIndent()),
-        buildFunction("deleteDocument", """
+        """
+    )
+    val deleteDocument = AppFunction(
+        name = "deleteDocument", source = """
             exports = function (service, db, collection, query) {
                 const mongodb = context.services.get(service);
                 const result = mongodb
@@ -44,8 +125,10 @@ object AppConfigs {
             
                 return result;
             };
-        """.trimIndent()),
-        buildFunction("queryDocument", """
+        """
+    )
+    val queryDocument = AppFunction(
+        name = "queryDocument", source = """
             exports = function (service, db, collection, query) {
                 const mongodb = context.services.get(service);
                 const result = mongodb
@@ -55,8 +138,10 @@ object AppConfigs {
             
                 return result;
             };
-        """.trimIndent()),
-        buildFunction("testAuthFunc", """
+        """
+    )
+    val testAuthFunc = AppFunction(
+        name = "testAuthFunc", source = """
             exports = ({mail, id}) => {
                 // Auth function will fail for emails with a domain different to @androidtest.realm.io
                 // or with id lower than 666
@@ -67,8 +152,10 @@ object AppConfigs {
                     return mail;
                 }
             }
-        """.trimIndent()),
-        buildFunction("confirmFunc", """
+        """
+    )
+    val confirmFunc = AppFunction(
+        name = "confirmFunc", source = """
             exports = async ({ token, tokenId, username }) => {
                 // process the confirm token, tokenId and username
             
@@ -92,8 +179,10 @@ object AppConfigs {
                   return { status: 'fail' };
                 }
               };
-        """.trimIndent()),
-        buildFunction("resetFunc", """
+        """
+    )
+    val resetFunc = AppFunction(
+        name = "resetFunc", source = """
             exports = ({ token, tokenId, username, password }, customParam1, customParam2) => {
                 if (customParam1 != "say-the-magic-word" || customParam2 != 42) {
                     return { status: 'fail' };
@@ -101,43 +190,42 @@ object AppConfigs {
                     return { status: 'success' };
                 }
             }
-        """.trimIndent())
-    )
-    fun authProviders(functionIds: Map<String, String>) = listOf(
-        """                
-            {
-                "name": "anon-user",
-                "type": "anon-user",
-                "disabled": false
-            }
-        """.trimIndent(), """                
-            {
-                "name": "custom-function",
-                "type": "custom-function",
-                "config": {
-                    "authFunctionId": "${functionIds["testAuthFunc"]}",
-                    "authFunctionName": "testAuthFunc"
-                },
-                "disabled": false
-            }
-        """.trimIndent(), """
-            {
-                "name": "local-userpass",
-                "type": "local-userpass",
-                "config": {
-                    "autoConfirm": true,
-                    "confirmationFunctionId": "${functionIds["confirmFunc"]}",
-                    "confirmationFunctionName": "confirmFunc",
-                    "emailConfirmationUrl": "http://realm.io/confirm-user",
-                    "resetFunctionId": "${functionIds["resetFunc"]}",
-                    "resetFunctionName": "resetFunc",
-                    "resetPasswordSubject": "Reset Password",
-                    "resetPasswordUrl": "http://realm.io/reset-password",
-                    "runConfirmationFunction": false,
-                    "runResetFunction": false
-                },
-                "disabled": false
-            }
         """.trimIndent()
+    )
+
+    val anonymousAuthProvider = AppAuthProvider(
+        name = "anon-user",
+        type = "anon-user"
+    )
+
+    fun customAuthProviderBuilder(
+        confirmationFunction: Pair<String, String>
+    ) = AppAuthProvider(
+        name = "custom-function",
+        type = "custom-function",
+        config = mapOf(
+            "authFunctionId" to JsonPrimitive(confirmationFunction.first),
+            "authFunctionName" to JsonPrimitive(confirmationFunction.second)
+        )
+    )
+
+    fun localUserAuthProviderBuilder(
+        confirmationFunction: Pair<String, String>?,
+        resetFunction: Pair<String, String>?,
+    ) = AppAuthProvider(
+        name = "local-userpass",
+        type = "local-userpass",
+        config = mapOf(
+            "autoConfirm" to JsonPrimitive(true),
+            "confirmationFunctionId" to JsonPrimitive(confirmationFunction?.first),
+            "confirmationFunctionName" to JsonPrimitive(confirmationFunction?.second),
+            "emailConfirmationUrl" to JsonPrimitive("http://realm.io/confirm-user"),
+            "resetFunctionId" to JsonPrimitive(resetFunction?.first),
+            "resetFunctionName" to JsonPrimitive(resetFunction?.second),
+            "resetPasswordSubject" to JsonPrimitive("Reset Password"),
+            "resetPasswordUrl" to JsonPrimitive("http://realm.io/reset-password"),
+            "runConfirmationFunction" to JsonPrimitive((confirmationFunction != null)),
+            "runResetFunction" to JsonPrimitive((resetFunction != null))
+        )
     )
 }

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AppConfigs.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AppConfigs.kt
@@ -1,16 +1,7 @@
 package io.realm.kotlin.test.mongodb.util
 
-import kotlinx.serialization.Contextual
-import kotlinx.serialization.Polymorphic
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.add
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putJsonArray
 
 @Serializable
 data class AppFunction constructor(
@@ -102,7 +93,8 @@ object AppConfigs {
     )
 
     val insertDocument = AppFunction(
-        name = "insertDocument", source = """
+        name = "insertDocument",
+        source = """
             exports = function (service, db, collection, document) {
                 const mongodb = context.services.get(service);
                 const result = mongodb
@@ -115,7 +107,8 @@ object AppConfigs {
         """
     )
     val deleteDocument = AppFunction(
-        name = "deleteDocument", source = """
+        name = "deleteDocument",
+        source = """
             exports = function (service, db, collection, query) {
                 const mongodb = context.services.get(service);
                 const result = mongodb
@@ -128,7 +121,8 @@ object AppConfigs {
         """
     )
     val queryDocument = AppFunction(
-        name = "queryDocument", source = """
+        name = "queryDocument",
+        source = """
             exports = function (service, db, collection, query) {
                 const mongodb = context.services.get(service);
                 const result = mongodb
@@ -141,7 +135,8 @@ object AppConfigs {
         """
     )
     val testAuthFunc = AppFunction(
-        name = "testAuthFunc", source = """
+        name = "testAuthFunc",
+        source = """
             exports = ({mail, id}) => {
                 // Auth function will fail for emails with a domain different to @androidtest.realm.io
                 // or with id lower than 666
@@ -155,7 +150,8 @@ object AppConfigs {
         """
     )
     val confirmFunc = AppFunction(
-        name = "confirmFunc", source = """
+        name = "confirmFunc",
+        source = """
             exports = async ({ token, tokenId, username }) => {
                 // process the confirm token, tokenId and username
             
@@ -182,7 +178,8 @@ object AppConfigs {
         """
     )
     val resetFunc = AppFunction(
-        name = "resetFunc", source = """
+        name = "resetFunc",
+        source = """
             exports = ({ token, tokenId, username, password }, customParam1, customParam2) => {
                 if (customParam1 != "say-the-magic-word" || customParam2 != 42) {
                     return { status: 'fail' };
@@ -210,13 +207,16 @@ object AppConfigs {
     )
 
     fun localUserAuthProviderBuilder(
-        confirmationFunction: Pair<String, String>?,
-        resetFunction: Pair<String, String>?,
+        confirmationFunction: Pair<String, String>? = null,
+        resetFunction: Pair<String, String>? = null,
+        runConfirmationFunction: Boolean = false,
+        runResetFunction: Boolean = false,
+        autoConfirm: Boolean = true
     ) = AppAuthProvider(
         name = "local-userpass",
         type = "local-userpass",
         config = mapOf(
-            "autoConfirm" to JsonPrimitive(true),
+            "autoConfirm" to JsonPrimitive(autoConfirm),
             "confirmationFunctionId" to JsonPrimitive(confirmationFunction?.first),
             "confirmationFunctionName" to JsonPrimitive(confirmationFunction?.second),
             "emailConfirmationUrl" to JsonPrimitive("http://realm.io/confirm-user"),
@@ -224,8 +224,8 @@ object AppConfigs {
             "resetFunctionName" to JsonPrimitive(resetFunction?.second),
             "resetPasswordSubject" to JsonPrimitive("Reset Password"),
             "resetPasswordUrl" to JsonPrimitive("http://realm.io/reset-password"),
-            "runConfirmationFunction" to JsonPrimitive((confirmationFunction != null)),
-            "runResetFunction" to JsonPrimitive((resetFunction != null))
+            "runConfirmationFunction" to JsonPrimitive(runConfirmationFunction),
+            "runResetFunction" to JsonPrimitive(runResetFunction)
         )
     )
 }

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AppConfigs.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AppConfigs.kt
@@ -1,0 +1,143 @@
+package io.realm.kotlin.test.mongodb.util
+
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+object AppConfigs {
+    private fun buildFunction(name: String, function: String) = buildJsonObject {
+        put("name", name)
+        put("private", false)
+        put("source", function)
+    }
+
+    val functions = listOf(
+        buildFunction("forwardAsPatch", """
+            exports = async function (url, body) {
+                const response = await context.http.patch({
+                    url: url,
+                    body: body,
+                    headers: context.request.requestHeaders,
+                    encodeBodyAsJSON: true
+                });
+    
+                return response;
+            };
+        """.trimIndent()),
+        buildFunction("insertDocument", """
+            exports = function (service, db, collection, document) {
+                const mongodb = context.services.get(service);
+                const result = mongodb
+                    .db(db)
+                    .collection(collection)
+                    .insertOne(document);
+            
+                return result;
+            };
+        """.trimIndent()),
+        buildFunction("deleteDocument", """
+            exports = function (service, db, collection, query) {
+                const mongodb = context.services.get(service);
+                const result = mongodb
+                    .db(db)
+                    .collection(collection)
+                    .deleteMany(EJSON.parse(query));
+            
+                return result;
+            };
+        """.trimIndent()),
+        buildFunction("queryDocument", """
+            exports = function (service, db, collection, query) {
+                const mongodb = context.services.get(service);
+                const result = mongodb
+                    .db(db)
+                    .collection(collection)
+                    .findOne(EJSON.parse(query));
+            
+                return result;
+            };
+        """.trimIndent()),
+        buildFunction("testAuthFunc", """
+            exports = ({mail, id}) => {
+                // Auth function will fail for emails with a domain different to @androidtest.realm.io
+                // or with id lower than 666
+                if (!new RegExp("@androidtest.realm.io${'$'}").test(mail) || id < 666) {
+                    return 0;
+                } else {
+                    // Use the users email as UID
+                    return mail;
+                }
+            }
+        """.trimIndent()),
+        buildFunction("confirmFunc", """
+            exports = async ({ token, tokenId, username }) => {
+                // process the confirm token, tokenId and username
+            
+                if (username.includes("realm_verify")) {
+                  // Automatically confirm users with `realm_verify` in their email.
+                  return { status: 'success' }
+                } else if (username.includes("realm_pending")) {
+                  // Emails with `realm_pending` in their email will be placed in Pending
+                  // the first time they register and will then be fully confirmed when
+                  // they retry their confirmation logic.
+                  const mdb = context.services.get("BackingDB");
+                  const collection = mdb.db("custom-auth").collection("users");
+                  const existing = await collection.findOne({ username: username });
+                  if (existing) {
+                      return { status: 'success' };
+                  }
+                  await collection.insertOne({ username: username });
+                  return { status: 'pending' }
+                } else {
+                  // All other emails should fail to confirm outright.
+                  return { status: 'fail' };
+                }
+              };
+        """.trimIndent()),
+        buildFunction("resetFunc", """
+            exports = ({ token, tokenId, username, password }, customParam1, customParam2) => {
+                if (customParam1 != "say-the-magic-word" || customParam2 != 42) {
+                    return { status: 'fail' };
+                } else {
+                    return { status: 'success' };
+                }
+            }
+        """.trimIndent())
+    )
+    fun authProviders(functionIds: Map<String, String>) = listOf(
+        """                
+            {
+                "name": "anon-user",
+                "type": "anon-user",
+                "disabled": false
+            }
+        """.trimIndent(), """                
+            {
+                "name": "custom-function",
+                "type": "custom-function",
+                "config": {
+                    "authFunctionId": "${functionIds["testAuthFunc"]}",
+                    "authFunctionName": "testAuthFunc"
+                },
+                "disabled": false
+            }
+        """.trimIndent(), """
+            {
+                "name": "local-userpass",
+                "type": "local-userpass",
+                "config": {
+                    "autoConfirm": true,
+                    "confirmationFunctionId": "${functionIds["confirmFunc"]}",
+                    "confirmationFunctionName": "confirmFunc",
+                    "emailConfirmationUrl": "http://realm.io/confirm-user",
+                    "resetFunctionId": "${functionIds["resetFunc"]}",
+                    "resetFunctionName": "resetFunc",
+                    "resetPasswordSubject": "Reset Password",
+                    "resetPasswordUrl": "http://realm.io/reset-password",
+                    "runConfirmationFunction": false,
+                    "runResetFunction": false
+                },
+                "disabled": false
+            }
+        """.trimIndent()
+    )
+}


### PR DESCRIPTION
The current approach to sync tests is to share a common App and database on the server. It can present some issues as if a test case modifies the server configuration and fails to revert it, the following test cases might fail. In such cases, it would be almost impossible to know that the cause of that failing test is a wrong server configuration.

With this PR we introduce App sandboxing, each test would have its own App and database. In this way, all the changes to the Realm app would be isolated to the test execution and would be discarded afterward.

It is also a step towards being able to run tests in parallel.