### PR TITLE
Enable auto-merge between branches

### DIFF
--- a/.github/workflows/auto-merge-branches.yml
+++ b/.github/workflows/auto-merge-branches.yml
@@ -21,6 +21,8 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
+      # Set the branch we want to merge changes into as step output. This step should list each branch name found in the `push`
+      # trigger in the top of this file.
       - name: Set target branch
         id: find-target-branch
         shell: sh

--- a/.github/workflows/auto-merge-branches.yml
+++ b/.github/workflows/auto-merge-branches.yml
@@ -1,3 +1,9 @@
+# This workflow is intended to keep certain branches in sync and will automatically create PR's between 
+# these branches. For now these PR's must be manually reviewed and merged. Consider if we should just 
+# automatically do this if there are no conflicts. 
+#
+# This step will fail if a PR already exists, so we ignore failures. This also 
+# mean that if some other error occur, the error will also be swallowed. This is acceptable.
 name: Auto merge change between branches
 
 on:
@@ -22,9 +28,7 @@ jobs:
           if [ "${GITHUB_REF#refs/heads/}" = "master" ]; then echo '::set-output name=branch::releases/ktor2-support'; fi
           if [ "${GITHUB_REF#refs/heads/}" = "releases" ]; then echo '::set-output name=branch::${{ github.event.repository.default_branch }}'; fi
 
-      # Unconditionally create a PR with the changes that needs to be manually reviewed. Consider if we should just automatically do this 
-      # if there is no conflicts. This step will fail if a PR already exists, so we ignore failures. This also mean that if some other error
-      # occur, the error will also be swallowed. This is acceptable.
+      # Unconditionally create a PR with the changes that needs to be manually reviewed. 
       # https://cli.github.com/manual/gh_pr_create
       - name: Create Pull Request
         id: open-pr

--- a/.github/workflows/auto-merge-release-to-master.yml
+++ b/.github/workflows/auto-merge-release-to-master.yml
@@ -27,12 +27,13 @@ jobs:
       # https://cli.github.com/manual/gh_pr_create
       - name: Create Pull Request
         id: open-pr
-        run: |
-          gh pr create \
-          --base '${{ steps.find-target-branch.outputs.branch }}' \
-          --head '${{ github.ref_name }}' \ 
-          --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" \
-          --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.'
+        run: gh pr create --base '${{ steps.find-target-branch.outputs.branch }}' --head '${{ github.ref_name }}' --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.'
+
+          # gh pr create \
+          # --base '${{ steps.find-target-branch.outputs.branch }}' \
+          # --head '${{ github.ref_name }}' \ 
+          # --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" \
+          # --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/auto-merge-release-to-master.yml
+++ b/.github/workflows/auto-merge-release-to-master.yml
@@ -6,7 +6,6 @@ on:
       # List of "from" branches. Targets are defined by the `find-target-branch`-step below.
       - releases
       - master
-      - cm/auto-merge
 
 jobs:
   main:
@@ -22,7 +21,6 @@ jobs:
         run: |
           if [ "${GITHUB_REF#refs/heads/}" = "master" ]; then echo '::set-output name=branch::releases/ktor2-support'; fi
           if [ "${GITHUB_REF#refs/heads/}" = "releases" ]; then echo '::set-output name=branch::${{ github.event.repository.default_branch }}'; fi
-          if [ "${GITHUB_REF#refs/heads/}" = "cm/auto-merge" ]; then echo '::set-output name=branch::cm/auto-merge-destination'; fi
 
       # Unconditionally create a PR with the changes that needs to be manually reviewed. Consider if we should just automatically do this 
       # if there is no conflicts. This step will fail if a PR already exists, so we ignore failures. This also mean that if some other error

--- a/.github/workflows/auto-merge-release-to-master.yml
+++ b/.github/workflows/auto-merge-release-to-master.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           if [ "${GITHUB_REF#refs/heads/}" = "master" ]; then echo '::set-output name=branch::releases/ktor2-support'; fi
           if [ "${GITHUB_REF#refs/heads/}" = "releases" ]; then echo '::set-output name=branch::${{ github.event.repository.default_branch }}'; fi
-          if [ "${GITHUB_REF#refs/heads/}" = "cm/auto-merge" ]; then echo '::set-output name=branch::master'; fi
+          if [ "${GITHUB_REF#refs/heads/}" = "cm/auto-merge" ]; then echo '::set-output name=branch::cm/auto-merge-destination'; fi
 
       # https://github.com/peter-evans/create-pull-request
       - name: Create Pull Request

--- a/.github/workflows/auto-merge-release-to-master.yml
+++ b/.github/workflows/auto-merge-release-to-master.yml
@@ -29,10 +29,10 @@ jobs:
         id: open-pr
         run: |
           gh pr create \
-          -B "${{ steps.find-target-branch.outputs.branch }}" \
-          -H "${{ github.ref_name }}" \ 
+          --base '${{ steps.find-target-branch.outputs.branch }}' \
+          --head '${{ github.ref_name }}' \ 
           --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" \
-          --body "Automated Pull Request. Remember to choose "Create a merge commit" before merging."
+          --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/auto-merge-release-to-master.yml
+++ b/.github/workflows/auto-merge-release-to-master.yml
@@ -24,28 +24,41 @@ jobs:
           if [ "${GITHUB_REF#refs/heads/}" = "releases" ]; then echo '::set-output name=branch::${{ github.event.repository.default_branch }}'; fi
           if [ "${GITHUB_REF#refs/heads/}" = "cm/auto-merge" ]; then echo '::set-output name=branch::cm/auto-merge-destination'; fi
 
-      # https://github.com/peter-evans/create-pull-request
+      # https://cli.github.com/manual/gh_pr_create
       - name: Create Pull Request
         id: open-pr
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update report
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          branch: ${{ steps.find-target-branch.outputs.branch }}
-          title: "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}"
-          body: "Automated Pull Request. Merge all changes"
-          team-reviewers: maintainers
-          signoff: false
-          draft: false
-          delete-branch: false
-
-      - name: Check outputs
-        if: ${{ steps.open-pr.outputs.pull-request-number }}
         run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          gh pr create \
+          -B ${{ steps.find-target-branch.outputs.branch }} \
+          -H ${{ github.ref_name }} \ 
+          --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" \
+          --body "Automated Pull Request. Remember to choose "Create a merge commit" before merging."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+      # # https://github.com/peter-evans/create-pull-request
+      # - name: Create Pull Request
+      #   id: open-pr
+      #   uses: peter-evans/create-pull-request@v4
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     commit-message: Update report
+      #     committer: GitHub <noreply@github.com>
+      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+      #     branch: ${{ steps.find-target-branch.outputs.branch }}
+      #     title: "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}"
+      #     body: "Automated Pull Request. Merge all changes"
+      #     team-reviewers: maintainers
+      #     signoff: false
+      #     draft: false
+      #     delete-branch: false
+
+      # - name: Check outputs
+      #   if: ${{ steps.open-pr.outputs.pull-request-number }}
+      #   run: |
+      #     echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+      #     echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
 
 
       # For now, require manual merge. Consider if we should just auto-merge this.    

--- a/.github/workflows/auto-merge-release-to-master.yml
+++ b/.github/workflows/auto-merge-release-to-master.yml
@@ -25,7 +25,8 @@ jobs:
           if [ "${GITHUB_REF#refs/heads/}" = "cm/auto-merge" ]; then echo '::set-output name=branch::cm/auto-merge-destination'; fi
 
       # Unconditionally create a PR with the changes that needs to be manually reviewed. Consider if we should just automatically do this 
-      # if there is no conflicts.
+      # if there is no conflicts. This step will fail if a PR already exists, so we ignore failures. This also mean that if some other error
+      # occur, the error will also be swallowed. This is acceptable.
       # https://cli.github.com/manual/gh_pr_create
       - name: Create Pull Request
         id: open-pr
@@ -38,38 +39,3 @@ jobs:
           || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-      # # https://github.com/peter-evans/create-pull-request
-      # - name: Create Pull Request
-      #   id: open-pr
-      #   uses: peter-evans/create-pull-request@v4
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     commit-message: Update report
-      #     committer: GitHub <noreply@github.com>
-      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-      #     branch: ${{ steps.find-target-branch.outputs.branch }}
-      #     title: "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}"
-      #     body: "Automated Pull Request. Merge all changes"
-      #     team-reviewers: maintainers
-      #     signoff: false
-      #     draft: false
-      #     delete-branch: false
-
-      # - name: Check outputs
-      #   if: ${{ steps.open-pr.outputs.pull-request-number }}
-      #   run: |
-      #     echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-      #     echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
-
-      # For now, require manual merge. Consider if we should just auto-merge this.    
-      # https://github.com/marketplace/actions/enable-pull-request-automerge
-      # - name: Enable automerge
-      #   if: steps.open-pr.outputs.pr_number != ''
-      #   uses: peter-evans/enable-pull-request-automerge@v2
-      #   with:
-      #     token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      #     pull-request-number: ${{ steps.open-pr.outputs.pr_number }}
-      #     merge-method: merge

--- a/.github/workflows/auto-merge-release-to-master.yml
+++ b/.github/workflows/auto-merge-release-to-master.yml
@@ -24,16 +24,17 @@ jobs:
           if [ "${GITHUB_REF#refs/heads/}" = "releases" ]; then echo '::set-output name=branch::${{ github.event.repository.default_branch }}'; fi
           if [ "${GITHUB_REF#refs/heads/}" = "cm/auto-merge" ]; then echo '::set-output name=branch::cm/auto-merge-destination'; fi
 
+      # Unconditionally create a PR with the changes that needs to be manually reviewed. Consider if we should just automatically do this 
+      # if there is no conflicts.
       # https://cli.github.com/manual/gh_pr_create
       - name: Create Pull Request
         id: open-pr
-        run: gh pr create --base '${{ steps.find-target-branch.outputs.branch }}' --head '${{ github.ref_name }}' --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.'
-
-          # gh pr create \
-          # --base '${{ steps.find-target-branch.outputs.branch }}' \
-          # --head '${{ github.ref_name }}' \ 
-          # --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" \
-          # --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.'
+        run: |
+          gh pr create \
+          --base '${{ steps.find-target-branch.outputs.branch }}' \
+          --head '${{ github.ref_name }}' \
+          --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" \
+          --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/auto-merge-release-to-master.yml
+++ b/.github/workflows/auto-merge-release-to-master.yml
@@ -34,7 +34,8 @@ jobs:
           --base '${{ steps.find-target-branch.outputs.branch }}' \
           --head '${{ github.ref_name }}' \
           --title "[Automated] Merge ${{ github.ref_name }} into ${{ steps.find-target-branch.outputs.branch }}" \
-          --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.'
+          --body 'Automated Pull Request. Remember to choose "Create a merge commit" before merging.' \
+          || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This will automatically create PR's between branches we think should be in sync:

- `releases` -> `master`
- `master` -> `release/ktor2-support`

Example: https://github.com/realm/realm-kotlin/pull/1019

PR is red because I canceled the build on CI as it didn't need to run for this.