### PR TITLE
Avoid processing classes extending other classes using Realm object interfaces as generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.1.1 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* Classes using `RealmObject` or `EmbeddedRealmObject` as a generics type would be modified by the compiler plugin causing compilation errors. (Issue [981] (https://github.com/realm/realm-kotlin/issues/981))
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10 and above.
+  * Coroutines 1.6.0-native-mt. Also compatible with Coroutines 1.6.0 but requires enabling of the new memory model and disabling of freezing, see https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility for details on that.
+  * AtomicFu 0.17.0.
+* Minimum Gradle version: 6.1.1.  
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None
+
 ## 1.1.0 (2022-08-23)
 
 ### Breaking Changes

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/kotlin/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/kotlin/compiler/GenerationExtensionTest.kt
@@ -301,6 +301,21 @@ class GenerationExtensionTest {
         inputs.assertGeneratedIR()
     }
 
+    @Test
+    fun `compiler plugin does not modify classes using Realm object interfaces as generics`() {
+        val OBJECT_IN_GENERICS = """
+import io.realm.kotlin.types.RealmObject
+
+open class BaseClass<T : RealmObject>
+class MyClass : BaseClass<RealmObject>() // last element is SUPER_TYPE_LIST but should NOT be modified
+class Dog: RealmObject
+        """.trimIndent()
+
+        val result =
+            compileFromSource(SourceFile.kotlin("objectInGenerics.kt", OBJECT_IN_GENERICS))
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
     private fun compile(
         inputs: Files,
         plugins: List<Registrar> = listOf(Registrar())


### PR DESCRIPTION
Closes #981 

Compiling this code
```
open class BaseFragment<T : RealmObject>
class RealmFragment : BaseFragment<RealmObject>()
```
would fail as our compiler plugin logic sees `: BaseFragment<RealmObject>()` in `RealmFragment` as a class implementing `RealmObject` which is wrong. We now exclude classes that contain `RealmObject` or `EmbeddedRealmObject` interfaces as generics in `SUPER_TYPE_LIST` elements from being modified by the compiler plugin.