### PR TITLE
Add support for `User.delete()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements
 * Added support for `UUID` through a new property type: `RealmUUID`.
+* [Sync] Add support for `User.delete()`, making it possible to delete user data on the server side (Issue [#570](https://github.com/realm/realm-kotlin/issues/570)).
 
 ### Fixed
 * Missing proguard configuration for `CoreErrorUtils`. (Issue [#942](https://github.com/realm/realm-kotlin/issues/942))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Enhancements
 * Added support for `UUID` through a new property type: `RealmUUID`.
-* [Sync] Add support for `User.delete()`, making it possible to delete user data on the server side (Issue [#570](https://github.com/realm/realm-kotlin/issues/570)).
+* [Sync] Add support for `User.delete()`, making it possible to delete user data on the server side (Issue [#491](https://github.com/realm/realm-kotlin/issues/491)).
 
 ### Fixed
 * Missing proguard configuration for `CoreErrorUtils`. (Issue [#942](https://github.com/realm/realm-kotlin/issues/942))

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -263,6 +263,7 @@ expect object RealmInterop {
     fun realm_app_log_in_with_credentials(app: RealmAppPointer, credentials: RealmCredentialsPointer, callback: AppCallback<RealmUserPointer>)
     fun realm_app_log_out(app: RealmAppPointer, user: RealmUserPointer, callback: AppCallback<Unit>)
     fun realm_app_remove_user(app: RealmAppPointer, user: RealmUserPointer, callback: AppCallback<Unit>)
+    fun realm_app_delete_user(app: RealmAppPointer, user: RealmUserPointer, callback: AppCallback<Unit>)
     fun realm_clear_cached_apps()
     fun realm_app_sync_client_get_default_file_path_for_realm(
         app: RealmAppPointer,

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1575,6 +1575,26 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_app_delete_user(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        callback: AppCallback<Unit>
+    ) {
+        checkedBooleanResult(
+            realm_wrapper.realm_app_delete_user(
+                app.cptr(),
+                user.cptr(),
+                staticCFunction { userData, error ->
+                    handleAppCallback(userData, error) { /* No-op, returns Unit */ }
+                },
+                StableRef.create(callback).asCPointer(),
+                staticCFunction { userdata ->
+                    disposeUserData<AppCallback<RealmUserPointer>>(userdata)
+                }
+            )
+        )
+    }
+
     actual fun realm_clear_cached_apps() {
         realm_wrapper.realm_clear_cached_apps()
     }

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -688,6 +688,14 @@ actual object RealmInterop {
         realmc.realm_app_remove_user(app.cptr(), user.cptr(), callback)
     }
 
+    actual fun realm_app_delete_user(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        callback: AppCallback<Unit>
+    ) {
+        realmc.realm_app_delete_user(app.cptr(), user.cptr(), callback)
+    }
+
     actual fun realm_app_get_current_user(app: RealmAppPointer): RealmUserPointer? {
         val ptr = realmc.realm_app_get_current_user(app.cptr())
         return nativePointerOrNull(ptr)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
@@ -89,6 +89,21 @@ public interface User {
     public suspend fun remove(): User
 
     /**
+     * Permanently deletes this user from your Atlas App Services app.
+     *
+     * If the user was deleted successfully on Atlas, the users state will be set to
+     * [State.REMOVED] and any local Realm files owned by the user will be deleted. If
+     * the server request fails, the local state will not be modified.
+     *
+     * All user realms should be closed before calling this method.
+     *
+     * @throws IllegalStateException if the user was already removed or not logged in.
+     * @throws io.realm.kotlin.mongodb.exceptions.ServiceException if a failure occurred when
+     * communicating with App Services. See [AppException] for details.
+     */
+    public suspend fun delete()
+
+    /**
      * Two Users are considered equal if they have the same user identity and are associated
      * with the same app.
      */

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
@@ -91,7 +91,7 @@ public interface User {
     /**
      * Permanently deletes this user from your Atlas App Services app.
      *
-     * If the user was deleted successfully on Atlas, the users state will be set to
+     * If the user was deleted successfully on Atlas, the user state will be set to
      * [State.REMOVED] and any local Realm files owned by the user will be deleted. If
      * the server request fails, the local state will not be modified.
      *

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
@@ -69,6 +69,23 @@ public class UserImpl(
         return this
     }
 
+    override suspend fun delete() {
+        if (state != User.State.LOGGED_IN) {
+            throw IllegalStateException("User must be logged in, in order to be deleted.")
+        }
+        Channel<Result<Unit>>(1).use { channel ->
+            RealmInterop.realm_app_delete_user(
+                app.nativePointer,
+                nativePointer,
+                channelResultCallback<Unit, Unit>(channel) {
+                    // No-op
+                }.freeze()
+            )
+            return@use channel.receive()
+                .getOrThrow()
+        }
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/UserTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/UserTests.kt
@@ -292,7 +292,7 @@ class UserTests {
     }
 
     @Test
-    fun deleteUser_throwsIfUserAlreadyRemoved() {
+    fun removeUser_throwsIfUserAlreadyRemoved() {
         runBlocking {
             val user1 = createUserAndLogin()
             assertEquals(user1, user1.remove())


### PR DESCRIPTION
Closes #491 

API should be straightforward and follows how it is implemented in Swift.