### PR TITLE
Refactor EmailPassword Auth tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -485,8 +485,9 @@ def testWithServer(tasks) {
             }
             def commandServerEnv = docker.build 'mongodb-realm-command-server', "tools/sync_test_server"
             def tempDir = runCommand('mktemp -d -t app_config.XXXXXXXXXX')
-            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template partition testapp1 testapp2"
-            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template flex testapp3"
+            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template partition auto testapp1"
+            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template partition email testapp2"
+            sh "tools/sync_test_server/app_config_generator.sh ${tempDir} tools/sync_test_server/app_template flex function testapp3"
 
             sh "docker network create ${dockerNetworkId}"
             mongoDbRealmContainer = mdbRealmImage.run("--rm -i -t -d --network ${dockerNetworkId} -v$tempDir:/apps -p9090:9090 -p8888:8888 -p26000:26000 -e AWS_ACCESS_KEY_ID='$BAAS_AWS_ACCESS_KEY_ID' -e AWS_SECRET_ACCESS_KEY='$BAAS_AWS_SECRET_ACCESS_KEY'")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -642,7 +642,7 @@ def startEmulatorInBgIfNeeded() {
     if (returnStatus != 0) {
         // Changing the name of the emulator image requires that this emulator image is
         // present on both atlanta_host13 and atlanta_host14.
-        sh '/usr/local/Cellar/daemonize/1.7.8/sbin/daemonize  -E JENKINS_NODE_COOKIE=dontKillMe  $ANDROID_SDK_ROOT/emulator/emulator -avd Pixel_2_API_30_x86_64 -no-boot-anim -no-window -wipe-data -noaudio -partition-size 4098'
+        sh '/usr/local/Cellar/daemonize/1.7.8/sbin/daemonize  -E JENKINS_NODE_COOKIE=dontKillMe  $ANDROID_SDK_ROOT/emulator/emulator -avd Pixel_2_API_30_x86_64 -no-boot-anim -no-window -wipe-data -noaudio -partition-size 4098 -memory 2048'
     }
 }
 

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
@@ -9,11 +9,11 @@ import io.realm.kotlin.mongodb.exceptions.BadRequestException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyConfirmedException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
 import io.realm.kotlin.mongodb.exceptions.UserNotFoundException
+import io.realm.kotlin.test.mongodb.TEST_APP_1
+import io.realm.kotlin.test.mongodb.TEST_APP_2
+import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
 import io.realm.kotlin.test.mongodb.TestApp
-import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.util.TestHelper
-import kotlin.random.Random
-import kotlin.random.nextULong
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
@@ -23,17 +23,12 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-class EmailPasswordAuthTests {
-
+class EmailPasswordAuthWithAutoConfirmTests {
     private lateinit var app: TestApp
 
     @BeforeTest
     fun setup() {
-        app = TestApp()
-        runBlocking {
-            app.setCustomConfirmation(false)
-            app.setAutomaticConfirmation(true)
-        }
+        app = TestApp(appName = TEST_APP_1)
     }
 
     @AfterTest
@@ -66,7 +61,6 @@ class EmailPasswordAuthTests {
     fun registerUser_invalidServerArgsThrows_invalidUser() = runBlocking {
         // Invalid mail and too short password
         val (email, password) = "invalid-email" to "1234"
-
         // TODO do exhaustive exception assertion once we have all AppException fields in place
         assertFailsWith<AppException> {
             app.emailPasswordAuth.registerUser(email, password)
@@ -79,7 +73,6 @@ class EmailPasswordAuthTests {
         runBlocking {
             // Valid mail but too short password
             val (email, password) = TestHelper.randomEmail() to "1234"
-
             // TODO do exhaustive exception assertion once we have all AppException fields in place
             assertFailsWith<AppException> {
                 app.emailPasswordAuth.registerUser(email, password)
@@ -121,36 +114,6 @@ class EmailPasswordAuthTests {
     }
 
     @Test
-    fun resendConfirmationEmail() = runBlocking {
-        // We only test that the server successfully accepts the request. We have no way of knowing
-        // if the Email was actually sent.
-        // TODO Figure out a way to check if this actually happened. Perhaps a custom SMTP server?
-        val email = TestHelper.randomEmail()
-        app.asTestApp.setAutomaticConfirmation(false)
-        try {
-            val provider = app.emailPasswordAuth
-            provider.registerUser(email, "123456")
-            provider.resendConfirmationEmail(email)
-        } finally {
-            app.asTestApp.setAutomaticConfirmation(true)
-        }
-    }
-
-    @Test
-    fun resendConfirmationEmail_noUserThrows() = runBlocking {
-        val email = TestHelper.randomEmail()
-        app.asTestApp.setAutomaticConfirmation(false)
-        try {
-            val provider = app.emailPasswordAuth
-            provider.registerUser(email, "123456")
-            val error = assertFailsWith<UserNotFoundException> { provider.resendConfirmationEmail("foo") }
-            assertTrue(error.message!!.contains("user not found"), error.message)
-        } finally {
-            app.asTestApp.setAutomaticConfirmation(true)
-        }
-    }
-
-    @Test
     fun resendConfirmationEmail_userAlreadyConfirmedThrows() = runBlocking {
         val email = TestHelper.randomEmail()
         val provider = app.emailPasswordAuth
@@ -164,95 +127,6 @@ class EmailPasswordAuthTests {
         val provider: EmailPasswordAuth = app.emailPasswordAuth
         assertFailsWith<IllegalArgumentException> { provider.resendConfirmationEmail("") }
         Unit
-    }
-
-    @Test
-    fun retryCustomConfirmation() {
-        val (email, password) = "realm_pending_${Random.nextULong()}@10gen.com" to "123456"
-        val adminApi = app.asTestApp
-        runBlocking {
-            adminApi.setAutomaticConfirmation(false)
-            adminApi.setCustomConfirmation(true)
-            try {
-                val provider = app.emailPasswordAuth
-                provider.registerUser(email, password) // Will move to "pending"
-                assertFailsWith<AuthException> {
-                    app.login(Credentials.emailPassword(email, password))
-                }
-                provider.retryCustomConfirmation(email) // Will properly "confirm"
-                app.login(Credentials.emailPassword(email, password))
-            } finally {
-                adminApi.setCustomConfirmation(false)
-                adminApi.setAutomaticConfirmation(true)
-            }
-        }
-    }
-
-    @Test
-    fun retryCustomConfirmation_failConfirmation() = runBlocking {
-        // Only emails containing realm_tests_do_autoverify will be confirmed
-        val email = "do_not_confirm@10gen.com"
-        app.setAutomaticConfirmation(false)
-        app.setCustomConfirmation(true)
-        try {
-            val provider = app.emailPasswordAuth
-            val exception = assertFailsWith<UserNotFoundException> {
-                provider.retryCustomConfirmation(email)
-            }
-            assertTrue(exception.message!!.contains("user not found"), exception.message)
-        } finally {
-            app.setCustomConfirmation(false)
-            app.setAutomaticConfirmation(true)
-        }
-    }
-
-    @Test
-    fun retryCustomConfirmation_noUserThrows() {
-        val email = "realm_pending_${Random.nextULong()}@10gen.com"
-        val adminApi = app.asTestApp
-        runBlocking {
-            adminApi.setAutomaticConfirmation(false)
-            adminApi.setCustomConfirmation(true)
-            val provider = app.emailPasswordAuth
-            provider.registerUser(email, "123456")
-            try {
-                provider.retryCustomConfirmation("foo@gen.com")
-                fail()
-            } catch (error: UserNotFoundException) {
-                assertTrue(error.message!!.contains("user not found"), error.message)
-            } finally {
-                adminApi.setCustomConfirmation(false)
-                adminApi.setAutomaticConfirmation(true)
-            }
-        }
-    }
-
-    @Test
-    fun retryCustomConfirmation_alreadyConfirmedThrows() {
-        val email = "realm_verify_${Random.nextULong()}@10gen.com"
-        val adminApi = app.asTestApp
-        runBlocking {
-            try {
-                val provider = app.emailPasswordAuth
-                adminApi.setAutomaticConfirmation(false)
-                adminApi.setCustomConfirmation(true)
-                provider.registerUser(email, "123456")
-                assertFailsWith<UserAlreadyConfirmedException> {
-                    provider.retryCustomConfirmation(email)
-                }
-            } finally {
-                adminApi.setCustomConfirmation(false)
-                adminApi.setAutomaticConfirmation(true)
-            }
-        }
-    }
-
-    @Test
-    fun retryCustomConfirmation_invalidArgumentsThrows() {
-        val provider: EmailPasswordAuth = app.emailPasswordAuth
-        runBlocking {
-            assertFailsWith<IllegalArgumentException> { provider.retryCustomConfirmation("") }
-        }
     }
 
     @Test
@@ -347,6 +221,113 @@ class EmailPasswordAuthTests {
         assertFailsWith<IllegalArgumentException> { provider.resetPassword("", "token-id", "password") }
         assertFailsWith<IllegalArgumentException> { provider.resetPassword("token", "", "password") }
         assertFailsWith<IllegalArgumentException> { provider.resetPassword("token", "token-id", "") }
+        Unit
+    }
+}
+
+class EmailPasswordAuthWithEmailConfirmTests {
+    private lateinit var app: TestApp
+
+    @BeforeTest
+    fun setup() {
+        app = TestApp(appName = TEST_APP_2)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (this::app.isInitialized) {
+            app.close()
+        }
+    }
+
+    @Test
+    fun resendConfirmationEmail() = runBlocking {
+        // We only test that the server successfully accepts the request. We have no way of knowing
+        // if the Email was actually sent.
+        // TODO Figure out a way to check if this actually happened. Perhaps a custom SMTP server?
+        val email = TestHelper.randomEmail()
+        val provider = app.emailPasswordAuth
+        provider.registerUser(email, "123456")
+        provider.resendConfirmationEmail(email)
+    }
+
+    @Test
+    fun resendConfirmationEmail_noUserThrows() = runBlocking {
+        val email = TestHelper.randomEmail()
+        val provider = app.emailPasswordAuth
+        provider.registerUser(email, "123456")
+        val error = assertFailsWith<UserNotFoundException> { provider.resendConfirmationEmail("foo") }
+        assertTrue(error.message!!.contains("user not found"), error.message)
+    }
+}
+
+class EmailPasswordAuthWithCustomFunctionTests {
+    private lateinit var app: TestApp
+
+    @BeforeTest
+    fun setup() {
+        app = TestApp(appName = TEST_APP_FLEX)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (this::app.isInitialized) {
+            app.close()
+        }
+    }
+
+    @Test
+    fun retryCustomConfirmation() = runBlocking {
+        val (email, password) = "realm_pending_${TestHelper.randomEmail()}" to "123456"
+        val provider = app.emailPasswordAuth
+        provider.registerUser(email, password) // Will move to "pending"
+        assertFailsWith<AuthException> {
+            app.login(Credentials.emailPassword(email, password))
+        }
+        provider.retryCustomConfirmation(email) // Will properly "confirm"
+        app.login(Credentials.emailPassword(email, password))
+        Unit
+    }
+
+    @Test
+    fun retryCustomConfirmation_failConfirmation() = runBlocking {
+        // Only emails containing realm_tests_do_autoverify will be confirmed
+        val email = "do_not_confirm_${TestHelper.randomEmail()}"
+        val provider = app.emailPasswordAuth
+        val exception = assertFailsWith<UserNotFoundException> {
+            provider.retryCustomConfirmation(email)
+        }
+        assertTrue(exception.message!!.contains("user not found"), exception.message)
+    }
+
+    @Test
+    fun retryCustomConfirmation_noUserThrows() = runBlocking {
+        val email = "realm_pending_${TestHelper.randomEmail()}"
+        val provider = app.emailPasswordAuth
+        provider.registerUser(email, "123456")
+        try {
+            provider.retryCustomConfirmation("foo@gen.com")
+            fail()
+        } catch (error: UserNotFoundException) {
+            assertTrue(error.message!!.contains("user not found"), error.message)
+        }
+    }
+
+    @Test
+    fun retryCustomConfirmation_alreadyConfirmedThrows() = runBlocking {
+        val email = "realm_verify_${TestHelper.randomEmail()}"
+        val provider = app.emailPasswordAuth
+        provider.registerUser(email, "123456")
+        assertFailsWith<UserAlreadyConfirmedException> {
+            provider.retryCustomConfirmation(email)
+        }
+        Unit
+    }
+
+    @Test
+    fun retryCustomConfirmation_invalidArgumentsThrows() = runBlocking {
+        val provider: EmailPasswordAuth = app.emailPasswordAuth
+        assertFailsWith<IllegalArgumentException> { provider.retryCustomConfirmation("") }
         Unit
     }
 }

--- a/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
+++ b/test/sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
@@ -41,11 +41,11 @@ import io.realm.kotlin.mongodb.sync.SyncSession
 import io.realm.kotlin.mongodb.sync.SyncSession.ErrorHandler
 import io.realm.kotlin.mongodb.syncSession
 import io.realm.kotlin.notifications.ResultsChange
+import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.mongodb.shared.DEFAULT_NAME
-import io.realm.kotlin.test.mongodb.util.SyncPermissions
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.TestHelper.randomEmail
@@ -244,8 +244,10 @@ class SyncedRealmTests {
 
     @Test
     fun errorHandlerReceivesPermissionDeniedSyncError() {
-        val channel = Channel<SyncException>(1).freeze()
-        val (email, password) = randomEmail() to "password1234"
+        val channel = Channel<Throwable>(1).freeze()
+        // Remove permissions to generate a sync error containing ONLY the original path
+        // This way we assert we don't read wrong data from the user_info field
+        val (email, password) = "test_nowrite_noread_${randomEmail()}" to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)
         }
@@ -258,24 +260,24 @@ class SyncedRealmTests {
             channel.trySend(error)
         }.build()
 
-        // Remove permissions to generate a sync error containing ONLY the original path
-        // This way we assert we don't read wrong data from the user_info field
         runBlocking {
-            app.asTestApp.changeSyncPermissions(SyncPermissions(read = false, write = false)) {
-                runBlocking {
-                    val deferred = async { Realm.open(config) }
-
-                    val error = channel.receive()
-                    assertTrue(error is UnrecoverableSyncException)
-                    val message = error.message
-                    assertNotNull(message)
-                    assertTrue(
-                        message.toLowerCase().contains("permission denied"),
-                        "The error should be 'PermissionDenied' but it was: $message"
-                    )
-                    deferred.cancel()
-                }
+            val deferred = async {
+                Realm.open(config)
+                // Make sure that the test eventually fail. Coroutines can cancel a delay
+                // so this doesn't always block the test for 10 seconds.
+                delay(10 * 1000)
+                channel.trySend(AssertionError("Realm was successfully opened"))
             }
+
+            val error = channel.receive()
+            assertTrue(error is UnrecoverableSyncException, "Was $error")
+            val message = error.message
+            assertNotNull(message)
+            assertTrue(
+                message.lowercase().contains("permission denied"),
+                "The error should be 'PermissionDenied' but it was: $message"
+            )
+            deferred.cancel()
         }
     }
 
@@ -563,13 +565,14 @@ class SyncedRealmTests {
             schema = setOf(SyncObjectWithAllTypes::class)
         ).let { config ->
             Realm.open(config).use { realm ->
-                val obj: SyncObjectWithAllTypes =
+                val list: RealmResults<SyncObjectWithAllTypes> =
                     realm.query<SyncObjectWithAllTypes>("_id = $0", id)
                         .asFlow()
                         .first {
-                            it.list.size == 1
-                        }.list.first()
-                assertTrue(SyncObjectWithAllTypes.compareAgainstSampleData(obj))
+                            it.list.size >= 1
+                        }.list
+                assertEquals(1, list.size)
+                assertTrue(SyncObjectWithAllTypes.compareAgainstSampleData(list.first()))
             }
         }
     }

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
@@ -115,7 +115,7 @@ class TestApp private constructor(
             val client = defaultClient("$appName-initializer", debug)
             return client.get<String>("$COMMAND_SERVER_BASE_URL/$appName").also {
                 client.close()
-            }
+            }.trim()
         }
 
         fun testAppConfigurationBuilder(

--- a/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AdminApi.kt
+++ b/test/sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AdminApi.kt
@@ -40,7 +40,6 @@ import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.test.mongodb.COMMAND_SERVER_BASE_URL
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable

--- a/tools/sync_test_server/app_config_generator.sh
+++ b/tools/sync_test_server/app_config_generator.sh
@@ -2,11 +2,64 @@
 TARGET_APP_PATH=$1;shift
 TEMPLATE_APP_PATH=$1;shift
 SYNC_MODE=$1;shift # Must be either "partition" or "flex"
+AUTH_MODE=$1;shift # Must be either "auto", "function" or "email"
 mkdir -p $TARGET_APP_PATH
 for APP_NAME in "$@"
 do
     cp -r $TEMPLATE_APP_PATH $TARGET_APP_PATH/$APP_NAME
     sed -i'.bak' 's/APP_NAME_PLACEHOLDER/'$APP_NAME'/g' $TARGET_APP_PATH/$APP_NAME/config.json
+done
+
+# Setup auth config
+for APP_NAME in "$@" 
+do
+    JSON="placeholder"
+    if [ "$AUTH_MODE" = "auto" ]; then
+        JSON='
+            "config": {
+                "autoConfirm": true,
+                "runConfirmationFunction": false,
+                "confirmationFunctionName": "confirmFunc",
+                "emailConfirmationUrl": "http://realm.io/confirm-user",
+                "resetFunctionName": "resetFunc",
+                "resetPasswordSubject": "Reset Password",
+                "resetPasswordUrl": "http://realm.io/reset-password",
+                "runResetFunction": false
+            },
+        '
+    fi
+    if [ "$AUTH_MODE" = "function" ]; then
+        JSON='
+            "config": {
+                "autoConfirm": false,
+                "runConfirmationFunction": true,
+                "confirmationFunctionName": "confirmFunc",
+                "emailConfirmationUrl": "http://realm.io/confirm-user",
+                "resetFunctionName": "resetFunc",
+                "resetPasswordSubject": "Reset Password",
+                "resetPasswordUrl": "http://realm.io/reset-password",
+                "runResetFunction": false
+            },
+        '
+    fi
+    if [ "$AUTH_MODE" = "email" ]; then
+        JSON='
+            "config": {
+                "autoConfirm": false,
+                "runConfirmationFunction": false,
+                "confirmationFunctionName": "confirmFunc",
+                "emailConfirmationUrl": "http://realm.io/confirm-user",
+                "resetFunctionName": "resetFunc",
+                "resetPasswordSubject": "Reset Password",
+                "resetPasswordUrl": "http://realm.io/reset-password",
+                "runResetFunction": false
+            },
+        '
+    fi
+
+    ESCAPED_JSON=`echo ${JSON} | tr '\n' "\\n"`     
+    cp -r $TEMPLATE_APP_PATH $TARGET_APP_PATH/$APP_NAME
+    sed -i'.bak' "s#%EMAIL_AUTH_CONFIG%#$ESCAPED_JSON#g" $TARGET_APP_PATH/$APP_NAME/auth_providers/local-userpass.json
 done
 
 # Setup sync configuration
@@ -22,8 +75,26 @@ do
                 "key": "realm_id",
                 "type": "string",
                 "permissions": {
-                    "read": true,
-                    "write": true
+                    "read": {
+                        "%%true": {
+                            "%function": {
+                                "arguments": [
+                                    "%%partition"
+                                ],
+                                "name": "canReadPartition"
+                            }
+                        }
+                    },
+                    "write": {
+                        "%%true": {
+                            "%function": {
+                                "arguments": [
+                                    "%%partition"
+                                ],
+                                "name": "canWritePartition"
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/tools/sync_test_server/app_template/auth_providers/local-userpass.json
+++ b/tools/sync_test_server/app_template/auth_providers/local-userpass.json
@@ -2,15 +2,6 @@
     "id": "60489e7df5d9bdc94de663db",
     "name": "local-userpass",
     "type": "local-userpass",
-    "config": {
-        "autoConfirm": true,
-        "confirmationFunctionName": "confirmFunc",
-        "emailConfirmationUrl": "http://realm.io/confirm-user",
-        "resetFunctionName": "resetFunc",
-        "resetPasswordSubject": "Reset Password",
-        "resetPasswordUrl": "http://realm.io/reset-password",
-        "runConfirmationFunction": false,
-        "runResetFunction": false
-    },
+    %EMAIL_AUTH_CONFIG%
     "disabled": false
 }

--- a/tools/sync_test_server/app_template/functions/canReadPartition/config.json
+++ b/tools/sync_test_server/app_template/functions/canReadPartition/config.json
@@ -1,0 +1,6 @@
+{
+    "can_evaluate": {},
+    "id": "60489e7df5d9bdc94de663da",
+    "name": "canReadPartition",
+    "private": false
+}

--- a/tools/sync_test_server/app_template/functions/canReadPartition/source.js
+++ b/tools/sync_test_server/app_template/functions/canReadPartition/source.js
@@ -4,5 +4,9 @@
  */
 exports = async (partition) => {
   const email = context.user.data.email;
-  return(!email.includes("_noread_"));
+  if (email != undefined) {
+    return !email.includes("_noread_");
+  } else {
+    return true;
+  }
 }

--- a/tools/sync_test_server/app_template/functions/canReadPartition/source.js
+++ b/tools/sync_test_server/app_template/functions/canReadPartition/source.js
@@ -1,0 +1,8 @@
+/**
+ * Users with an email that contains `_noread_` do not have read access,
+ * all others do.
+ */
+exports = async (partition) => {
+  const email = context.user.data.email;
+  return(!email.includes("_noread_"));
+}

--- a/tools/sync_test_server/app_template/functions/canWritePartition/config.json
+++ b/tools/sync_test_server/app_template/functions/canWritePartition/config.json
@@ -1,0 +1,6 @@
+{
+    "can_evaluate": {},
+    "id": "60489e7df5d9bdc94de783cf",
+    "name": "canWritePartition",
+    "private": false
+}

--- a/tools/sync_test_server/app_template/functions/canWritePartition/source.js
+++ b/tools/sync_test_server/app_template/functions/canWritePartition/source.js
@@ -1,0 +1,8 @@
+/**
+ * Users with an email that contains `_nowrite_` do not have write access,
+ * all others do.
+ */
+exports = async (partition) => {
+  const email = context.user.data.email;
+  return(!email.includes("_nowrite_"));
+}

--- a/tools/sync_test_server/app_template/functions/canWritePartition/source.js
+++ b/tools/sync_test_server/app_template/functions/canWritePartition/source.js
@@ -4,5 +4,9 @@
  */
 exports = async (partition) => {
   const email = context.user.data.email;
-  return(!email.includes("_nowrite_"));
+  if (email != undefined) {
+    return(!email.includes("_nowrite_"));
+  } else {
+    return true;
+  }  
 }

--- a/tools/sync_test_server/app_template/functions/confirmFunc/source.js
+++ b/tools/sync_test_server/app_template/functions/confirmFunc/source.js
@@ -56,6 +56,8 @@ exports = async ({ token, tokenId, username }) => {
       }
       await collection.insertOne({ username: username });
       return { status: 'pending' }
+    } else if (username.endsWith("@10gen.com")) {
+      return { status: 'success' }
     } else {
       // All other emails should fail to confirm outright.
       return { status: 'fail' };

--- a/tools/sync_test_server/mongodb-realm-command-server.js
+++ b/tools/sync_test_server/mongodb-realm-command-server.js
@@ -100,8 +100,11 @@ function handleApplicationId(appName, req, resp) {
             try {
                  const data = fs.readFileSync('/apps/' + appName + '/app_id', 'utf8')
                  console.log(data)
-                 resp.writeHead(200, {'Content-Type': 'text/plain'});
-                 resp.end(data.replace(/\n$/, ''));
+                 resp.writeHead(200, {
+                    'Content-Length': Buffer.byteLength(data),
+                    'Content-Type': 'text/plain'
+                });
+                 resp.end(data);
             } catch (err) {
                  console.error(err)
                  resp.writeHead(404, {'Content-Type': 'text/plain'});

--- a/tools/sync_test_server/start_local_server.sh
+++ b/tools/sync_test_server/start_local_server.sh
@@ -126,8 +126,9 @@ function boot_command_server () {
 
 function generate_app_configs () {
   APP_CONFIG_DIR=`mktemp -d -t app_config`
-  $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template partition testapp1 testapp2
-  $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template flex testapp3
+  $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template partition auto testapp1
+  $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template partition email testapp2
+  $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template flex function testapp3
 }
 
 function import_apps () {

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -35,8 +35,9 @@ SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 # Create app configurations
 APP_CONFIG_DIR=`mktemp -d -t app_config`
-$SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template partition testapp1 testapp2
-$SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template flex testapp3
+$SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template partition auto testapp1
+$SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template partition email testapp2
+$SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template flex function testapp3
 
 # Run Stitch and Stitch CLI Docker images
 docker network create mongodb-realm-network


### PR DESCRIPTION
In the past, we have seen quite a lot of flakiness in the EmailPasswordAuth tests. The root cause was never discovered. With the refactor to Ktor 2, we started to see them again. This PR refactors the tests, so instead of modifying the config of a single app, we now use different test apps.

This seems to fix the flakiness + has the advantage of improving the speed of running tests.