### PR TITLE
Fix assemble task for packages

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -33,7 +33,9 @@ import io.realm.kotlin.internal.runIfManaged
 import io.realm.kotlin.internal.toRealmObject
 import io.realm.kotlin.query.RealmQuery
 
-internal open class DynamicMutableRealmImpl(
+// Public due to tests needing to access `close` and trying to make the class visible through
+// annotations didn't work for some reason.
+public open class DynamicMutableRealmImpl(
     configuration: InternalConfiguration,
     dbPointer: LiveRealmPointer
 ) :
@@ -91,5 +93,9 @@ internal open class DynamicMutableRealmImpl(
 
     override fun delete(deleteable: Deleteable) {
         deleteable.asInternalDeleteable().delete()
+    }
+
+    public override fun close() {
+        super.close()
     }
 }

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/StandaloneDynamicMutableRealm.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/StandaloneDynamicMutableRealm.kt
@@ -35,7 +35,7 @@ internal class StandaloneDynamicMutableRealm(configuration: InternalConfiguratio
         RealmInterop.realm_open(configuration.createNativeConfiguration(), null)
     ) {
 
-    fun close() {
+    override fun close() {
         realmReference.close()
     }
 }


### PR DESCRIPTION
This PR just contains some small convenience changes that fixes executing `./gradlew assemble` in `packages`