### PR TITLE
Throw proper exception when returning invalid RealmObject from write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 1.0.3 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* Returning deleted objects from `Realm.write` and `Realm.writeBlocking` threw a non-sensical `NullPointerException`. Returning such a value is not allowed and now throws an `IllegalStateException`. (Issue [#965](https://github.com/realm/realm-kotlin/issues/965))
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10 and above.
+  * Coroutines 1.6.0-native-mt. Also compatible with Coroutines 1.6.0 but requires enabling of the new memory model and disabling of freezing, see https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility for details on that.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.0.2 (2022-08-05)
 
 ### Breaking Changes

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/SuspendableWriter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/SuspendableWriter.kt
@@ -18,6 +18,7 @@ package io.realm.kotlin.internal
 
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.ext.isManaged
+import io.realm.kotlin.ext.isValid
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.internal.platform.threadId
@@ -141,6 +142,9 @@ internal class SuspendableWriter(private val owner: RealmImpl, val dispatcher: C
                 // FIXME If we could transfer ownership (the owning Realm) in Realm instead then we
                 //  could completely eliminate the need for the external owner in here!?
                 result.runIfManaged {
+                    if (!result.isValid()) {
+                        throw IllegalStateException("A deleted Realm object cannot be returned from a write transaction.")
+                    }
                     freeze(reference)!!.toRealmObject()
                 }
             }

--- a/test/base/src/androidTest/kotlin/io/realm/kotlin/test/shared/RealmTests.kt
+++ b/test/base/src/androidTest/kotlin/io/realm/kotlin/test/shared/RealmTests.kt
@@ -161,6 +161,18 @@ class RealmTests {
             }
     }
 
+    @Test
+    fun write_throwsIfReturningDeletedObject() = runBlocking {
+        assertFailsWithMessage(IllegalStateException::class, "A deleted Realm object cannot be returned from a write transaction.") {
+            // must store result of `write` as the return value is otherwise ignored.
+            val returnValue: Child = realm.write {
+                val child = copyToRealm(Child()).apply { this.name = "Realm" }
+                child.apply { delete(this) }
+            }
+        }
+        Unit
+    }
+
     @Suppress("invisible_member")
     @Test
     fun exceptionInWriteWillRollback() = runBlocking {
@@ -257,6 +269,18 @@ class RealmTests {
             writeBlockingQueued.unlock()
             async.await()
         }
+    }
+
+    @Test
+    fun writeBlocking_throwsIfReturningDeletedObject() {
+        assertFailsWithMessage(IllegalStateException::class, "A deleted Realm object cannot be returned from a write transaction.") {
+            // must store result of `write` as the return value is otherwise ignored.
+            val returnValue: Child = realm.writeBlocking {
+                val child = copyToRealm(Child()).apply { this.name = "Realm" }
+                child.apply { delete(this) }
+            }
+        }
+        Unit
     }
 
     @Test

--- a/test/base/src/commonTest/kotlin/io/realm/kotlin/test/Utils.kt
+++ b/test/base/src/commonTest/kotlin/io/realm/kotlin/test/Utils.kt
@@ -23,7 +23,7 @@ import kotlin.test.assertFailsWith
  * fuzzy, i.e. we only check that the provided message is contained within the whole exception
  * message. The match is case sensitive.
  */
-fun <T : Throwable> assertFailsWithMessage(exceptionClass: KClass<T>, exceptionMessage: String, block: () -> Unit): T {
+inline fun <T : Throwable> assertFailsWithMessage(exceptionClass: KClass<T>, exceptionMessage: String, block: () -> Unit): T {
     val exception: T = assertFailsWith(exceptionClass, null, block)
     if (exception.message?.contains(exceptionMessage, ignoreCase = false) != true) {
         throw AssertionError(


### PR DESCRIPTION
Closes #965

We didn't correctly check if users tried to return deleted objects from a write, which caused a NullPointer when we tried to freeze an invalid object.

We basically have two choices on what to do here:

1) Allow sending back a deleted object without trying to freeze it.
2) Throw some error if it happens.

I opted for 2) as I cannot see any use case where sending back a deleted object would actually be the behavior wanted, but if someone feel that there is a use case, I'll be happy to change it.

Regarding the exception type, I was torn a bit between `IllegalArgument` and `IllegalState`, but opted for `IllegalState` as argument exceptions are usually only used for input to a public function. Again, this can probably be debated, so if anyone can come up with good arguments for making it an `IllegalArgument`, I'll be happy to change it.