### PR TITLE
Fix erroneous package name in proguard consumer file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 1.0.2 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* Missing proguard configuration for `CoreErrorUtils`. (Issue [#942](https://github.com/realm/realm-kotlin/issues/942))
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10 and above.
+  * Coroutines 1.6.0-native-mt. Also compatible with Coroutines 1.6.0 but requires enabling of the new memory model and disabling of freezing, see https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility for details on that.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.0.1 (2022-07-07)
 
 ### Breaking Changes

--- a/packages/cinterop/src/jvm/jni/java_class_global_def.hpp
+++ b/packages/cinterop/src/jvm/jni/java_class_global_def.hpp
@@ -47,18 +47,19 @@ private:
         , m_java_lang_int(env, "java/lang/Integer", false)
         , m_kotlin_jvm_functions_function0(env, "kotlin/jvm/functions/Function0", false)
         , m_kotlin_jvm_functions_function1(env, "kotlin/jvm/functions/Function1", false)
-        , m_io_realm_kotlinnetwork_transport(env, "io/realm/kotlin/internal/interop/sync/NetworkTransport", false)
-        , m_io_realm_kotlinresponse(env, "io/realm/kotlin/internal/interop/sync/Response", false)
-        , m_io_realm_kotlinlong_pointer_wrapper(env, "io/realm/kotlin/internal/interop/LongPointerWrapper", false)
-        , m_io_realm_kotlininternal_interop_sync_sync_error(env, "io/realm/kotlin/internal/interop/sync/SyncError", false)
-        , m_io_realm_kotlininternal_interop_sync_app_error(env, "io/realm/kotlin/internal/interop/sync/AppError", false)
-        , m_io_realm_kotlinsync_log_callback(env, "io/realm/kotlin/internal/interop/SyncLogCallback", false)
-        , m_io_realm_kotlinsync_error_callback(env, "io/realm/kotlin/internal/interop/SyncErrorCallback", false)
-        , m_io_realm_kotlinsync_session_transfer_completion_callback(env, "io/realm/kotlin/internal/interop/sync/JVMSyncSessionTransferCompletionCallback", false)
-        , m_io_realm_kotlininternal_interop_sync_response_callback(env, "io/realm/kotlin/internal/interop/sync/ResponseCallbackImpl", false)
-        , m_io_realm_kotlininternal_interop_sync_subscriptionset_changed_callback(env, "io/realm/kotlin/internal/interop/SubscriptionSetCallback", false)
-        , m_io_realm_kotlinsync_interop_sync_before_client_reset_handler(env, "io/realm/kotlin/internal/interop/SyncBeforeClientResetHandler", false)
-        , m_io_realm_kotlinsync_interop_sync_after_client_reset_handler(env, "io/realm/kotlin/internal/interop/SyncAfterClientResetHandler", false)
+        , m_io_realm_kotlin_internal_interop_sync_network_transport(env, "io/realm/kotlin/internal/interop/sync/NetworkTransport", false)
+        , m_io_realm_kotlin_internal_interop_sync_response(env, "io/realm/kotlin/internal/interop/sync/Response", false)
+        , m_io_realm_kotlin_internal_interop_long_pointer_wrapper(env, "io/realm/kotlin/internal/interop/LongPointerWrapper", false)
+        , m_io_realm_kotlin_internal_interop_sync_sync_error(env, "io/realm/kotlin/internal/interop/sync/SyncError", false)
+        , m_io_realm_kotlin_internal_interop_sync_app_error(env, "io/realm/kotlin/internal/interop/sync/AppError", false)
+        , m_io_realm_kotlin_internal_interop_sync_log_callback(env, "io/realm/kotlin/internal/interop/SyncLogCallback", false)
+        , m_io_realm_kotlin_internal_interop_sync_error_callback(env, "io/realm/kotlin/internal/interop/SyncErrorCallback", false)
+        , m_io_realm_kotlin_internal_interop_sync_jvm_sync_session_transfer_completion_callback(env, "io/realm/kotlin/internal/interop/sync/JVMSyncSessionTransferCompletionCallback", false)
+        , m_io_realm_kotlin_internal_interop_sync_response_callback_impl(env, "io/realm/kotlin/internal/interop/sync/ResponseCallbackImpl", false)
+        , m_io_realm_kotlin_internal_interop_subscription_set_callback(env, "io/realm/kotlin/internal/interop/SubscriptionSetCallback", false)
+        , m_io_realm_kotlin_internal_interop_sync_before_client_reset_handler(env, "io/realm/kotlin/internal/interop/SyncBeforeClientResetHandler", false)
+        , m_io_realm_kotlin_internal_interop_sync_after_client_reset_handler(env, "io/realm/kotlin/internal/interop/SyncAfterClientResetHandler", false)
+        , m_io_realm_kotlin_internal_interop_core_error_utils(env, "io/realm/kotlin/internal/interop/CoreErrorUtils", false)
     {
     }
 
@@ -66,19 +67,19 @@ private:
     jni_util::JavaClass m_java_lang_int;
     jni_util::JavaClass m_kotlin_jvm_functions_function0;
     jni_util::JavaClass m_kotlin_jvm_functions_function1;
-    jni_util::JavaClass m_io_realm_kotlinnetwork_transport;
-    jni_util::JavaClass m_io_realm_kotlinresponse;
-    jni_util::JavaClass m_io_realm_kotlinlong_pointer_wrapper;
-    jni_util::JavaClass m_io_realm_kotlininternal_interop_sync_sync_error;
-    jni_util::JavaClass m_io_realm_kotlininternal_interop_sync_app_error;
-    jni_util::JavaClass m_io_realm_kotlinsync_log_callback;
-    jni_util::JavaClass m_io_realm_kotlinsync_error_callback;
-    jni_util::JavaClass m_io_realm_kotlinsync_error_code;
-    jni_util::JavaClass m_io_realm_kotlinsync_session_transfer_completion_callback;
-    jni_util::JavaClass m_io_realm_kotlininternal_interop_sync_response_callback;
-    jni_util::JavaClass m_io_realm_kotlininternal_interop_sync_subscriptionset_changed_callback;
-    jni_util::JavaClass m_io_realm_kotlinsync_interop_sync_before_client_reset_handler;
-    jni_util::JavaClass m_io_realm_kotlinsync_interop_sync_after_client_reset_handler;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_network_transport;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_response;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_long_pointer_wrapper;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_sync_error;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_app_error;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_log_callback;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_error_callback;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_jvm_sync_session_transfer_completion_callback;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_response_callback_impl;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_subscription_set_callback;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_before_client_reset_handler;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_after_client_reset_handler;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_core_error_utils;
 
     inline static std::unique_ptr<JavaClassGlobalDef>& instance()
     {
@@ -100,6 +101,11 @@ public:
         instance().release();
     }
 
+    inline static const jni_util::JavaClass& java_util_hashmap()
+    {
+        return instance()->m_java_util_hashmap;
+    }
+
     inline static jobject new_int(JNIEnv* env, int32_t value)
     {
         static jni_util::JavaMethod init(env,
@@ -109,68 +115,67 @@ public:
         return env->NewObject(instance()->m_java_lang_int, init, value);
     }
 
-    inline static const jni_util::JavaClass& network_transport_response_class()
-    {
-        return instance()->m_io_realm_kotlinresponse;
-    }
-
     inline static const jni_util::JavaClass& network_transport_class()
     {
-        return instance()->m_io_realm_kotlinnetwork_transport;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_network_transport;
     }
 
-    inline static const jni_util::JavaClass& java_util_hashmap()
+    inline static const jni_util::JavaClass& network_transport_response_class()
     {
-        return instance()->m_java_util_hashmap;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_response;
     }
 
     inline static const jni_util::JavaClass& long_pointer_wrapper()
     {
-        return instance()->m_io_realm_kotlinlong_pointer_wrapper;
+        return instance()->m_io_realm_kotlin_internal_interop_long_pointer_wrapper;
     }
 
     inline static const jni_util::JavaClass& sync_error()
     {
-        return instance()->m_io_realm_kotlininternal_interop_sync_sync_error;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_sync_error;
     }
 
     inline static const jni_util::JavaClass& app_error()
     {
-        return instance()->m_io_realm_kotlininternal_interop_sync_app_error;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_app_error;
     }
 
     inline static const jni_util::JavaClass& sync_log_callback()
     {
-        return instance()->m_io_realm_kotlinsync_log_callback;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_log_callback;
     }
 
     inline static const jni_util::JavaClass& sync_error_callback()
     {
-        return instance()->m_io_realm_kotlinsync_error_callback;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_error_callback;
     }
 
     inline static const jni_util::JavaClass& sync_session_transfer_completion_callback()
     {
-        return instance()->m_io_realm_kotlinsync_session_transfer_completion_callback;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_jvm_sync_session_transfer_completion_callback;
     };
 
     inline static const jni_util::JavaClass& app_response_callback()
     {
-        return instance()->m_io_realm_kotlininternal_interop_sync_response_callback;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_response_callback_impl;
     };
 
     inline static const jni_util::JavaClass& subscriptionset_changed_callback() {
-        return instance()->m_io_realm_kotlininternal_interop_sync_subscriptionset_changed_callback;
+        return instance()->m_io_realm_kotlin_internal_interop_subscription_set_callback;
     }
 
     inline static const jni_util::JavaClass& sync_before_client_reset() {
-        return instance()->m_io_realm_kotlinsync_interop_sync_before_client_reset_handler;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_before_client_reset_handler;
     }
 
     inline static const jni_util::JavaClass& sync_after_client_reset() {
-        return instance()->m_io_realm_kotlinsync_interop_sync_after_client_reset_handler;
+        return instance()->m_io_realm_kotlin_internal_interop_sync_after_client_reset_handler;
     }
 
+    inline static const jni_util::JavaClass& core_error_utils()
+    {
+        return instance()->m_io_realm_kotlin_internal_interop_core_error_utils;
+    }
 
     inline static const jni_util::JavaMethod function0Method(JNIEnv* env) {
         return jni_util::JavaMethod(env, instance()->m_kotlin_jvm_functions_function0, "invoke",

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -245,10 +245,12 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 
         // Invoke CoreErrorUtils.coreErrorAsThrowable() to retrieve an exception instance that
         // maps to the core error.
-        jclass error_type_class = (jenv)->FindClass("io/realm/kotlin/internal/interop/CoreErrorUtils");
-        static jmethodID error_type_as_exception = (jenv)->GetStaticMethodID(error_type_class,
-                                                                      "coreErrorAsThrowable",
-                                                                      "(ILjava/lang/String;)Ljava/lang/Throwable;");
+        const JavaClass& error_type_class = realm::_impl::JavaClassGlobalDef::core_error_utils();
+        static JavaMethod error_type_as_exception(jenv,
+                                                  error_type_class,
+                                                  "coreErrorAsThrowable",
+                                                  "(ILjava/lang/String;)Ljava/lang/Throwable;", true);
+
         jstring error_message = (jenv)->NewStringUTF(message.c_str());
 
         jobject exception = (jenv)->CallStaticObjectMethod(

--- a/packages/library-base/proguard-rules-consumer-common.pro
+++ b/packages/library-base/proguard-rules-consumer-common.pro
@@ -14,7 +14,7 @@
 }
 
 # Utils to convert core errors into Kotlin exceptions
--keep class io.realm.kotlin.interop.CoreErrorUtils {
+-keep class io.realm.kotlin.internal.interop.CoreErrorUtils {
     *;
 }
 


### PR DESCRIPTION
Fix erroneous package reference in proguard consumer file and moves initialization of `CoreErrorUtils` java class reference to library initialization. 

Closes #942