### PR TITLE
Fix benchmark library not being compiled correctly on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -368,7 +368,7 @@ def runBenchmarks() {
     // For now, just make sure that the benchmarks compile.
     sh '''
           cd benchmarks
-          chmod +x gradlew && ./gradlew assemble --stacktrace --no-daemon
+          chmod +x gradlew && ./gradlew assembleAndroidTest jmhCompileGeneratedClasses --stacktrace --no-daemon
        '''
 }
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,7 +18,7 @@ Benchmarks on Android uses [Jetpack Microbenchmarks](https://developer.android.c
 
 Running benchmarks:
 ```
-./gradlew androidApp:connectedCheck
+./gradlew androidApp:connectedCheck -e no-isolated-storage true
 ```
 
 Benchmarks can also be run from within the IDE as a normal Android Integration Test.
@@ -43,7 +43,8 @@ benchmark results. This must be done manually.
 
 **WARNING:** The Android benchmarks have been configured so they can be run on emulators, but results from
 these should generally not be trusted as variance is extremely high. Prefer running on real devices
-for more accurate results. Read more [here](https://developer.android.com/studio/profile/microbenchmark-overview#benchmark-consistency).
+for more accurate results. Read more [here](https://developer.android.com/studio/profile/microbenchmark-overview#benchmark-consistency). If you are running on an emulator, only emulators on API level 29 and below is working due to restrictions with scoped storage.
+
 
 ### JVM
 

--- a/benchmarks/androidApp/src/androidTest/AndroidManifest.xml
+++ b/benchmarks/androidApp/src/androidTest/AndroidManifest.xml
@@ -11,6 +11,7 @@
     -->
     <application
         android:debuggable="false"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="HardcodedDebugMode"
         tools:replace="android:debuggable" />
 </manifest>

--- a/benchmarks/androidApp/src/androidTest/kotlin/io/realm/kotlin/benchmarks/android/AccessorTests.kt
+++ b/benchmarks/androidApp/src/androidTest/kotlin/io/realm/kotlin/benchmarks/android/AccessorTests.kt
@@ -18,10 +18,10 @@ package io.realm.kotlin.benchmarks.android
 import androidx.benchmark.junit4.BenchmarkRule
 import androidx.benchmark.junit4.measureRepeated
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.realm.Realm
-import io.realm.RealmConfiguration
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.benchmarks.Entity1
-import io.realm.realmListOf
+import io.realm.kotlin.ext.realmListOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -44,7 +44,7 @@ class AccessorTests {
 
     @Before
     fun before() {
-        config = RealmConfiguration.with(schema = setOf(Entity1::class))
+        config = RealmConfiguration.create(schema = setOf(Entity1::class))
         realm = Realm.open(config)
         managedObject = realm.writeBlocking {
             unmanagedObject = Entity1().apply {

--- a/benchmarks/androidApp/src/androidTest/kotlin/io/realm/kotlin/benchmarks/android/BulkWriteTests.kt
+++ b/benchmarks/androidApp/src/androidTest/kotlin/io/realm/kotlin/benchmarks/android/BulkWriteTests.kt
@@ -17,11 +17,11 @@ package io.realm.kotlin.benchmarks.android
 
 import androidx.benchmark.junit4.BenchmarkRule
 import androidx.benchmark.junit4.measureRepeated
-import io.realm.Realm
-import io.realm.RealmConfiguration
-import io.realm.RealmObject
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.benchmarks.Entity1
 import io.realm.kotlin.benchmarks.WithPrimaryKey
+import io.realm.kotlin.types.RealmObject
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule

--- a/benchmarks/androidApp/src/androidTest/kotlin/io/realm/kotlin/benchmarks/android/OpenRealmTests.kt
+++ b/benchmarks/androidApp/src/androidTest/kotlin/io/realm/kotlin/benchmarks/android/OpenRealmTests.kt
@@ -17,10 +17,10 @@ package io.realm.kotlin.benchmarks.android
 
 import androidx.benchmark.junit4.BenchmarkRule
 import androidx.benchmark.junit4.measureRepeated
-import io.realm.Realm
-import io.realm.RealmConfiguration
-import io.realm.RealmObject
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.benchmarks.SchemaSize
+import io.realm.kotlin.types.RealmObject
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule

--- a/benchmarks/jvmApp/src/jmh/kotlin/io/realm/kotlin/benchmark/AccessorTests.kt
+++ b/benchmarks/jvmApp/src/jmh/kotlin/io/realm/kotlin/benchmark/AccessorTests.kt
@@ -15,10 +15,10 @@
  */
 package io.realm.kotlin.benchmark
 
-import io.realm.Realm
-import io.realm.RealmConfiguration
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.benchmarks.Entity1
-import io.realm.realmListOf
+import io.realm.kotlin.ext.realmListOf
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork

--- a/benchmarks/jvmApp/src/jmh/kotlin/io/realm/kotlin/benchmark/BulkWriteTests.kt
+++ b/benchmarks/jvmApp/src/jmh/kotlin/io/realm/kotlin/benchmark/BulkWriteTests.kt
@@ -15,11 +15,11 @@
  */
 package io.realm.kotlin.benchmark
 
-import io.realm.Realm
-import io.realm.RealmConfiguration
-import io.realm.RealmObject
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.benchmarks.Entity1
 import io.realm.kotlin.benchmarks.WithPrimaryKey
+import io.realm.kotlin.types.RealmObject
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork

--- a/benchmarks/jvmApp/src/jmh/kotlin/io/realm/kotlin/benchmark/OpenRealmTests.kt
+++ b/benchmarks/jvmApp/src/jmh/kotlin/io/realm/kotlin/benchmark/OpenRealmTests.kt
@@ -15,11 +15,11 @@
  */
 package io.realm.kotlin.benchmark
 
-import io.realm.Realm
-import io.realm.RealmConfiguration
-import io.realm.RealmObject
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.benchmarks.SCHEMAS
 import io.realm.kotlin.benchmarks.SchemaSize
+import io.realm.kotlin.types.RealmObject
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork


### PR DESCRIPTION
Our CI setup was calling a task that didn't actually check our benchmark code, so it had bit rottet a bit. This PR fixes this + improves the documentation a bit.