### PR TITLE
Support for building and publishing each architecture independently.

### DIFF
--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -328,11 +328,16 @@ android {
 val capiMacosUniversal by tasks.registering {
     build_C_API_Macos_Universal(releaseBuild = isReleaseBuild)
 }
-// Building Simulator binaries for iosX64 (x86_64) and iosSimulatorArm64 (i.e Apple silicon arm64)
-val capiSimulator by tasks.registering {
+// Building Simulator binaries for iosX64 (x86_64)
+val capiSimulatorX64 by tasks.registering {
     build_C_API_Simulator("x86_64", isReleaseBuild)
+}
+
+// Building Simulator binaries for iosSimulatorArm64 (i.e Apple silicon arm64)
+val capiSimulatorArm64 by tasks.registering {
     build_C_API_Simulator("arm64", isReleaseBuild)
 }
+
 // Building for ios device (arm64 only)
 val capiIosArm64 by tasks.registering {
     build_C_API_iOS_Arm64(releaseBuild = isReleaseBuild)
@@ -599,8 +604,12 @@ afterEvaluate {
     }
 }
 
-tasks.named("cinteropRealm_wrapperIosX64") { // TODO is this the correct arch qualifier for OSX-ARM64? test on M1
-    dependsOn(capiSimulator)
+tasks.named("cinteropRealm_wrapperIosX64") { 
+    dependsOn(capiSimulatorX64)
+}
+
+tasks.named("cinteropRealm_wrapperIosArm64") { 
+    dependsOn(capiSimulatorArm64)
 }
 
 tasks.named("cinteropRealm_wrapperIosArm64") {
@@ -611,8 +620,16 @@ tasks.named("cinteropRealm_wrapperMacos") {
     dependsOn(capiMacosUniversal)
 }
 
+tasks.named("cinteropRealm_wrapperMacosArm64") {
+    dependsOn(capiMacosUniversal)
+}
+
 tasks.named("jvmMainClasses") {
-    dependsOn(buildJVMSharedLibs)
+    if (project.extra.properties["ignoreNativeLibs"] == false) {
+        dependsOn(buildJVMSharedLibs)
+    } else {
+        logger.warn("Ignore building native libs")
+    }
 }
 
 // Maven Central requires JavaDoc so add empty javadoc artifacts

--- a/packages/plugin-compiler/build.gradle.kts
+++ b/packages/plugin-compiler/build.gradle.kts
@@ -36,7 +36,9 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:${Versions.kotlinCompileTesting}")
     // Have to be mentioned explicitly as it is not an api dependency of library
-    implementation(project(":cinterop"))
+    implementation(project(":cinterop") {
+        this.extra["ignoreNativeLibs"] = true
+    })
     testImplementation(project(":library-base"))
     testImplementation(project(":library-sync"))
 }


### PR DESCRIPTION
Our current `cinterop` package has a few problems if you want to build and publish packages for each platform independently. This PR fixes those issues. They were discovered while trying to add parallel builds on Github Actions.