### PR TITLE
Fix test converting a partition-based Realm into a local Realm.

### DIFF
--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
@@ -570,7 +570,12 @@ class SyncedRealmTests {
         }
     }
 
-    private fun createWriteCopyLocalConfig(name: String, encryptionKey: ByteArray? = null): RealmConfiguration {
+    private fun createWriteCopyLocalConfig(
+        name: String,
+        directory: String = PlatformUtils.createTempDir(),
+        encryptionKey: ByteArray? = null,
+        schemaVersion: Long = 0
+    ): RealmConfiguration {
         val builder = RealmConfiguration.Builder(
             schema = setOf(
                 SyncObjectWithAllTypes::class,
@@ -579,7 +584,8 @@ class SyncedRealmTests {
                 FlexEmbeddedObject::class
             )
         )
-            .directory(PlatformUtils.createTempDir())
+            .directory(directory)
+            .schemaVersion(schemaVersion)
             .name(name)
         if (encryptionKey != null) {
             builder.encryptionKey(encryptionKey)
@@ -666,7 +672,9 @@ class SyncedRealmTests {
     fun writeCopyTo_partitionBasedToLocal() = runBlocking {
         val (email, password) = randomEmail() to "password1234"
         val user = app.createUserAndLogIn(email, password)
-        val localConfig = createWriteCopyLocalConfig("local.realm")
+        val dir = PlatformUtils.createTempDir()
+        val localConfig = createWriteCopyLocalConfig("local.realm", directory = dir)
+        val migratedLocalConfig = createWriteCopyLocalConfig("local.realm", directory = dir, schemaVersion = 1)
         val partitionValue = TestHelper.randomPartitionValue()
         val syncConfig = createSyncConfig(
             user = user,
@@ -683,11 +691,24 @@ class SyncedRealmTests {
                     }
                 )
             }
+
+            // Ensure that we have have synchronized the server schema, including the
+            // partition field.
+            syncRealm.syncSession.uploadAllLocalChanges(30.seconds)
+            syncRealm.syncSession.downloadAllServerChanges(30.seconds)
+
             // Copy to partition-based Realm
             syncRealm.writeCopyTo(localConfig)
         }
-        // Open Local Realm and check that data can read.
-        Realm.open(localConfig).use { localRealm: Realm ->
+
+        // Opening the local Realm with the same schema will throw a schema mismatch, because
+        // the server schema contains classes and fields not in the local schema.
+        assertFailsWith<IllegalStateException> {
+            Realm.open(localConfig)
+        }
+
+        // Opening with a migration should work fine
+        Realm.open(migratedLocalConfig).use { localRealm: Realm ->
             assertEquals(1, localRealm.query<SyncObjectWithAllTypes>().count().find())
             assertEquals("local object", localRealm.query<SyncObjectWithAllTypes>().first().find()!!.stringField)
         }


### PR DESCRIPTION
Local schema checks are more restrictive than synced Realms, so all server-side fields must also be part of the schema or be removed through a migration.