### PR TITLE
Use async open when opening partition-based Realms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.2.1 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* [Sync] Using `SyncConfiguration.Builder.waitForInitialRemoteDataOpen()` is now much faster if the server realm contains a lot of data.
+
+### Compatibility
+* This release is compatible with:
+  * Kotlin 1.6.10 and above.
+  * Coroutines 1.6.0-native-mt. Also compatible with Coroutines 1.6.0 but requires enabling of the new memory model and disabling of freezing, see https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility for details on that.
+  * AtomicFu 0.17.0 and above.
+* Minimum Gradle version: 6.1.1.
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
 ## 1.2.0 (2022-09-30)
 
 ### Breaking Changes

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/Callback.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/Callback.kt
@@ -80,3 +80,7 @@ fun interface SubscriptionSetCallback {
 fun interface DataInitializationCallback {
     fun invoke(): Boolean
 }
+
+fun interface AsyncOpenCallback {
+    fun invoke(error: Throwable?)
+}

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -82,6 +82,7 @@ typealias RealmChangesPointer = NativePointer<RealmChangesT>
 
 // Sync types
 // Pure marker interfaces corresponding to the C-API realm_x_t struct types
+interface RealmAsyncOpenTaskT : CapiT
 interface RealmAppT : CapiT
 interface RealmAppConfigT : CapiT
 interface RealmSyncConfigT : CapiT
@@ -96,6 +97,7 @@ interface RealmSubscriptionSetT : RealmBaseSubscriptionSet
 interface RealmMutableSubscriptionSetT : RealmBaseSubscriptionSet
 // Public type aliases binding to internal verbose type safe type definitions. This should allow us
 // to easily change implementation details later on.
+typealias RealmAsyncOpenTaskPointer = NativePointer<RealmAsyncOpenTaskT>
 typealias RealmAppPointer = NativePointer<RealmAppT>
 typealias RealmAppConfigurationPointer = NativePointer<RealmAppConfigT>
 typealias RealmSyncConfigurationPointer = NativePointer<RealmSyncConfigT>
@@ -148,12 +150,17 @@ expect object RealmInterop {
      *  The [config] Pointer passed in should only be used _once_ to open a Realm.
      *
      *  @return Pair of `(pointer, fileCreated)` where `pointer` is a reference to the SharedReam
-     *  that was opened and `fileCreated` indicate wether or not the file was created as part of
+     *  that was opened and `fileCreated` indicate whether or not the file was created as part of
      *  opening the Realm.
      */
     // The dispatcher argument is only used on Native to build a core scheduler dispatching to the
     // dispatcher. The realm itself must also be opened on the same thread
     fun realm_open(config: RealmConfigurationPointer, dispatcher: CoroutineDispatcher? = null): Pair<LiveRealmPointer, Boolean>
+
+    // Opening a Realm asynchronously. Only supported for synchronized realms.
+    fun realm_open_synchronized(config: RealmConfigurationPointer): RealmAsyncOpenTaskPointer
+    fun realm_async_open_task_start(task: RealmAsyncOpenTaskPointer, callback: AsyncOpenCallback)
+    fun realm_async_open_task_cancel(task: RealmAsyncOpenTaskPointer)
 
     fun realm_add_realm_changed_callback(realm: LiveRealmPointer, block: () -> Unit): RealmCallbackTokenPointer
     fun realm_add_schema_changed_callback(realm: LiveRealmPointer, block: (RealmSchemaPointer) -> Unit): RealmCallbackTokenPointer

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -532,14 +532,12 @@ actual object RealmInterop {
                 memScoped {
                     var exception: Throwable? = null
                     if (error != null) {
-                        val err = alloc<realm_error_t>() // FIXME Does this need to be memscoped
+                        val err = alloc<realm_error_t>()
                         realm_wrapper.realm_get_async_error(error, err.ptr)
                         val message = "[${err.error}]: ${err.message?.toKString()}"
                         exception = coreErrorAsThrowable(err.error, message)
                     } else {
-                        val realmPtr = realm_wrapper.realm_from_thread_safe_reference(realm, null)
-                        realm_wrapper.realm_close(realmPtr)
-                        realm_wrapper.realm_release(realm) // FIXME Do we need to cleanup the realm_threadsafe_reference. We don't do that in client reset callbacks
+                        realm_wrapper.realm_release(realm)
                     }
                     safeUserData<AsyncOpenCallback>(userData).invoke(exception)
                 }
@@ -1953,6 +1951,7 @@ actual object RealmInterop {
 
                 // afterRealm is wrapped inside a ThreadSafeReference so the pointer needs to be resolved
                 val afterRealmPtr = realm_wrapper.realm_from_thread_safe_reference(afterRealm, null)
+                realm_release(afterRealm)
                 val afterDb = CPointerWrapper<LiveRealmT>(afterRealmPtr, false)
 
                 // Check if exceptions have been thrown, return true if all went as it should

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -109,7 +109,6 @@ import realm_wrapper.realm_sync_error_code_t
 import realm_wrapper.realm_sync_session_resync_mode
 import realm_wrapper.realm_sync_session_state_e
 import realm_wrapper.realm_t
-import realm_wrapper.realm_thread_safe_reference_t
 import realm_wrapper.realm_user_identity
 import realm_wrapper.realm_user_t
 import realm_wrapper.realm_value_t
@@ -533,14 +532,14 @@ actual object RealmInterop {
                 memScoped {
                     var exception: Throwable? = null
                     if (error != null) {
-                       val err = alloc<realm_error_t>() // FIXME Does this need to be memscoped
-                       realm_wrapper.realm_get_async_error(error, err.ptr)
-                       val message = "[${err.error}]: ${err.message?.toKString()}"
-                       exception = coreErrorAsThrowable(err.error, message)
+                        val err = alloc<realm_error_t>() // FIXME Does this need to be memscoped
+                        realm_wrapper.realm_get_async_error(error, err.ptr)
+                        val message = "[${err.error}]: ${err.message?.toKString()}"
+                        exception = coreErrorAsThrowable(err.error, message)
                     } else {
-                       val realmPtr = realm_wrapper.realm_from_thread_safe_reference(realm, null)
-                       realm_wrapper.realm_close(realmPtr)
-                       realm_wrapper.realm_release(realm) // FIXME Do we need to cleanup the realm_threadsafe_reference. We don't do that in client reset callbacks
+                        val realmPtr = realm_wrapper.realm_from_thread_safe_reference(realm, null)
+                        realm_wrapper.realm_close(realmPtr)
+                        realm_wrapper.realm_release(realm) // FIXME Do we need to cleanup the realm_threadsafe_reference. We don't do that in client reset callbacks
                     }
                     safeUserData<AsyncOpenCallback>(userData).invoke(exception)
                 }

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1951,7 +1951,6 @@ actual object RealmInterop {
 
                 // afterRealm is wrapped inside a ThreadSafeReference so the pointer needs to be resolved
                 val afterRealmPtr = realm_wrapper.realm_from_thread_safe_reference(afterRealm, null)
-                realm_release(afterRealm)
                 val afterDb = CPointerWrapper<LiveRealmT>(afterRealmPtr, false)
 
                 // Check if exceptions have been thrown, return true if all went as it should

--- a/packages/cinterop/src/jvm/jni/java_class_global_def.hpp
+++ b/packages/cinterop/src/jvm/jni/java_class_global_def.hpp
@@ -60,6 +60,7 @@ private:
         , m_io_realm_kotlin_internal_interop_sync_before_client_reset_handler(env, "io/realm/kotlin/internal/interop/SyncBeforeClientResetHandler", false)
         , m_io_realm_kotlin_internal_interop_sync_after_client_reset_handler(env, "io/realm/kotlin/internal/interop/SyncAfterClientResetHandler", false)
         , m_io_realm_kotlin_internal_interop_core_error_utils(env, "io/realm/kotlin/internal/interop/CoreErrorUtils", false)
+        , m_io_realm_kotlin_internal_interop_sync_async_open_callback(env, "io/realm/kotlin/internal/interop/AsyncOpenCallback", false)
     {
     }
 
@@ -80,6 +81,7 @@ private:
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_before_client_reset_handler;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_after_client_reset_handler;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_core_error_utils;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_async_open_callback;
 
     inline static std::unique_ptr<JavaClassGlobalDef>& instance()
     {
@@ -175,6 +177,11 @@ public:
     inline static const jni_util::JavaClass& core_error_utils()
     {
         return instance()->m_io_realm_kotlin_internal_interop_core_error_utils;
+    }
+
+    inline static const jni_util::JavaClass& async_open_callback()
+    {
+        return instance()->m_io_realm_kotlin_internal_interop_sync_async_open_callback;
     }
 
     inline static const jni_util::JavaMethod function0Method(JNIEnv* env) {

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -186,6 +186,18 @@ actual object RealmInterop {
         return Pair(realmPtr, fileCreated)
     }
 
+    actual fun realm_open_synchronized(config: RealmConfigurationPointer): RealmAsyncOpenTaskPointer {
+        return LongPointerWrapper(realmc.realm_open_synchronized(config.cptr()))
+    }
+
+    actual fun realm_async_open_task_start(task: RealmAsyncOpenTaskPointer, callback: AsyncOpenCallback) {
+        realmc.realm_async_open_task_start(task.cptr(), callback)
+    }
+
+    actual fun realm_async_open_task_cancel(task: RealmAsyncOpenTaskPointer) {
+        realmc.realm_async_open_task_cancel(task.cptr())
+    }
+
     actual fun realm_add_realm_changed_callback(realm: LiveRealmPointer, block: () -> Unit): RealmCallbackTokenPointer {
         return LongPointerWrapper(
             realmc.realm_add_realm_changed_callback(realm.cptr(), block),

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -164,7 +164,7 @@ std::string rlm_stdstr(realm_string_t val)
     };
 }
 
-// reuse void callback type as template for `
+// reuse void callback type as template for `realm_async_open_task_completion_func_t` function
 %apply (realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
 (realm_async_open_task_completion_func_t, void* userdata, realm_free_userdata_func_t userdata_free)
 };

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -164,6 +164,19 @@ std::string rlm_stdstr(realm_string_t val)
     };
 }
 
+// reuse void callback type as template for `
+%apply (realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
+(realm_async_open_task_completion_func_t, void* userdata, realm_free_userdata_func_t userdata_free)
+};
+%typemap(in) (realm_async_open_task_completion_func_t, void* userdata, realm_free_userdata_func_t userdata_free) {
+    auto jenv = get_env(true);
+    $1 = reinterpret_cast<realm_async_open_task_completion_func_t>(realm_async_open_task_callback);
+    $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
+    $3 = [](void *userdata) {
+        get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
+    };
+}
+
 // Core isn't strict about naming their callbacks, so sometimes SWIG cannot map correctly :/
 %typemap(jstype) (realm_sync_on_subscription_state_changed_t, void* userdata, realm_free_userdata_func_t userdata_free) "Object" ;
 %typemap(jtype) (realm_sync_on_subscription_state_changed_t, void* userdata, realm_free_userdata_func_t userdata_free) "Object" ;
@@ -216,7 +229,7 @@ return $jnicall;
                realm_collection_changes_t*, realm_callback_token_t*,
                realm_flx_sync_subscription_t*, realm_flx_sync_subscription_set_t*,
                realm_flx_sync_mutable_subscription_set_t*, realm_flx_sync_subscription_desc_t*,
-               realm_set_t*};
+               realm_set_t*, realm_async_open_task_t* };
 
 // For all functions returning a pointer or bool, check for null/false and throw an error if
 // realm_get_last_error returns true.

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -677,9 +677,7 @@ void realm_async_open_task_callback(void* userdata, realm_thread_safe_reference_
                 jint(err.error),
                 error_message);
     } else {
-        auto realm_ptr = realm_from_thread_safe_reference(realm, nullptr);
-        realm_close(realm_ptr);
-        realm_release(realm); // FIXME Is this needed. We are not doing it for client reset callbacks?
+        realm_release(realm);
     }
     jobject callback = static_cast<jobject>(userdata);
     env->CallVoidMethod(callback, java_invoke_method, exception);
@@ -715,6 +713,7 @@ after_client_reset(void* userdata, realm_t* before_realm,
                                                    "(Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;Z)V");
     auto before_pointer = wrap_pointer(env, reinterpret_cast<jlong>(before_realm), false);
     realm_t* after_realm_ptr = realm_from_thread_safe_reference(after_realm, NULL);
+    realm_release(after_realm);
     auto after_pointer = wrap_pointer(env, reinterpret_cast<jlong>(after_realm_ptr), false);
     env->CallVoidMethod(static_cast<jobject>(userdata), java_after_callback_function, before_pointer, after_pointer, did_recover);
 

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -654,6 +654,38 @@ void realm_subscriptionset_changed_callback(void* userdata, realm_flx_sync_subsc
     jni_check_exception(env);
 }
 
+void realm_async_open_task_callback(void* userdata, realm_thread_safe_reference_t* realm, const realm_async_error_t* error) {
+    auto env = get_env(true);
+    static JavaMethod java_invoke_method(env,
+                                         JavaClassGlobalDef::async_open_callback(),
+                                         "invoke",
+                                         "(Ljava/lang/Throwable;)V");
+    jobject exception = nullptr;
+    if (error) {
+        realm_error_t err;
+        realm_get_async_error(error, &err);
+        std::string message("[" + std::to_string(err.error) + "]: " + err.message);
+        const JavaClass& error_type_class = realm::_impl::JavaClassGlobalDef::core_error_utils();
+        static JavaMethod error_type_as_exception(env,
+                                                  error_type_class,
+                                                  "coreErrorAsThrowable",
+                                                  "(ILjava/lang/String;)Ljava/lang/Throwable;", true);
+        jstring error_message = (env)->NewStringUTF(message.c_str());
+        exception = (env)->CallStaticObjectMethod(
+                error_type_class,
+                error_type_as_exception,
+                jint(err.error),
+                error_message);
+    } else {
+        auto realm_ptr = realm_from_thread_safe_reference(realm, nullptr);
+        realm_close(realm_ptr);
+        realm_release(realm); // FIXME Is this needed. We are not doing it for client reset callbacks?
+    }
+    jobject callback = static_cast<jobject>(userdata);
+    env->CallVoidMethod(callback, java_invoke_method, exception);
+    jni_check_exception(env);
+}
+
 bool
 before_client_reset(void* userdata, realm_t* before_realm) {
     auto env = get_env(true);

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -713,7 +713,6 @@ after_client_reset(void* userdata, realm_t* before_realm,
                                                    "(Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;Z)V");
     auto before_pointer = wrap_pointer(env, reinterpret_cast<jlong>(before_realm), false);
     realm_t* after_realm_ptr = realm_from_thread_safe_reference(after_realm, NULL);
-    realm_release(after_realm);
     auto after_pointer = wrap_pointer(env, reinterpret_cast<jlong>(after_realm_ptr), false);
     env->CallVoidMethod(static_cast<jobject>(userdata), java_after_callback_function, before_pointer, after_pointer, did_recover);
 

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -76,6 +76,15 @@ void
 realm_subscriptionset_changed_callback(void* userdata,
                                        realm_flx_sync_subscription_set_state_e state);
 
+void
+realm_async_open_task_callback(void* userdata,
+                               realm_thread_safe_reference_t* realm,
+                               const realm_async_error_t* error);
+
+void
+realm_subscriptionset_changed_callback(void* userdata,
+                                       realm_flx_sync_subscription_set_state_e state);
+
 bool
 before_client_reset(void* userdata, realm_t* before_realm);
 

--- a/packages/library-base/proguard-rules-consumer-common.pro
+++ b/packages/library-base/proguard-rules-consumer-common.pro
@@ -87,6 +87,9 @@
 -keep class io.realm.kotlin.internal.interop.SyncAfterClientResetHandler {
     *;
 }
+-keep class io.realm.kotlin.internal.interop.AsyncOpenCallback {
+    *;
+}
 
 # Preserve Function<X> methods as they back various functional interfaces called from JNI
 -keep class kotlin.jvm.functions.Function* {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -98,9 +98,14 @@ public open class ConfigurationImpl constructor(
         return configInitializer(nativeConfig)
     }
 
-    override suspend fun realmOpened(realm: RealmImpl, fileCreated: Boolean) {
+    override suspend fun openRealm(realm: RealmImpl): Pair<LiveRealmPointer, Boolean> {
+        val configPtr = realm.configuration.createNativeConfiguration()
+        return RealmInterop.realm_open(configPtr)
+    }
+
+    override suspend fun initializeRealmData(realm: RealmImpl, realmFileCreated: Boolean) {
         val initCallback = initialDataCallback
-        if (fileCreated && initCallback != null) {
+        if (realmFileCreated && initCallback != null) {
             realm.write { // this: MutableRealm
                 with(initCallback) { // this: InitialDataCallback
                     write()

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
@@ -68,7 +68,7 @@ public class RealmImpl private constructor(
         SuspendableWriter(this, configuration.writeDispatcher)
 
     // inline classes cannot be lateinit, so use a placeholder instead.
-    private var _realmReference: AtomicRef<RealmReference> = atomic(object: RealmReference {
+    private var _realmReference: AtomicRef<RealmReference> = atomic(object : RealmReference {
         override val owner: BaseRealmImpl
             get() = throw IllegalStateException("Placeholder should not be access")
         override val schemaMetadata: SchemaMetadata
@@ -127,7 +127,6 @@ public class RealmImpl private constructor(
                     updateRealmPointer(realmReference)
                 }
             }
-
         } catch (ex: Throwable) {
             // Something went wrong initializing Realm, delete the file, so initialization logic
             // can run again.

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -127,11 +127,11 @@ internal class SyncConfigurationImpl(
         // Download subscription data if needed. Partition-base realms can only configure
         // `waitForInitialRemoteData` which is being accounted for when calling `openRealm`, so that
         // case is ignored here.
-        if (initialRemoteData != null) {
-            val newFile = initialSubscriptions != null && realmFileCreated
-            val updateExistingFile = initialSubscriptions != null && initialSubscriptions.rerunOnOpen && !realmFileCreated
-            if (newFile || updateExistingFile) {
-                val success: Boolean = realm.subscriptions.waitForSynchronization(initialRemoteData.timeout)
+        if (initialRemoteData != null && initialSubscriptions != null) {
+            val updateExistingFile = initialSubscriptions.rerunOnOpen && !realmFileCreated
+            if (realmFileCreated || updateExistingFile) {
+                val success: Boolean =
+                    realm.subscriptions.waitForSynchronization(initialRemoteData.timeout)
                 if (!success) {
                     throw DownloadingRealmTimeOutException(this)
                 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -20,9 +20,11 @@ import io.realm.kotlin.internal.InternalConfiguration
 import io.realm.kotlin.internal.MutableLiveRealmImpl
 import io.realm.kotlin.internal.RealmImpl
 import io.realm.kotlin.internal.TypedFrozenRealmImpl
+import io.realm.kotlin.internal.interop.AsyncOpenCallback
 import io.realm.kotlin.internal.interop.FrozenRealmPointer
 import io.realm.kotlin.internal.interop.LiveRealmPointer
 import io.realm.kotlin.internal.interop.RealmAppPointer
+import io.realm.kotlin.internal.interop.RealmAsyncOpenTaskPointer
 import io.realm.kotlin.internal.interop.RealmConfigurationPointer
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.RealmSyncConfigurationPointer
@@ -45,11 +47,16 @@ import io.realm.kotlin.mongodb.sync.SyncClientResetStrategy
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncMode
 import io.realm.kotlin.mongodb.sync.SyncSession
-import io.realm.kotlin.mongodb.syncSession
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 
 @Suppress("LongParameterList")
 internal class SyncConfigurationImpl(
-    private val configuration: io.realm.kotlin.internal.InternalConfiguration,
+    private val configuration: InternalConfiguration,
     internal val partitionValue: PartitionValue?,
     override val user: UserImpl,
     override val errorHandler: SyncSession.ErrorHandler,
@@ -58,9 +65,57 @@ internal class SyncConfigurationImpl(
     override val initialRemoteData: InitialRemoteDataConfiguration?
 ) : InternalConfiguration by configuration, SyncConfiguration {
 
-    override suspend fun realmOpened(realm: RealmImpl, fileCreated: Boolean) {
+    override suspend fun openRealm(realm: RealmImpl): Pair<LiveRealmPointer, Boolean> {
+        // Partition-based Realms with `waitForInitialRemoteData` enabled will use
+        // async open first do download the server side Realm. This is much much faster than
+        // creating the Realm locally first and then downloading (and integrating) changes into
+        // that.
+        if (partitionValue != null && initialRemoteData != null) {
+            // Channel to work around not being able to use `suspendCoroutine` to wrap the callback, as
+            // that results in the `Continuation` being frozen, which breaks it.
+            val channel = Channel<Any>(1)
+            val taskPointer: AtomicRef<RealmAsyncOpenTaskPointer?> = atomic(null)
+            try {
+                val result: Any = withTimeout(initialRemoteData.timeout.inWholeMilliseconds) {
+                    withContext(realm.configuration.notificationDispatcher) {
+                        val callback = AsyncOpenCallback { error: Throwable? ->
+                            if (error != null) {
+                                channel.trySend(error)
+                            } else {
+                                channel.trySend(true)
+                            }
+                        }.freeze()
+
+                        val configPtr = createNativeConfiguration()
+                        taskPointer.value = RealmInterop.realm_open_synchronized(configPtr)
+                        RealmInterop.realm_async_open_task_start(taskPointer.value!!, callback)
+                        channel.receive()
+                    }
+                }
+                when (result) {
+                    is Boolean -> { /* Do nothing, opening the Realm will follow below */ }
+                    is Throwable -> throw result
+                    else -> throw IllegalStateException("Unexpected value: $result")
+                }
+            } catch (ex: TimeoutCancellationException) {
+                taskPointer.value?.let { ptr: RealmAsyncOpenTaskPointer ->
+                    RealmInterop.realm_async_open_task_cancel(ptr)
+                }
+                throw DownloadingRealmTimeOutException(this)
+            } finally {
+                channel.close()
+            }
+        }
+
+        // Open the local Realm file. This will also include any data potentially downloaded
+        // by Async Open above.
+        return configuration.openRealm(realm)
+    }
+
+    override suspend fun initializeRealmData(realm: RealmImpl, realmFileCreated: Boolean) {
+        // Create or update subscriptions for Flexible Sync realms as needed.
         initialSubscriptions?.let { initialSubscriptionsConfig ->
-            if (initialSubscriptionsConfig.rerunOnOpen || fileCreated) {
+            if (initialSubscriptionsConfig.rerunOnOpen || realmFileCreated) {
                 realm.subscriptions.update {
                     with(initialSubscriptions.callback) {
                         write(realm)
@@ -68,17 +123,23 @@ internal class SyncConfigurationImpl(
                 }
             }
         }
-        if (initialRemoteData != null && (fileCreated || initialSubscriptions?.rerunOnOpen == true)) {
-            val success: Boolean = if (initialSubscriptions != null) {
-                realm.subscriptions.waitForSynchronization(initialRemoteData.timeout)
-            } else {
-                realm.syncSession.downloadAllServerChanges(initialRemoteData.timeout)
-            }
-            if (!success) {
-                throw DownloadingRealmTimeOutException(this)
+
+        // Download subscription data if needed. Partition-base realms can only configure
+        // `waitForInitialRemoteData` which is being accounted for when calling `openRealm`, so that
+        // case is ignored here.
+        if (initialRemoteData != null) {
+            val newFile = initialSubscriptions != null && realmFileCreated
+            val updateExistingFile = initialSubscriptions != null && initialSubscriptions.rerunOnOpen && !realmFileCreated
+            if (newFile || updateExistingFile) {
+                val success: Boolean = realm.subscriptions.waitForSynchronization(initialRemoteData.timeout)
+                if (!success) {
+                    throw DownloadingRealmTimeOutException(this)
+                }
             }
         }
-        configuration.realmOpened(realm, fileCreated)
+
+        // Last, run any local Realm initialization logic
+        configuration.initializeRealmData(realm, realmFileCreated)
     }
 
     override fun createNativeConfiguration(): RealmConfigurationPointer {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
@@ -427,7 +427,7 @@ public interface SyncConfiguration : Configuration {
          * ```
          *
          * @param timeout how long to wait for the download to complete before an
-         * [io.realm.mongodb.exceptions.DownloadingRealmTimeOutException] is thrown when opening
+         * [io.realm.kotlin.mongodb.exceptions.DownloadingRealmTimeOutException] is thrown when opening
          * the Realm.
          */
         public fun waitForInitialRemoteData(timeout: Duration = Duration.INFINITE): Builder =


### PR DESCRIPTION
Closing #1046 

This has been verified to fix the difference reported in https://jira.mongodb.org/browse/HELP-37904.

There are some open questions about how to clean up threadsafe references. It looks like we might be leaking memory in the client reset tests.