### PR TITLE
Add RealmInstant.now()

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -2,6 +2,7 @@ package io.realm.kotlin.internal.platform
 
 import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.log.RealmLogger
+import io.realm.kotlin.types.RealmInstant
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KType
 
@@ -108,6 +109,11 @@ public expect fun threadId(): ULong
  * Returns UNIX epoch time in seconds.
  */
 public expect fun epochInSeconds(): Long
+
+/**
+ * Returns a RealmInstant representing the time that has passed since the Unix epoch.
+ */
+public expect fun internalNow(): RealmInstant
 
 /**
  * Returns the type of a mutable property.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmInstant.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmInstant.kt
@@ -16,6 +16,7 @@
 package io.realm.kotlin.types
 
 import io.realm.kotlin.internal.RealmInstantImpl
+import io.realm.kotlin.internal.platform.internalNow
 
 /**
  * A representation of a Realm timestamp. A timestamp represent a single point in time defined as
@@ -72,6 +73,11 @@ public interface RealmInstant : Comparable<RealmInstant> {
                 return if (epochSeconds < 0) MIN else MAX
             }
             return RealmInstantImpl(s, ns)
+        }
+
+        public fun now(): RealmInstant {
+            val internalNow = internalNow()
+            return RealmInstantImpl(internalNow.epochSeconds, internalNow.nanosecondsOfSecond)
         }
     }
 

--- a/packages/library-base/src/darwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/darwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -1,7 +1,9 @@
 package io.realm.kotlin.internal.platform
 
+import io.realm.kotlin.internal.RealmInstantImpl
 import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.log.RealmLogger
+import io.realm.kotlin.types.RealmInstant
 import kotlinx.cinterop.BooleanVar
 import kotlinx.cinterop.ObjCObjectVar
 import kotlinx.cinterop.ULongVar
@@ -43,6 +45,33 @@ public actual fun threadId(): ULong {
 
 public actual fun epochInSeconds(): Long =
     NSDate().timeIntervalSince1970().toLong()
+
+/**
+ * Inspired by: https://github.com/Kotlin/kotlinx-datetime/blob/master/core/darwin/src/Converters.kt
+ * and https://github.com/Kotlin/kotlinx-datetime/blob/master/core/native/src/Instant.kt.
+ *
+ * Even though Darwin only uses millisecond precision, it is possible that [date] uses larger resolution, storing
+ * microseconds or even nanoseconds. In this case, the sub-millisecond parts of [date] are rounded to the nearest
+ * millisecond, given that they are likely to be conversion artifacts.
+ *
+ * Since internalNow() should only logically return a value after the Unix epoch, it is safe to create a RealmInstant
+ * without considering having to pass negative nanoseconds.
+ */
+@Suppress("MagicNumber")
+public actual fun internalNow(): RealmInstant {
+    val secs = NSDate().timeIntervalSince1970
+    val millis = (secs * 1000 + if (secs > 0) 0.5 else -0.5).toLong()
+    return if (millis < RealmInstant.MIN.epochSeconds * 1000) {
+        RealmInstant.MIN
+    } else if (millis > RealmInstant.MAX.epochSeconds * 1000) {
+        RealmInstant.MAX
+    } else {
+        RealmInstantImpl(
+            millis.floorDiv(1000.toLong()),
+            (millis.mod(1000.toLong()) * 1000).toInt()
+        )
+    }
+}
 
 public actual fun <T> T.freeze(): T = this.freeze()
 

--- a/packages/library-base/src/jvm/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/jvm/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -1,9 +1,12 @@
 package io.realm.kotlin.internal.platform
 
+import io.realm.kotlin.internal.RealmInstantImpl
+import io.realm.kotlin.types.RealmInstant
 import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KType
+import java.time.Clock as jtClock
 
 @Suppress("MayBeConst") // Cannot make expect/actual const
 public actual val RUNTIME: String = "JVM"
@@ -17,6 +20,15 @@ public actual fun threadId(): ULong {
 
 public actual fun epochInSeconds(): Long =
     TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())
+
+/**
+* Since internalNow() should only logically return a value after the Unix epoch, it is safe to create a RealmInstant
+* without considering having to pass negative nanoseconds.
+*/
+public actual fun internalNow(): RealmInstant {
+    val jtInstant = jtClock.systemUTC().instant()
+    return RealmInstantImpl(jtInstant.epochSecond, jtInstant.nano)
+}
 
 public actual fun <T> T.freeze(): T = this
 

--- a/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/RealmInstantTests.kt
+++ b/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/RealmInstantTests.kt
@@ -151,6 +151,17 @@ class RealmInstantTests {
         assertEquals("RealmInstant(epochSeconds=42, nanosecondsOfSecond=420)", ts.toString())
     }
 
+    /**
+     * When this method was implemented the unix epoch time was 1664980145.
+     * Nanoseconds are too granular to perform tests on especially since the
+     * darwin implementation rounds the timestamp to a precision of milliseconds.
+     */
+    @Test
+    fun now() {
+        val ts = RealmInstant.now()
+        assertTrue(ts.epochSeconds > 1664980145)
+    }
+
     @Test
     fun compare() {
         val ts1 = RealmInstant.from(0, 0)


### PR DESCRIPTION
Adds ability to fetch a RealmInstant representing how long it was since the Unix epoch