### PR TITLE
Fix error formatting for log entries without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Ordering not respected for `RealmQuery.first()`. (Issue [#953](https://github.com/realm/realm-kotlin/issues/953))
 * Sub-querying on a RealmResults ignored the original filter. (Issue [#998](https://github.com/realm/realm-kotlin/pull/998))
 * `RealmResults.query()` semantic returning `RealmResults` was wrong, the return type should be a `RealmQuery`. (Issue [#1013](https://github.com/realm/realm-kotlin/pull/1013))
+* Crash when logging messages with formatting specifiers. (Issue [#1034](https://github.com/realm/realm-kotlin/issues/1034))
 
 ### Compatibility
 * This release is compatible with:

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -533,6 +533,7 @@ void set_log_callback(realm_sync_client_config_t* sync_client_config, jobject lo
                                                                                "log",
                                                                                "(SLjava/lang/String;)V");
                                                   jenv->CallVoidMethod(log_callback, log_method, level, to_jstring(jenv, message));
+                                                  jni_check_exception(jenv);
                                               },
                                               jenv->NewGlobalRef(log_callback), // userdata is the log callback
                                               [](void* userdata) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/RealmLogger.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/RealmLogger.kt
@@ -44,6 +44,6 @@ public interface RealmLogger {
      * Log an event.
      */
     public fun log(level: LogLevel, message: String) {
-        log(level, null, message, null)
+        log(level, null, message)
     }
 }


### PR DESCRIPTION
When messages was logged with formatting arguments, it was erroneously passed a `null` argument, which triggered formatting even though it should. 

Closes #1034 