### PR TITLE
Add support for deleteAll()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Breaking Changes
 
 ### Enhancements
+* Support for `MutableRealm.deleteAll()`.
+* Support for `MutableRealm.delete()`.
+* Support for `DynamicMutableRealm.deleteAll()`.
+* Support for `DynamicMutableRealm.delete()`.
 * [Sync] Support for `User.getProviderType()`.
 * [Sync] Support for `User.getAccessToken()`.
 * [Sync] Support for `User.getRefreshToken()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Enhancements
 * Support for `MutableRealm.deleteAll()`.
-* Support for `MutableRealm.delete()`.
+* Support for `MutableRealm.delete(KClass)`.
 * Support for `DynamicMutableRealm.deleteAll()`.
-* Support for `DynamicMutableRealm.delete()`.
+* Support for `DynamicMutableRealm.delete(className)`.
 * [Sync] Support for `User.getProviderType()`.
 * [Sync] Support for `User.getAccessToken()`.
 * [Sync] Support for `User.getRefreshToken()`.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
@@ -126,4 +126,11 @@ public interface MutableRealm : TypedRealm {
      * @throws IllegalArgumentException if the object is invalid, frozen or not managed by Realm.
      */
     public fun delete(deleteable: Deleteable)
+
+    /**
+     * Deletes all objects from this Realm.
+     *
+     * @throws IllegalStateException if the Realm is closed.
+     */
+    public fun deleteAll()
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
@@ -136,10 +136,16 @@ public interface MutableRealm : TypedRealm {
      * Deletes all objects of the specified class from the Realm.
      *
      * @param KClass the class whose objects should be removed.
+     * @throws IllegalStateException if the class does not exist within the schema.
      */
     public fun delete(schemaClass: KClass<out BaseRealmObject>)
 }
 
+/**
+ * Deletes all objects of the specified class from the Realm.
+ *
+ * Reified convenience wrapper of [MutableRealm.delete].
+ */
 public inline fun <reified T : BaseRealmObject> MutableRealm.delete() {
     delete(T::class)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
@@ -129,8 +129,6 @@ public interface MutableRealm : TypedRealm {
 
     /**
      * Deletes all objects from this Realm.
-     *
-     * @throws IllegalStateException if the Realm is closed.
      */
     public fun deleteAll()
 
@@ -138,7 +136,6 @@ public interface MutableRealm : TypedRealm {
      * Deletes all objects of the specified class from the Realm.
      *
      * @param KClass the class whose objects should be removed.
-     * @throws IllegalStateException if the Realm is closed.
      */
     public fun delete(schemaClass: KClass<out BaseRealmObject>)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
@@ -135,7 +135,7 @@ public interface MutableRealm : TypedRealm {
     /**
      * Deletes all objects of the specified class from the Realm.
      *
-     * @param KClass the class whose objects should be removed.
+     * @param schemaClass the class whose objects should be removed.
      * @throws IllegalStateException if the class does not exist within the schema.
      */
     public fun delete(schemaClass: KClass<out BaseRealmObject>)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
@@ -136,7 +136,7 @@ public interface MutableRealm : TypedRealm {
      * Deletes all objects of the specified class from the Realm.
      *
      * @param schemaClass the class whose objects should be removed.
-     * @throws IllegalStateException if the class does not exist within the schema.
+     * @throws IllegalArgumentException if the class does not exist within the schema.
      */
     public fun delete(schemaClass: KClass<out BaseRealmObject>)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
@@ -133,4 +133,16 @@ public interface MutableRealm : TypedRealm {
      * @throws IllegalStateException if the Realm is closed.
      */
     public fun deleteAll()
+
+    /**
+     * Deletes all objects of the specified class from the Realm.
+     *
+     * @param KClass the class whose objects should be removed.
+     * @throws IllegalStateException if the Realm is closed.
+     */
+    public fun delete(schemaClass: KClass<out BaseRealmObject>)
+}
+
+public inline fun <reified T : BaseRealmObject> MutableRealm.delete() {
+    delete(T::class)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealm.kt
@@ -102,4 +102,11 @@ public interface DynamicMutableRealm : DynamicRealm {
      * @throws IllegalArgumentException if the object is invalid, frozen or not managed by Realm.
      */
     public fun delete(deleteable: Deleteable)
+
+    /**
+     * Deletes all objects from this Realm.
+     *
+     * @throws IllegalStateException if the Realm is closed.
+     */
+    public fun deleteAll()
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealm.kt
@@ -106,12 +106,13 @@ public interface DynamicMutableRealm : DynamicRealm {
     /**
      * Deletes all objects of the specified class from the Realm.
      *
-     * @param schemaClassName the class whose objects should be removed.
+     * @param className the class whose objects should be removed.
+     * @throws IllegalArgumentException if the class does not exist within the schema.
      */
-    public fun delete(schemaClassName: String)
+    public fun delete(className: String)
 
     /**
-     * Deletes all objects from this Realm.
+     * Deletes all objects from the defined schema in the current Realm.
      */
     public fun deleteAll()
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealm.kt
@@ -107,14 +107,11 @@ public interface DynamicMutableRealm : DynamicRealm {
      * Deletes all objects of the specified class from the Realm.
      *
      * @param schemaClassName the class whose objects should be removed.
-     * @throws IllegalStateException if the Realm is closed.
      */
     public fun delete(schemaClassName: String)
 
     /**
      * Deletes all objects from this Realm.
-     *
-     * @throws IllegalStateException if the Realm is closed.
      */
     public fun deleteAll()
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealm.kt
@@ -104,6 +104,14 @@ public interface DynamicMutableRealm : DynamicRealm {
     public fun delete(deleteable: Deleteable)
 
     /**
+     * Deletes all objects of the specified class from the Realm.
+     *
+     * @param schemaClassName the class whose objects should be removed.
+     * @throws IllegalStateException if the Realm is closed.
+     */
+    public fun delete(schemaClassName: String)
+
+    /**
      * Deletes all objects from this Realm.
      *
      * @throws IllegalStateException if the Realm is closed.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
@@ -73,7 +73,7 @@ internal interface InternalMutableRealm : MutableRealm {
             delete(query(schemaClass).find())
         } catch (err: IllegalStateException) {
             if (err.message?.contains("not part of this configuration schema") == true) {
-                throw IllegalArgumentException()
+                throw IllegalArgumentException(err.message)
             } else {
                 throw err
             }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
@@ -68,9 +68,13 @@ internal interface InternalMutableRealm : MutableRealm {
         deleteable.asInternalDeleteable().delete()
     }
 
+    override fun delete(schemaClass: KClass<out BaseRealmObject>) {
+        delete(query(schemaClass).find())
+    }
+
     override fun deleteAll() {
         for (schemaClass: KClass<out BaseRealmObject> in configuration.schema) {
-            delete(query(schemaClass).find())
+            delete(schemaClass)
         }
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
@@ -69,7 +69,15 @@ internal interface InternalMutableRealm : MutableRealm {
     }
 
     override fun delete(schemaClass: KClass<out BaseRealmObject>) {
-        delete(query(schemaClass).find())
+        try {
+            delete(query(schemaClass).find())
+        } catch (err: IllegalStateException) {
+            if (err.message?.contains("not part of this configuration schema") == true) {
+                throw IllegalArgumentException()
+            } else {
+                throw err
+            }
+        }
     }
 
     override fun deleteAll() {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
@@ -22,6 +22,7 @@ import io.realm.kotlin.ext.isValid
 import io.realm.kotlin.types.BaseRealmObject
 import io.realm.kotlin.types.RealmObject
 import kotlinx.coroutines.flow.Flow
+import kotlin.reflect.KClass
 
 internal interface InternalMutableRealm : MutableRealm {
 
@@ -65,5 +66,11 @@ internal interface InternalMutableRealm : MutableRealm {
 
     override fun delete(deleteable: Deleteable) {
         deleteable.asInternalDeleteable().delete()
+    }
+
+    override fun deleteAll() {
+        for (schemaClass: KClass<out BaseRealmObject> in configuration.schema) {
+            delete(query(schemaClass).find())
+        }
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -32,6 +32,7 @@ import io.realm.kotlin.internal.query.ObjectQuery
 import io.realm.kotlin.internal.runIfManaged
 import io.realm.kotlin.internal.toRealmObject
 import io.realm.kotlin.query.RealmQuery
+import io.realm.kotlin.schema.RealmClass
 
 // Public due to tests needing to access `close` and trying to make the class visible through
 // annotations didn't work for some reason.
@@ -93,6 +94,12 @@ public open class DynamicMutableRealmImpl(
 
     override fun delete(deleteable: Deleteable) {
         deleteable.asInternalDeleteable().delete()
+    }
+
+    public override fun deleteAll() {
+        for (schemaClass: RealmClass in schema().classes) {
+            delete(query(schemaClass.name).find())
+        }
     }
 
     public override fun close() {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -96,9 +96,13 @@ public open class DynamicMutableRealmImpl(
         deleteable.asInternalDeleteable().delete()
     }
 
-    public override fun deleteAll() {
+    override fun delete(schemaClassName: String) {
+        delete(query(schemaClassName).find())
+    }
+
+    override fun deleteAll() {
         for (schemaClass: RealmClass in schema().classes) {
-            delete(query(schemaClass.name).find())
+            delete(schemaClass.name)
         }
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmImpl.kt
@@ -96,8 +96,8 @@ public open class DynamicMutableRealmImpl(
         deleteable.asInternalDeleteable().delete()
     }
 
-    override fun delete(schemaClassName: String) {
-        delete(query(schemaClassName).find())
+    override fun delete(className: String) {
+        delete(query(className).find())
     }
 
     override fun deleteAll() {

--- a/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/MutableRealmTests.kt
+++ b/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/MutableRealmTests.kt
@@ -769,7 +769,7 @@ class MutableRealmTests {
     @Test
     fun delete_nonExistingClassThrows() {
         realm.writeBlocking {
-            assertFailsWith<IllegalStateException> {
+            assertFailsWith<IllegalArgumentException> {
                 delete(EmbeddedParentWithPrimaryKey::class)
             }
         }

--- a/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/MutableRealmTests.kt
+++ b/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/MutableRealmTests.kt
@@ -675,4 +675,28 @@ class MutableRealmTests {
             }
         }
     }
+
+    @Test
+    fun deleteAll() {
+        realm.writeBlocking {
+            for (i in 0..9) {
+                copyToRealm(Parent())
+                copyToRealm(Child())
+                copyToRealm(StringPropertyWithPrimaryKey().apply { id = i.toString() })
+                copyToRealm(Sample())
+                copyToRealm(SampleWithPrimaryKey().apply { primaryKey = i.toLong() })
+            }
+            assertEquals(10, query<Parent>().count().find())
+            assertEquals(10, query<Child>().count().find())
+            assertEquals(10, query<StringPropertyWithPrimaryKey>().count().find())
+            assertEquals(10, query<Sample>().count().find())
+            assertEquals(10, query<SampleWithPrimaryKey>().count().find())
+            deleteAll()
+            assertEquals(0, query<Parent>().count().find())
+            assertEquals(0, query<Child>().count().find())
+            assertEquals(0, query<StringPropertyWithPrimaryKey>().count().find())
+            assertEquals(0, query<Sample>().count().find())
+            assertEquals(0, query<SampleWithPrimaryKey>().count().find())
+        }
+    }
 }

--- a/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/MutableRealmTests.kt
+++ b/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/MutableRealmTests.kt
@@ -21,6 +21,9 @@ import io.realm.kotlin.UpdatePolicy
 import io.realm.kotlin.entities.Sample
 import io.realm.kotlin.entities.SampleWithPrimaryKey
 import io.realm.kotlin.entities.StringPropertyWithPrimaryKey
+import io.realm.kotlin.entities.embedded.EmbeddedChild
+import io.realm.kotlin.entities.embedded.EmbeddedParent
+import io.realm.kotlin.entities.embedded.embeddedSchema
 import io.realm.kotlin.entities.link.Child
 import io.realm.kotlin.entities.link.Parent
 import io.realm.kotlin.ext.query
@@ -59,7 +62,7 @@ class MutableRealmTests {
                 StringPropertyWithPrimaryKey::class,
                 Sample::class,
                 SampleWithPrimaryKey::class
-            )
+            ) + embeddedSchema
         ).directory(tmpDir).build()
         realm = Realm.open(configuration)
     }
@@ -680,23 +683,26 @@ class MutableRealmTests {
     fun deleteAll() {
         realm.writeBlocking {
             for (i in 0..9) {
-                copyToRealm(Parent())
-                copyToRealm(Child())
-                copyToRealm(StringPropertyWithPrimaryKey().apply { id = i.toString() })
                 copyToRealm(Sample())
                 copyToRealm(SampleWithPrimaryKey().apply { primaryKey = i.toLong() })
+                copyToRealm(
+                    EmbeddedParent().apply {
+                        id = "level$i-parent"
+                        child = EmbeddedChild().apply {
+                            id = "level$i-child1"
+                        }
+                    }
+                )
             }
-            assertEquals(10, query<Parent>().count().find())
-            assertEquals(10, query<Child>().count().find())
-            assertEquals(10, query<StringPropertyWithPrimaryKey>().count().find())
             assertEquals(10, query<Sample>().count().find())
             assertEquals(10, query<SampleWithPrimaryKey>().count().find())
+            assertEquals(10, query<EmbeddedParent>().count().find())
+            assertEquals(10, query<EmbeddedChild>().count().find())
             deleteAll()
-            assertEquals(0, query<Parent>().count().find())
-            assertEquals(0, query<Child>().count().find())
-            assertEquals(0, query<StringPropertyWithPrimaryKey>().count().find())
             assertEquals(0, query<Sample>().count().find())
             assertEquals(0, query<SampleWithPrimaryKey>().count().find())
+            assertEquals(0, query<EmbeddedParent>().count().find())
+            assertEquals(0, query<EmbeddedChild>().count().find())
         }
     }
 }

--- a/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicMutableRealmTests.kt
+++ b/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicMutableRealmTests.kt
@@ -642,4 +642,25 @@ class DynamicMutableRealmTests {
             }
         }
     }
+
+    @Test
+    fun deleteAll() {
+        dynamicMutableRealm.run {
+            for (i in 0..9) {
+                copyToRealm(DynamicMutableRealmObject.create("Sample"))
+                copyToRealm(DynamicMutableRealmObject.create("PrimaryKeyString").set("primaryKey", i.toString()))
+                copyToRealm(DynamicMutableRealmObject.create("PrimaryKeyStringNullable").set("primaryKey", i.toString()))
+                copyToRealm(DynamicMutableRealmObject.create("SampleWithPrimaryKey").set("primaryKey", i.toLong()))
+            }
+            assertEquals(10, query("Sample").count().find())
+            assertEquals(10, query("PrimaryKeyString").count().find())
+            assertEquals(10, query("PrimaryKeyStringNullable").count().find())
+            assertEquals(10, query("SampleWithPrimaryKey").count().find())
+            deleteAll()
+            assertEquals(0, query("Sample").count().find())
+            assertEquals(0, query("PrimaryKeyString").count().find())
+            assertEquals(0, query("PrimaryKeyStringNullable").count().find())
+            assertEquals(0, query("SampleWithPrimaryKey").count().find())
+        }
+    }
 }

--- a/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicMutableRealmTests.kt
+++ b/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicMutableRealmTests.kt
@@ -648,19 +648,28 @@ class DynamicMutableRealmTests {
         dynamicMutableRealm.run {
             for (i in 0..9) {
                 copyToRealm(DynamicMutableRealmObject.create("Sample"))
-                copyToRealm(DynamicMutableRealmObject.create("PrimaryKeyString").set("primaryKey", i.toString()))
-                copyToRealm(DynamicMutableRealmObject.create("PrimaryKeyStringNullable").set("primaryKey", i.toString()))
                 copyToRealm(DynamicMutableRealmObject.create("SampleWithPrimaryKey").set("primaryKey", i.toLong()))
+                copyToRealm(
+                    DynamicMutableRealmObject.create(
+                        "EmbeddedParent",
+                        "children" to realmListOf(
+                            DynamicMutableRealmObject.create(
+                                "EmbeddedChild",
+                                "id" to "child$i"
+                            )
+                        )
+                    )
+                )
             }
             assertEquals(10, query("Sample").count().find())
-            assertEquals(10, query("PrimaryKeyString").count().find())
-            assertEquals(10, query("PrimaryKeyStringNullable").count().find())
             assertEquals(10, query("SampleWithPrimaryKey").count().find())
+            assertEquals(10, query("EmbeddedParent").count().find())
+            assertEquals(10, query("EmbeddedChild").count().find())
             deleteAll()
             assertEquals(0, query("Sample").count().find())
-            assertEquals(0, query("PrimaryKeyString").count().find())
-            assertEquals(0, query("PrimaryKeyStringNullable").count().find())
             assertEquals(0, query("SampleWithPrimaryKey").count().find())
+            assertEquals(0, query("EmbeddedParent").count().find())
+            assertEquals(0, query("EmbeddedChild").count().find())
         }
     }
 }

--- a/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicMutableRealmTests.kt
+++ b/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicMutableRealmTests.kt
@@ -52,6 +52,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@Suppress("LargeClass")
 class DynamicMutableRealmTests {
     private lateinit var tmpDir: String
     private lateinit var configuration: RealmConfiguration
@@ -670,6 +671,50 @@ class DynamicMutableRealmTests {
             assertEquals(0, query("SampleWithPrimaryKey").count().find())
             assertEquals(0, query("EmbeddedParent").count().find())
             assertEquals(0, query("EmbeddedChild").count().find())
+        }
+    }
+
+    @Test
+    fun delete() {
+        dynamicMutableRealm.run {
+            for (i in 0..9) {
+                copyToRealm(DynamicMutableRealmObject.create("Sample"))
+                copyToRealm(
+                    DynamicMutableRealmObject.create("SampleWithPrimaryKey")
+                        .set("primaryKey", i.toLong())
+                )
+                copyToRealm(
+                    DynamicMutableRealmObject.create(
+                        "EmbeddedParent",
+                        "children" to realmListOf(
+                            DynamicMutableRealmObject.create(
+                                "EmbeddedChild",
+                                "id" to "child$i"
+                            )
+                        )
+                    )
+                )
+            }
+            assertEquals(10, query("Sample").count().find())
+            delete("Sample")
+            assertEquals(0, query("Sample").count().find())
+            assertEquals(10, query("SampleWithPrimaryKey").count().find())
+            delete("SampleWithPrimaryKey")
+            assertEquals(0, query("SampleWithPrimaryKey").count().find())
+            assertEquals(10, query("EmbeddedParent").count().find())
+            assertEquals(10, query("EmbeddedChild").count().find())
+            delete("EmbeddedParent")
+            assertEquals(0, query("EmbeddedParent").count().find())
+            assertEquals(0, query("EmbeddedChild").count().find())
+        }
+    }
+
+    @Test
+    fun delete_nonExistingClassThrows() {
+        dynamicMutableRealm.run {
+            assertFailsWith<IllegalArgumentException> {
+                delete("NonExistingClassName")
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #574 and #573.
Adds functionality that allows a user to wipe their current realm by invoking deleteAll().
Adds functionality to delete all objects of a specified class with delete(classname) or delete(KClass).