### PR TITLE
Add support for ApiKeyAuthProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* Updated to Realm Core 12.9.0, commit 8ce82fe3a8d5a2fbc89d719de8559f5a792c2dc9.
+* Updated to Realm Core 12.10.0, commit 8ce82fe3a8d5a2fbc89d719de8559f5a792c2dc9.
 * Updated to Kotlin 1.7.20.
 * Updated to Coroutines 1.6.4.
 * Updated to AtomicFu 0.18.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Minimum Ktor version has been raised from 1.6.8 to 2.1.2.
 
 ### Enhancements
+* Support for API key authentication as an alternative to email and password authentication. (Issue [#432](https://github.com/realm/realm-kotlin/issues/432))
 * [Sync] The sync variant `io.realm.kotlin:library-sync:1.4.0`, now support Apple Silicon targets, ie. `macosArm64()`, `iosArm64()` and `iosSimulatorArm64`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Minimum Android SDK: 16.
 
 ### Internal
+* Updated to Realm Core 12.9.0, commit f6bbd45cbb6cfb3a2d4212eeba59b4a46bca22d6.
 * Updated to Kotlin 1.7.20.
 * Updated to Coroutines 1.6.4.
 * Updated to AtomicFu 0.18.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* Updated to Realm Core 12.9.0, commit f6bbd45cbb6cfb3a2d4212eeba59b4a46bca22d6.
+* Updated to Realm Core 12.9.0, commit 4f9dd284b0667a203f742518d87780e4f307fd9d.
 * Updated to Kotlin 1.7.20.
 * Updated to Coroutines 1.6.4.
 * Updated to AtomicFu 0.18.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Minimum Ktor version has been raised from 1.6.8 to 2.1.2.
 
 ### Enhancements
-* [Sync] Added support for API key authentication as an alternative to email and password authentication. (Issue [#432](https://github.com/realm/realm-kotlin/issues/432))
+* [Sync] Added support for API key authentication. (Issue [#432](https://github.com/realm/realm-kotlin/issues/432))
 * [Sync] The sync variant `io.realm.kotlin:library-sync:1.4.0`, now support Apple Silicon targets, ie. `macosArm64()`, `iosArm64()` and `iosSimulatorArm64`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Minimum Ktor version has been raised from 1.6.8 to 2.1.2.
 
 ### Enhancements
-* Support for API key authentication as an alternative to email and password authentication. (Issue [#432](https://github.com/realm/realm-kotlin/issues/432))
+* [Sync] Added support for API key authentication as an alternative to email and password authentication. (Issue [#432](https://github.com/realm/realm-kotlin/issues/432))
 * [Sync] The sync variant `io.realm.kotlin:library-sync:1.4.0`, now support Apple Silicon targets, ie. `macosArm64()`, `iosArm64()` and `iosSimulatorArm64`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* Updated to Realm Core 12.9.0, commit 4f9dd284b0667a203f742518d87780e4f307fd9d.
+* Updated to Realm Core 12.9.0, commit 8ce82fe3a8d5a2fbc89d719de8559f5a792c2dc9.
 * Updated to Kotlin 1.7.20.
 * Updated to Coroutines 1.6.4.
 * Updated to AtomicFu 0.18.3.

--- a/packages/cinterop/src/androidTest/java/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/androidTest/java/io/realm/kotlin/test/CinteropTest.kt
@@ -173,7 +173,7 @@ class CinteropTest {
                 )
             }.run {
                 assertEquals(
-                    "[36]: 'foo' has no property: 'int'",
+                    "[36]: 'foo' has no property 'int'",
                     message
                 )
             }

--- a/packages/cinterop/src/androidTest/java/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/androidTest/java/io/realm/kotlin/test/CinteropTest.kt
@@ -62,7 +62,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("12.9.0", realmc.realm_get_library_version())
+        assertEquals("12.10.0", realmc.realm_get_library_version())
     }
 
     // Test various schema migration with automatic flag:

--- a/packages/cinterop/src/androidTest/java/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/androidTest/java/io/realm/kotlin/test/CinteropTest.kt
@@ -62,7 +62,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("12.7.0", realmc.realm_get_library_version())
+        assertEquals("12.9.0", realmc.realm_get_library_version())
     }
 
     // Test various schema migration with automatic flag:

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -18,6 +18,7 @@
 
 package io.realm.kotlin.internal.interop
 
+import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
 import io.realm.kotlin.internal.interop.sync.AuthProvider
 import io.realm.kotlin.internal.interop.sync.CoreSubscriptionSetState
 import io.realm.kotlin.internal.interop.sync.CoreSyncSessionState
@@ -312,6 +313,12 @@ expect object RealmInterop {
         syncConfig: RealmSyncConfigurationPointer,
         overriddenName: String?
     ): String
+    fun realm_app_user_apikey_provider_client_create_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        name: String,
+        callback: AppCallback<ApiKeyWrapper>
+    )
 
     // User
     fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity>

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -348,6 +348,12 @@ expect object RealmInterop {
         callback: AppCallback<ApiKeyWrapper>,
     )
 
+    fun realm_app_user_apikey_provider_client_fetch_apikeys(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        callback: AppCallback<Array<ApiKeyWrapper>>,
+    )
+
     // User
     fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity>
     fun realm_user_get_identity(user: RealmUserPointer): String

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -334,6 +334,13 @@ expect object RealmInterop {
         callback: AppCallback<Unit>,
     )
 
+    fun realm_app_user_apikey_provider_client_enable_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>,
+    )
+
     // User
     fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity>
     fun realm_user_get_identity(user: RealmUserPointer): String

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -327,6 +327,13 @@ expect object RealmInterop {
         callback: AppCallback<Unit>,
     )
 
+    fun realm_app_user_apikey_provider_client_disable_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>,
+    )
+
     // User
     fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity>
     fun realm_user_get_identity(user: RealmUserPointer): String

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -320,6 +320,13 @@ expect object RealmInterop {
         callback: AppCallback<ApiKeyWrapper>
     )
 
+    fun realm_app_user_apikey_provider_client_delete_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>,
+    )
+
     // User
     fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity>
     fun realm_user_get_identity(user: RealmUserPointer): String

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -341,6 +341,13 @@ expect object RealmInterop {
         callback: AppCallback<Unit>,
     )
 
+    fun realm_app_user_apikey_provider_client_fetch_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<ApiKeyWrapper>,
+    )
+
     // User
     fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity>
     fun realm_user_get_identity(user: RealmUserPointer): String

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/ApiKeyWrapper.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/ApiKeyWrapper.kt
@@ -1,0 +1,5 @@
+package io.realm.kotlin.internal.interop.sync
+
+import io.realm.kotlin.internal.interop.ObjectIdWrapper
+
+public data class ApiKeyWrapper public constructor(public val id: ObjectIdWrapper, public val value: String?, public val name: String, public val disabled: Boolean)

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/ApiKeyWrapper.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/ApiKeyWrapper.kt
@@ -1,5 +1,18 @@
 package io.realm.kotlin.internal.interop.sync
 
 import io.realm.kotlin.internal.interop.ObjectIdWrapper
+import io.realm.kotlin.internal.interop.ObjectIdWrapperImpl
 
-public data class ApiKeyWrapper public constructor(public val id: ObjectIdWrapper, public val value: String?, public val name: String, public val disabled: Boolean)
+public data class ApiKeyWrapper internal constructor(
+    public val id: ObjectIdWrapper,
+    public val value: String?,
+    public val name: String,
+    public val disabled: Boolean) {
+
+    // Used by JNI
+    internal constructor(
+        id: ByteArray,
+        value: String?,
+        name: String,
+        disabled: Boolean): this(ObjectIdWrapperImpl(id), value, name, disabled)
+    }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/ApiKeyWrapper.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/ApiKeyWrapper.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.realm.kotlin.internal.interop.sync
 
 import io.realm.kotlin.internal.interop.ObjectIdWrapper

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/ApiKeyWrapper.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/sync/ApiKeyWrapper.kt
@@ -7,12 +7,14 @@ public data class ApiKeyWrapper internal constructor(
     public val id: ObjectIdWrapper,
     public val value: String?,
     public val name: String,
-    public val disabled: Boolean) {
+    public val disabled: Boolean
+) {
 
     // Used by JNI
     internal constructor(
         id: ByteArray,
         value: String?,
         name: String,
-        disabled: Boolean): this(ObjectIdWrapperImpl(id), value, name, disabled)
-    }
+        disabled: Boolean
+    ) : this(ObjectIdWrapperImpl(id), value, name, disabled)
+}

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -19,7 +19,6 @@
 package io.realm.kotlin.internal.interop
 
 import io.realm.kotlin.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
-import io.realm.kotlin.internal.interop.RealmInterop.safeKString
 import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
 import io.realm.kotlin.internal.interop.sync.AppError
 import io.realm.kotlin.internal.interop.sync.AuthProvider
@@ -76,7 +75,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
-import kotlinx.wasm.jsinterop.Object
 import platform.posix.memcpy
 import platform.posix.posix_errno
 import platform.posix.pthread_threadid_np
@@ -120,19 +118,7 @@ import realm_wrapper.realm_user_t
 import realm_wrapper.realm_value_t
 import realm_wrapper.realm_value_type
 import realm_wrapper.realm_version_id_t
-import kotlin.collections.List
-import kotlin.collections.MutableList
-import kotlin.collections.asByteArray
-import kotlin.collections.emptyList
-import kotlin.collections.forEachIndexed
-import kotlin.collections.map
-import kotlin.collections.mapIndexed
-import kotlin.collections.mapNotNull
-import kotlin.collections.mutableListOf
-import kotlin.collections.mutableMapOf
 import kotlin.collections.set
-import kotlin.collections.toMap
-import kotlin.collections.withIndex
 import kotlin.native.internal.createCleaner
 
 private inline fun <T> T.freeze(): T {

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -19,6 +19,7 @@
 package io.realm.kotlin.internal.interop
 
 import io.realm.kotlin.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
+import io.realm.kotlin.internal.interop.RealmInterop.safeKString
 import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
 import io.realm.kotlin.internal.interop.sync.AppError
 import io.realm.kotlin.internal.interop.sync.AuthProvider
@@ -78,6 +79,7 @@ import kotlinx.coroutines.launch
 import platform.posix.memcpy
 import platform.posix.posix_errno
 import platform.posix.pthread_threadid_np
+import platform.posix.size_t
 import platform.posix.size_tVar
 import platform.posix.strerror
 import platform.posix.uint64_t
@@ -1812,7 +1814,7 @@ actual object RealmInterop {
                             ObjectIdWrapperImpl(
                                 it.id.bytes.readBytes(OBJECT_ID_BYTES_SIZE),
                             ),
-                            it.key.safeKString(),
+                            null,
                             it.name.safeKString(),
                             it.disabled
                         )
@@ -1829,7 +1831,30 @@ actual object RealmInterop {
         user: RealmUserPointer,
         callback: AppCallback<Array<ApiKeyWrapper>>,
     ) {
-        TODO()
+        realm_wrapper.realm_app_user_apikey_provider_client_fetch_apikeys(
+            app.cptr(),
+            user.cptr(),
+            staticCFunction { userData: CPointer<out CPointed>?, apiKeys: CPointer<realm_app_user_apikey_t>?, count: size_t, error: CPointer<realm_app_error_t>? ->
+                handleAppCallback(userData, error) {
+                    val result = arrayOfNulls<ApiKeyWrapper>(count.toInt())
+                    for (i in 0 until count.toInt()) {
+                        apiKeys!![i].let {
+                            result[i] = ApiKeyWrapper(
+                                ObjectIdWrapperImpl(
+                                    it.id.bytes.readBytes(OBJECT_ID_BYTES_SIZE),
+                                ),
+                                null,
+                                it.name.safeKString(),
+                                it.disabled
+                            )
+                        }
+                    }
+                    result
+                }
+            },
+            StableRef.create(callback).asCPointer(),
+            staticCFunction { userdata -> disposeUserData<AppCallback<Array<ApiKeyWrapper>>>(userdata) }
+        )
     }
 
     actual fun realm_app_log_out(

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -98,6 +98,7 @@ import realm_wrapper.realm_http_request_t
 import realm_wrapper.realm_http_response_t
 import realm_wrapper.realm_link_t
 import realm_wrapper.realm_list_t
+import realm_wrapper.realm_object_id_t
 import realm_wrapper.realm_object_t
 import realm_wrapper.realm_property_info_t
 import realm_wrapper.realm_query_arg_t
@@ -116,6 +117,19 @@ import realm_wrapper.realm_user_t
 import realm_wrapper.realm_value_t
 import realm_wrapper.realm_value_type
 import realm_wrapper.realm_version_id_t
+import kotlin.collections.List
+import kotlin.collections.MutableList
+import kotlin.collections.asByteArray
+import kotlin.collections.emptyList
+import kotlin.collections.forEachIndexed
+import kotlin.collections.map
+import kotlin.collections.mapIndexed
+import kotlin.collections.mapNotNull
+import kotlin.collections.mutableListOf
+import kotlin.collections.mutableMapOf
+import kotlin.collections.set
+import kotlin.collections.toMap
+import kotlin.collections.withIndex
 import kotlin.native.concurrent.freeze
 import kotlin.native.internal.createCleaner
 
@@ -1668,6 +1682,29 @@ actual object RealmInterop {
             },
             StableRef.create(callback).asCPointer(),
             staticCFunction { userdata -> disposeUserData<AppCallback<ApiKeyWrapper>>(userdata) }
+        )
+    }
+
+    actual fun realm_app_user_apikey_provider_client_delete_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>,
+    ) {
+        val objectId = cValue<realm_object_id_t> {
+            (0 until OBJECT_ID_BYTES_SIZE).map {
+                bytes[it] = id.bytes[it].toUByte()
+            }
+        }
+        realm_wrapper.realm_app_user_apikey_provider_client_delete_apikey(
+            app.cptr(),
+            user.cptr(),
+            objectId,
+            staticCFunction { userData, error ->
+                handleAppCallback(userData, error) { /* No-op, returns Unit */ }
+            },
+            StableRef.create(callback).asCPointer(),
+            staticCFunction { userData -> disposeUserData<AppCallback<Unit>>(userData) }
         )
     }
 

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1788,6 +1788,14 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_app_user_apikey_provider_client_fetch_apikeys(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        callback: AppCallback<Array<ApiKeyWrapper>>,
+    ) {
+        TODO()
+    }
+
     actual fun realm_app_log_out(
         app: RealmAppPointer,
         user: RealmUserPointer,

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1708,6 +1708,29 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_app_user_apikey_provider_client_disable_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>,
+    ) {
+        val objectId = cValue<realm_object_id_t> {
+            (0 until OBJECT_ID_BYTES_SIZE).map {
+                bytes[it] = id.bytes[it].toUByte()
+            }
+        }
+        realm_wrapper.realm_app_user_apikey_provider_client_disable_apikey(
+            app.cptr(),
+            user.cptr(),
+            objectId,
+            staticCFunction { userData, error ->
+                handleAppCallback(userData, error) { /* No-op, returns Unit */ }
+            },
+            StableRef.create(callback).asCPointer(),
+            staticCFunction { userData -> disposeUserData<AppCallback<Unit>>(userData) }
+        )
+    }
+
     actual fun realm_app_log_out(
         app: RealmAppPointer,
         user: RealmUserPointer,

--- a/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/darwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1731,6 +1731,29 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_app_user_apikey_provider_client_enable_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>,
+    ) {
+        val objectId = cValue<realm_object_id_t> {
+            (0 until OBJECT_ID_BYTES_SIZE).map {
+                bytes[it] = id.bytes[it].toUByte()
+            }
+        }
+        realm_wrapper.realm_app_user_apikey_provider_client_enable_apikey(
+            app.cptr(),
+            user.cptr(),
+            objectId,
+            staticCFunction { userData, error ->
+                handleAppCallback(userData, error) { /* No-op, returns Unit */ }
+            },
+            StableRef.create(callback).asCPointer(),
+            staticCFunction { userData -> disposeUserData<AppCallback<Unit>>(userData) }
+        )
+    }
+
     actual fun realm_app_log_out(
         app: RealmAppPointer,
         user: RealmUserPointer,

--- a/packages/cinterop/src/darwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/darwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -93,7 +93,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("12.9.0", realm_get_library_version()!!.toKString())
+        assertEquals("12.10.0", realm_get_library_version()!!.toKString())
     }
 
     @Test

--- a/packages/cinterop/src/darwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/darwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -93,7 +93,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("12.7.0", realm_get_library_version()!!.toKString())
+        assertEquals("12.9.0", realm_get_library_version()!!.toKString())
     }
 
     @Test

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1594,6 +1594,15 @@ actual object RealmInterop {
         TODO()
     }
 
+    actual fun realm_app_user_apikey_provider_client_disable_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>
+    ) {
+        TODO()
+    }
+
     private fun realm_value_t.asTimestamp(): Timestamp {
         if (this.type != realm_value_type_e.RLM_TYPE_TIMESTAMP) {
             error("Value is not of type Timestamp: $this.type")

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -18,6 +18,7 @@ package io.realm.kotlin.internal.interop
 
 import io.realm.kotlin.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
 import io.realm.kotlin.internal.interop.RealmInterop.cptr
+import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
 import io.realm.kotlin.internal.interop.sync.AuthProvider
 import io.realm.kotlin.internal.interop.sync.CoreSubscriptionSetState
 import io.realm.kotlin.internal.interop.sync.CoreSyncSessionState
@@ -1573,6 +1574,15 @@ actual object RealmInterop {
             }
             return cArgs
         }
+    }
+
+    actual fun realm_app_user_apikey_provider_client_create_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        name: String,
+        callback: AppCallback<ApiKeyWrapper>
+    ) {
+        TODO()
     }
 
     private fun realm_value_t.asTimestamp(): Timestamp {

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1602,13 +1602,28 @@ actual object RealmInterop {
         )
     }
 
+    private fun toObjectId(objectIdWrapper: ObjectIdWrapper): realm_object_id_t {
+        return realm_object_id_t().apply {
+            val data = ShortArray(OBJECT_ID_BYTES_SIZE)
+            (0 until OBJECT_ID_BYTES_SIZE).map {
+                data[it] = objectIdWrapper.bytes[it].toShort()
+            }
+            bytes = data
+        }
+    }
+
     actual fun realm_app_user_apikey_provider_client_delete_apikey(
         app: RealmAppPointer,
         user: RealmUserPointer,
         id: ObjectIdWrapper,
         callback: AppCallback<Unit>
     ) {
-        TODO()
+        realmc.realm_app_user_apikey_provider_client_delete_apikey(
+            app.cptr(),
+            user.cptr(),
+            toObjectId(id),
+            callback
+        )
     }
 
     actual fun realm_app_user_apikey_provider_client_disable_apikey(
@@ -1617,7 +1632,12 @@ actual object RealmInterop {
         id: ObjectIdWrapper,
         callback: AppCallback<Unit>
     ) {
-        TODO()
+        realmc.realm_app_user_apikey_provider_client_disable_apikey(
+            app.cptr(),
+            user.cptr(),
+            toObjectId(id),
+            callback
+        )
     }
 
     actual fun realm_app_user_apikey_provider_client_enable_apikey(
@@ -1626,7 +1646,12 @@ actual object RealmInterop {
         id: ObjectIdWrapper,
         callback: AppCallback<Unit>
     ) {
-        TODO()
+        realmc.realm_app_user_apikey_provider_client_enable_apikey(
+            app.cptr(),
+            user.cptr(),
+            toObjectId(id),
+            callback
+        )
     }
 
     actual fun realm_app_user_apikey_provider_client_fetch_apikey(
@@ -1635,7 +1660,19 @@ actual object RealmInterop {
         id: ObjectIdWrapper,
         callback: AppCallback<ApiKeyWrapper>,
     ) {
-        TODO()
+        val object_id = realm_object_id_t().apply {
+            val data = ShortArray(OBJECT_ID_BYTES_SIZE)
+            (0 until OBJECT_ID_BYTES_SIZE).map {
+                data[it] = id.bytes[it].toShort()
+            }
+            bytes = data
+        }
+        realmc.realm_app_user_apikey_provider_client_fetch_apikey(
+            app.cptr(),
+            user.cptr(),
+            object_id,
+            callback
+        )
     }
 
     actual fun realm_app_user_apikey_provider_client_fetch_apikeys(

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1603,6 +1603,15 @@ actual object RealmInterop {
         TODO()
     }
 
+    actual fun realm_app_user_apikey_provider_client_enable_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>
+    ) {
+        TODO()
+    }
+
     private fun realm_value_t.asTimestamp(): Timestamp {
         if (this.type != realm_value_type_e.RLM_TYPE_TIMESTAMP) {
             error("Value is not of type Timestamp: $this.type")

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1582,7 +1582,12 @@ actual object RealmInterop {
         name: String,
         callback: AppCallback<ApiKeyWrapper>
     ) {
-        TODO()
+        realmc.realm_app_user_apikey_provider_client_create_apikey(
+            app.cptr(),
+            user.cptr(),
+            name,
+            callback
+        )
     }
 
     actual fun realm_app_user_apikey_provider_client_delete_apikey(

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1585,6 +1585,15 @@ actual object RealmInterop {
         TODO()
     }
 
+    actual fun realm_app_user_apikey_provider_client_delete_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<Unit>
+    ) {
+        TODO()
+    }
+
     private fun realm_value_t.asTimestamp(): Timestamp {
         if (this.type != realm_value_type_e.RLM_TYPE_TIMESTAMP) {
             error("Value is not of type Timestamp: $this.type")

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1612,6 +1612,15 @@ actual object RealmInterop {
         TODO()
     }
 
+    actual fun realm_app_user_apikey_provider_client_fetch_apikey(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        id: ObjectIdWrapper,
+        callback: AppCallback<ApiKeyWrapper>,
+    ) {
+        TODO()
+    }
+
     private fun realm_value_t.asTimestamp(): Timestamp {
         if (this.type != realm_value_type_e.RLM_TYPE_TIMESTAMP) {
             error("Value is not of type Timestamp: $this.type")

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1626,6 +1626,18 @@ actual object RealmInterop {
         TODO()
     }
 
+    actual fun realm_app_user_apikey_provider_client_fetch_apikeys(
+        app: RealmAppPointer,
+        user: RealmUserPointer,
+        callback: AppCallback<Array<ApiKeyWrapper>>,
+    ) {
+        realmc.realm_app_user_apikey_provider_client_fetch_apikeys(
+            app.cptr(),
+            user.cptr(),
+            callback
+        )
+    }
+
     private fun realm_value_t.asTimestamp(): Timestamp {
         if (this.type != realm_value_type_e.RLM_TYPE_TIMESTAMP) {
             error("Value is not of type Timestamp: $this.type")

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -88,19 +88,6 @@ std::string rlm_stdstr(realm_string_t val)
     };
 }
 
-// Reuse void callback typemap as template for api_key_callback
-%apply (realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
-(void (*)(realm_userdata_t userdata, realm_app_user_apikey_t*, const realm_app_error_t*), void* userdata, realm_free_userdata_func_t userdata_free)
-};
-%typemap(in) (void (*)(realm_userdata_t userdata, realm_app_user_apikey_t*, const realm_app_error_t*), void* userdata, realm_free_userdata_func_t userdata_free) {
-    auto jenv = get_env(true);
-    $1 = reinterpret_cast<void (*)(realm_userdata_t userdata, realm_app_user_apikey_t*, const realm_app_error_t*)>(app_api_key_callback);
-    $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
-    $3 = [](void *userdata) {
-        get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
-    };
-}
-
 // Reuse void callback typemap as template for `realm_on_realm_change_func_t`
 %apply (realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
 (realm_on_realm_change_func_t, void* userdata, realm_free_userdata_func_t)
@@ -177,6 +164,35 @@ std::string rlm_stdstr(realm_string_t val)
         get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
     };
 }
+
+// Reuse void callback typemap as template for callbacks returning a single api key
+%apply (realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
+(realm_return_apikey_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free)
+};
+%typemap(in) (realm_return_apikey_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
+    auto jenv = get_env(true);
+    $1 = reinterpret_cast<realm_return_apikey_func_t>(app_apikey_callback);
+    $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
+    $3 = [](void *userdata) {
+        get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
+    };
+}
+
+// Reuse void callback typemap as template for callbacks returning a list of api keys
+%apply (realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
+(realm_return_apikey_list_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free)
+};
+%typemap(in) (realm_return_apikey_list_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free) {
+    auto jenv = get_env(true);
+    $1 = reinterpret_cast<realm_return_apikey_list_func_t>(app_apikey_list_callback);
+    $2 = static_cast<jobject>(jenv->NewGlobalRef($input));
+    $3 = [](void *userdata) {
+        get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
+    };
+}
+
+
+
 
 // Core isn't strict about naming their callbacks, so sometimes SWIG cannot map correctly :/
 %typemap(jstype) (realm_sync_on_subscription_state_changed_t, void* userdata, realm_free_userdata_func_t userdata_free) "Object" ;

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -338,17 +338,28 @@ void app_complete_result_callback(void* userdata, void* result, const realm_app_
     }
 }
 
-jobject create_api_key_wrapper(const realm_app_user_apikey_t* key_data) {
-
+jobject create_api_key_wrapper(JNIEnv* env, const realm_app_user_apikey_t* key_data) {
+        auto id_size = sizeof(key_data->id.bytes);
+        static JavaClass api_key_wrapper_class(env, "io/realm/kotlin/internal/interop/sync/ApiKeyWrapper");
+        static JavaMethod api_key_wrapper_constructor(env, api_key_wrapper_class, "<init>", "([BLjava/lang/String;Ljava/lang/String;Z)V");
+        jbyteArray id = env->NewByteArray(id_size);
+        env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(key_data->id.bytes));
+        jstring key = to_jstring(env, key_data->key);
+        jstring name = to_jstring(env, key_data->name);
+        jboolean disabled = key_data->disabled;
+        return env->NewObject(api_key_wrapper_class,
+                                                     api_key_wrapper_constructor,
+                                                     id,
+                                                     key,
+                                                     name,
+                                                     disabled,
+                                                     false);
 }
 
 
 
 void app_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* apikey, const realm_app_error_t* error) {
     auto env = get_env(true);
-    static JavaClass api_key_wrapper_class(env, "io/realm/kotlin/internal/interop/sync/ApiKeyWrapper");
-    static JavaMethod api_key_wrapper_constructor(env, api_key_wrapper_class, "<init>", "([BLjava/lang/String;Ljava/lang/String;Z)V");
-
     static JavaClass java_callback_class(env, "io/realm/kotlin/internal/interop/AppCallback");
     static JavaMethod java_notify_onerror(env, java_callback_class, "onError",
                                           "(Lio/realm/kotlin/internal/interop/sync/AppError;)V");
@@ -359,20 +370,7 @@ void app_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* api
         env->CallVoidMethod(static_cast<jobject>(userdata), java_notify_onerror, app_exception);
         jni_check_exception(env);
     } else {
-        jobject api_key_wrapper_obj = create_api_key_wrapper(apikey);
-//        auto id_size = sizeof(apikey->id.bytes);
-//        jbyteArray id = env->NewByteArray(id_size);
-//        env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(apikey->id.bytes));
-//        jstring key = to_jstring(env, apikey->key);
-//        jstring name = to_jstring(env, apikey->name);
-//        jboolean disabled = apikey->disabled;
-//        jobject api_key_wrapper_obj = env->NewObject(api_key_wrapper_class,
-//                                                     api_key_wrapper_constructor,
-//                                                     id,
-//                                                     key,
-//                                                     name,
-//                                                     disabled,
-//                                                     false);
+        jobject api_key_wrapper_obj = create_api_key_wrapper(env, apikey);
 
         env->CallVoidMethod(static_cast<jobject>(userdata), java_notify_onsuccess, api_key_wrapper_obj);
         jni_check_exception(env);
@@ -383,7 +381,6 @@ void app_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* api
 void app_apikey_list_callback(realm_userdata_t userdata, realm_app_user_apikey_t* keys, size_t count, realm_app_error_t* error) {
     auto env = get_env(true);
     static JavaClass api_key_wrapper_class(env, "io/realm/kotlin/internal/interop/sync/ApiKeyWrapper");
-    static JavaMethod api_key_wrapper_constructor(env, api_key_wrapper_class, "<init>", "([BLjava/lang/String;Ljava/lang/String;Z)V");
 
     static JavaClass java_callback_class(env, "io/realm/kotlin/internal/interop/AppCallback");
     static JavaMethod java_notify_onerror(env, java_callback_class, "onError",
@@ -401,22 +398,7 @@ void app_apikey_list_callback(realm_userdata_t userdata, realm_app_user_apikey_t
         // For each ApiKey, create the Kotlin Wrapper and insert into array
         for (int i = 0; i < count; i++) {
             realm_app_user_apikey_t api_key = keys[i];
-            jobject api_key_wrapper_obj = create_api_key_wrapper(&api_key);
-//
-//
-//            auto id_size = sizeof(api_key.id.bytes);
-//            jbyteArray id = env->NewByteArray(id_size);
-//            env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(api_key.id.bytes));
-//            jstring key = to_jstring(env, api_key.key);
-//            jstring name = to_jstring(env, api_key.name);
-//            jboolean disabled = api_key.disabled;
-//            jobject api_key_wrapper_obj = env->NewObject(api_key_wrapper_class,
-//                                                         api_key_wrapper_constructor,
-//                                                         id,
-//                                                         key,
-//                                                         name,
-//                                                         disabled,
-//                                                         false);
+            jobject api_key_wrapper_obj = create_api_key_wrapper(env, &api_key);
             env->SetObjectArrayElement(key_array, i, api_key_wrapper_obj);
         }
 

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -339,21 +339,21 @@ void app_complete_result_callback(void* userdata, void* result, const realm_app_
 }
 
 jobject create_api_key_wrapper(JNIEnv* env, const realm_app_user_apikey_t* key_data) {
-        auto id_size = sizeof(key_data->id.bytes);
         static JavaClass api_key_wrapper_class(env, "io/realm/kotlin/internal/interop/sync/ApiKeyWrapper");
         static JavaMethod api_key_wrapper_constructor(env, api_key_wrapper_class, "<init>", "([BLjava/lang/String;Ljava/lang/String;Z)V");
+        auto id_size = sizeof(key_data->id.bytes);
         jbyteArray id = env->NewByteArray(id_size);
         env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(key_data->id.bytes));
         jstring key = to_jstring(env, key_data->key);
         jstring name = to_jstring(env, key_data->name);
         jboolean disabled = key_data->disabled;
         return env->NewObject(api_key_wrapper_class,
-                                                     api_key_wrapper_constructor,
-                                                     id,
-                                                     key,
-                                                     name,
-                                                     disabled,
-                                                     false);
+                              api_key_wrapper_constructor,
+                              id,
+                              key,
+                              name,
+                              disabled,
+                              false);
 }
 
 
@@ -371,7 +371,6 @@ void app_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* api
         jni_check_exception(env);
     } else {
         jobject api_key_wrapper_obj = create_api_key_wrapper(env, apikey);
-
         env->CallVoidMethod(static_cast<jobject>(userdata), java_notify_onsuccess, api_key_wrapper_obj);
         jni_check_exception(env);
     }

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -338,6 +338,12 @@ void app_complete_result_callback(void* userdata, void* result, const realm_app_
     }
 }
 
+jobject create_api_key_wrapper(const realm_app_user_apikey_t* key_data) {
+
+}
+
+
+
 void app_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* apikey, const realm_app_error_t* error) {
     auto env = get_env(true);
     static JavaClass api_key_wrapper_class(env, "io/realm/kotlin/internal/interop/sync/ApiKeyWrapper");
@@ -353,24 +359,26 @@ void app_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* api
         env->CallVoidMethod(static_cast<jobject>(userdata), java_notify_onerror, app_exception);
         jni_check_exception(env);
     } else {
-        auto id_size = sizeof(apikey->id.bytes);
-        jbyteArray id = env->NewByteArray(id_size);
-        env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(apikey->id.bytes));
-        jstring key = to_jstring(env, apikey->key);
-        jstring name = to_jstring(env, apikey->name);
-        jboolean disabled = apikey->disabled;
-        jobject api_key_wrapper_obj = env->NewObject(api_key_wrapper_class,
-                                                     api_key_wrapper_constructor,
-                                                     id,
-                                                     key,
-                                                     name,
-                                                     disabled,
-                                                     false);
+        jobject api_key_wrapper_obj = create_api_key_wrapper(apikey);
+//        auto id_size = sizeof(apikey->id.bytes);
+//        jbyteArray id = env->NewByteArray(id_size);
+//        env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(apikey->id.bytes));
+//        jstring key = to_jstring(env, apikey->key);
+//        jstring name = to_jstring(env, apikey->name);
+//        jboolean disabled = apikey->disabled;
+//        jobject api_key_wrapper_obj = env->NewObject(api_key_wrapper_class,
+//                                                     api_key_wrapper_constructor,
+//                                                     id,
+//                                                     key,
+//                                                     name,
+//                                                     disabled,
+//                                                     false);
 
         env->CallVoidMethod(static_cast<jobject>(userdata), java_notify_onsuccess, api_key_wrapper_obj);
         jni_check_exception(env);
     }
 }
+
 
 void app_apikey_list_callback(realm_userdata_t userdata, realm_app_user_apikey_t* keys, size_t count, realm_app_error_t* error) {
     auto env = get_env(true);
@@ -393,19 +401,22 @@ void app_apikey_list_callback(realm_userdata_t userdata, realm_app_user_apikey_t
         // For each ApiKey, create the Kotlin Wrapper and insert into array
         for (int i = 0; i < count; i++) {
             realm_app_user_apikey_t api_key = keys[i];
-            auto id_size = sizeof(api_key.id.bytes);
-            jbyteArray id = env->NewByteArray(id_size);
-            env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(api_key.id.bytes));
-            jstring key = to_jstring(env, api_key.key);
-            jstring name = to_jstring(env, api_key.name);
-            jboolean disabled = api_key.disabled;
-            jobject api_key_wrapper_obj = env->NewObject(api_key_wrapper_class,
-                                                         api_key_wrapper_constructor,
-                                                         id,
-                                                         key,
-                                                         name,
-                                                         disabled,
-                                                         false);
+            jobject api_key_wrapper_obj = create_api_key_wrapper(&api_key);
+//
+//
+//            auto id_size = sizeof(api_key.id.bytes);
+//            jbyteArray id = env->NewByteArray(id_size);
+//            env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(api_key.id.bytes));
+//            jstring key = to_jstring(env, api_key.key);
+//            jstring name = to_jstring(env, api_key.name);
+//            jboolean disabled = api_key.disabled;
+//            jobject api_key_wrapper_obj = env->NewObject(api_key_wrapper_class,
+//                                                         api_key_wrapper_constructor,
+//                                                         id,
+//                                                         key,
+//                                                         name,
+//                                                         disabled,
+//                                                         false);
             env->SetObjectArrayElement(key_array, i, api_key_wrapper_obj);
         }
 

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -289,6 +289,7 @@ jobject convert_to_jvm_app_error(JNIEnv* env, const realm_app_error_t* error) {
                           serverLogs);
 }
 
+
 void app_complete_void_callback(void *userdata, const realm_app_error_t *error) {
     auto env = get_env(true);
     static JavaClass java_callback_class(env, "io/realm/kotlin/internal/interop/AppCallback");
@@ -336,6 +337,11 @@ void app_complete_result_callback(void* userdata, void* result, const realm_app_
         env->CallVoidMethod(static_cast<jobject>(userdata), java_notify_onsuccess, pointer);
     }
 }
+
+void app_api_key_callback(realm_userdata_t userdata, realm_app_user_apikey_t* api_key, const realm_app_error_t* api_error) {
+    api_key->
+}
+
 
 bool realm_should_compact_callback(void* userdata, uint64_t total_bytes, uint64_t used_bytes) {
     auto env = get_env(true);

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -353,7 +353,9 @@ void app_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t* api
         env->CallVoidMethod(static_cast<jobject>(userdata), java_notify_onerror, app_exception);
         jni_check_exception(env);
     } else {
-        jbyteArray id = env->NewByteArray(sizeof(apikey->id.bytes));
+        auto id_size = sizeof(apikey->id.bytes);
+        jbyteArray id = env->NewByteArray(id_size);
+        env->SetByteArrayRegion(id, 0, id_size, reinterpret_cast<const jbyte*>(apikey->id.bytes));
         jstring key = to_jstring(env, apikey->key);
         jstring name = to_jstring(env, apikey->name);
         jboolean disabled = apikey->disabled;

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -94,6 +94,9 @@ void
 realm_value_t_cleanup(realm_value_t* value);
 
 void
-app_api_key_callback(realm_userdata_t userdata, realm_app_user_apikey_t*, const realm_app_error_t*);
+app_apikey_callback(realm_userdata_t userdata, realm_app_user_apikey_t*, const realm_app_error_t*);
+
+void
+app_apikey_list_callback(realm_userdata_t userdata, realm_app_user_apikey_t[], size_t count, realm_app_error_t*);
 
 #endif //TEST_REALM_API_HELPERS_H

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -93,4 +93,7 @@ sync_after_client_reset_handler(realm_sync_config_t* config, jobject after_handl
 void
 realm_value_t_cleanup(realm_value_t* value);
 
+void
+app_api_key_callback(realm_userdata_t userdata, realm_app_user_apikey_t*, const realm_app_error_t*);
+
 #endif //TEST_REALM_API_HELPERS_H

--- a/packages/library-sync/proguard-rules-consumer-common.pro
+++ b/packages/library-sync/proguard-rules-consumer-common.pro
@@ -5,3 +5,8 @@
     # TODO OPTIMIZE Only keep actually required symbols
     *;
 }
+
+-keep class io.realm.kotlin.internal.interop.sync.ApiKeyWrapper {
+    # TODO OPTIMIZE Only keep actually required symbols
+    *;
+}

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
@@ -16,6 +16,7 @@
 
 package io.realm.kotlin.mongodb
 
+import io.realm.kotlin.mongodb.auth.ApiKeyAuth
 import io.realm.kotlin.mongodb.exceptions.AppException
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 
@@ -35,6 +36,11 @@ public interface User {
      * The [App] this user is associated with.
      */
     public val app: App
+
+    /**
+     * TODO
+     */
+    public val apiKeyAuth: ApiKeyAuth
 
     /**
      * The [State] this user is in.

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
@@ -38,7 +38,7 @@ public interface User {
     public val app: App
 
     /**
-     * TODO
+     * Interface which exposes functionality for a user to manage API keys under their control.
      */
     public val apiKeyAuth: ApiKeyAuth
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
@@ -38,7 +38,7 @@ public interface User {
     public val app: App
 
     /**
-     * Interface which exposes functionality for a user to manage API keys under their control.
+     * Gives access to the [ApiKeyAuth] interface so that users can manage their API keys.
      */
     public val apiKeyAuth: ApiKeyAuth
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.realm.kotlin.mongodb.auth
 
 import io.realm.kotlin.types.ObjectId

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
@@ -23,6 +23,7 @@ import io.realm.kotlin.types.ObjectId
  * which point it is not visible anymore. This means that keys returned by [ApiKeyAuth.fetch] and
  * [ApikeyAuth.fetchall] will have a `null` [value]. Anyone creating an API key is responsible for
  * storing it safely after that.
+ *
  * @param id an [ObjectId] uniquely identifying the key.
  * @param value the value of this key, only returned when the key is created, `null` otherwise.
  * @param name the name of the key.

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
@@ -2,12 +2,14 @@ package io.realm.kotlin.mongodb.auth
 
 import io.realm.kotlin.types.ObjectId
 /**
- * Class representing an API key for a User. An API can be used to represent the
- * user when logging instead of using email and password.
- * Note that a keys value is only available when the key is created, after that it is not
- * visible. So anyone creating an API key is responsible for storing it safely after that.
- * @param ObjectId, an id uniquely identifying the key.
- * @param value, the value of this key. Only returned when the key is created.
+ * Class representing an API key for a [User]. An API key can be used to represent a
+ * user when logging in instead of using email and password.
+ * Note that the value of a key will only be available immediately after the key is created, after
+ * which point it is not visible anymore. This means that keys returned by [ApiKeyAuth.fetch] and
+ * [ApikeyAuth.fetchall] will have a `null` [value]. Anyone creating an API key is responsible for
+ * storing it safely after that.
+ * @param id, an [ObjectId] uniquely identifying the key.
+ * @param value, the value of this key, only returned when the key is created, `null` otherwise.
  * @param name, the name of the key.
  * @param enabled, whether the key is enabled or not.
  */

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
@@ -1,0 +1,5 @@
+package io.realm.kotlin.mongodb.auth
+
+import io.realm.kotlin.types.ObjectId
+
+public data class ApiKey public constructor(public val id: ObjectId, public val value: String?, public val name: String, public val enabled: Boolean)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
@@ -23,9 +23,9 @@ import io.realm.kotlin.types.ObjectId
  * which point it is not visible anymore. This means that keys returned by [ApiKeyAuth.fetch] and
  * [ApikeyAuth.fetchall] will have a `null` [value]. Anyone creating an API key is responsible for
  * storing it safely after that.
- * @param id, an [ObjectId] uniquely identifying the key.
- * @param value, the value of this key, only returned when the key is created, `null` otherwise.
- * @param name, the name of the key.
- * @param enabled, whether the key is enabled or not.
+ * @param id an [ObjectId] uniquely identifying the key.
+ * @param value the value of this key, only returned when the key is created, `null` otherwise.
+ * @param name the name of the key.
+ * @param enabled whether the key is enabled or not.
  */
 public data class ApiKey public constructor(public val id: ObjectId, public val value: String?, public val name: String, public val enabled: Boolean)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKey.kt
@@ -1,5 +1,14 @@
 package io.realm.kotlin.mongodb.auth
 
 import io.realm.kotlin.types.ObjectId
-
+/**
+ * Class representing an API key for a User. An API can be used to represent the
+ * user when logging instead of using email and password.
+ * Note that a keys value is only available when the key is created, after that it is not
+ * visible. So anyone creating an API key is responsible for storing it safely after that.
+ * @param ObjectId, an id uniquely identifying the key.
+ * @param value, the value of this key. Only returned when the key is created.
+ * @param name, the name of the key.
+ * @param enabled, whether the key is enabled or not.
+ */
 public data class ApiKey public constructor(public val id: ObjectId, public val value: String?, public val name: String, public val enabled: Boolean)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
@@ -1,7 +1,5 @@
 package io.realm.kotlin.mongodb.auth
 
-import io.realm.kotlin.mongodb.App
-import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.types.ObjectId
 
 public interface ApiKeyAuth {
@@ -11,6 +9,4 @@ public interface ApiKeyAuth {
     public suspend fun enable(id: ObjectId)
     public suspend fun fetch(id: ObjectId): ApiKey
     public suspend fun fetchAll(): List<ApiKey>
-    public val user: User
-    public val app: App
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
@@ -41,26 +41,30 @@ public interface ApiKeyAuth {
      * The key is enabled when created. It can be disabled by calling the [disable] method.
      *
      * @param name the name of the key
+     * @return the new API key for the user.
+     *
      * @throws IllegalArgumentException if an invalid name for the key is sent to the server.
      * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for other failures that can happen when
      * communicating with App Services. See [AppException] for details.
-     * @return the new API key for the user.
      */
     public suspend fun create(name: String): ApiKey
 
     /**
      * Deletes a specific API key created by the user.
      * Returns silently if no key is deleted.
+     *
      * @param id the id of the key to delete.
+     *
      * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for failures that can happen when
      * communicating with App Services. See [AppException] for details.
      */
     public suspend fun delete(id: ObjectId)
 
     /**
-     * Disables a specific API key created by the user.
+     * Deletes a specific API key created by the user. The function would complete normally if the provided key does not exist.
      *
      * @param id the id of the key to disable.
+     *
      * @throws IllegalArgumentException if a non existing API key is disabled.
      * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for other failures that can happen when
      * communicating with App Services. See [AppException] for details.
@@ -71,6 +75,7 @@ public interface ApiKeyAuth {
      * Enables a specific API key created by the user.
      *
      * @param id the id of the key to disable.
+     *
      * @throws IllegalArgumentException if a non existing API key is enabled.
      * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for other failures that can happen when
      * communicating with App Services. See [AppException] for details.
@@ -81,6 +86,7 @@ public interface ApiKeyAuth {
      * Fetches a specific user API key associated with the user.
      *
      * @param id the id of the key to fetch.
+     *
      * @throws IllegalArgumentException if a non existing API key is fetched.
      * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for other failures that can happen when
      * communicating with App Services. See [AppException] for details.
@@ -90,6 +96,7 @@ public interface ApiKeyAuth {
     /**
      * Fetches all API keys associated with the user.
      * Returns an empty list if no key is found.
+     *
      * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for failures that can happen when
      * communicating with App Services. See [AppException] for details.
      */

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
@@ -17,6 +17,7 @@ package io.realm.kotlin.mongodb.auth
 
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.mongodb.exceptions.AppException
 import io.realm.kotlin.types.ObjectId
 
 /**
@@ -37,10 +38,12 @@ public interface ApiKeyAuth {
     /**
      * Creates a user API key that can be used to authenticate as the user.
      * The value of the key must be persisted at this time as this is the only time it is visible.
-     * The key is enabled when created. It can be disabled by calling the disable method.
+     * The key is enabled when created. It can be disabled by calling the [disable] method.
      *
      * @param name the name of the key
      * @throws IllegalArgumentException if an invalid name for the key is sent to the server.
+     * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for other failures that can happen when
+     * communicating with App Services. See [AppException] for details.
      * @return the new API key for the user.
      */
     public suspend fun create(name: String): ApiKey
@@ -49,6 +52,8 @@ public interface ApiKeyAuth {
      * Deletes a specific API key created by the user.
      * Returns silently if no key is deleted.
      * @param id the id of the key to delete.
+     * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for failures that can happen when
+     * communicating with App Services. See [AppException] for details.
      */
     public suspend fun delete(id: ObjectId)
 
@@ -57,6 +62,8 @@ public interface ApiKeyAuth {
      *
      * @param id the id of the key to disable.
      * @throws IllegalArgumentException if a non existing API key is disabled.
+     * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for other failures that can happen when
+     * communicating with App Services. See [AppException] for details.
      */
     public suspend fun disable(id: ObjectId)
 
@@ -65,6 +72,8 @@ public interface ApiKeyAuth {
      *
      * @param id the id of the key to disable.
      * @throws IllegalArgumentException if a non existing API key is enabled.
+     * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for other failures that can happen when
+     * communicating with App Services. See [AppException] for details.
      */
     public suspend fun enable(id: ObjectId)
 
@@ -73,12 +82,16 @@ public interface ApiKeyAuth {
      *
      * @param id the id of the key to fetch.
      * @throws IllegalArgumentException if a non existing API key is fetched.
+     * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for other failures that can happen when
+     * communicating with App Services. See [AppException] for details.
      */
     public suspend fun fetch(id: ObjectId): ApiKey?
 
     /**
      * Fetches all API keys associated with the user.
      * Returns an empty list if no key is found.
+     * @throws io.realm.kotlin.mongodb.exceptions.ServiceException for failures that can happen when
+     * communicating with App Services. See [AppException] for details.
      */
     public suspend fun fetchAll(): List<ApiKey>
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
@@ -4,13 +4,66 @@ import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.types.ObjectId
 
+/**
+ * Exposes functionality for a user to manage API keys under their control.
+ */
 public interface ApiKeyAuth {
-    public suspend fun create(name: String): ApiKey
-    public suspend fun delete(id: ObjectId)
-    public suspend fun disable(id: ObjectId)
-    public suspend fun enable(id: ObjectId)
-    public suspend fun fetch(id: ObjectId): ApiKey?
-    public suspend fun fetchAll(): List<ApiKey>
+
+    /**
+     * The User that this instance in associated with.
+     */
     public val user: User
+
+    /**
+     * The App that this instance in associated with.
+     */
     public val app: App
+
+    /**
+     * Creates a user API key that can be used to authenticate as the user.
+     * The value of the key must be persisted at this time as this is the only time it is visible.
+     * The key is enabled when created. It can be disabled by calling the disable method.
+     *
+     * @param name the name of the key
+     * @throws IllegalArgumentException if an invalid name for the key is sent to the server.
+     * @return the new API key for the user.
+     */
+    public suspend fun create(name: String): ApiKey
+
+    /**
+     * Deletes a specific API key created by the user.
+     * Returns silently if no key is deleted.
+     * @param id the id of the key to delete.
+     */
+    public suspend fun delete(id: ObjectId)
+
+    /**
+     * Disables a specific API key created by the user.
+     *
+     * @param id the id of the key to disable.
+     * @throws IllegalArgumentException if a non existing API key is disabled.
+     */
+    public suspend fun disable(id: ObjectId)
+
+    /**
+     * Enables a specific API key created by the user.
+     *
+     * @param id the id of the key to disable.
+     * @throws IllegalArgumentException if a non existing API key is enabled.
+     */
+    public suspend fun enable(id: ObjectId)
+
+    /**
+     * Fetches a specific user API key associated with the user.
+     *
+     * @param id the id of the key to fetch.
+     * @throws IllegalArgumentException if a non existing API key is fetched.
+     */
+    public suspend fun fetch(id: ObjectId): ApiKey?
+
+    /**
+     * Fetches all API keys associated with the user.
+     * Returns an empty list if no key is found.
+     */
+    public suspend fun fetchAll(): List<ApiKey>
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
@@ -1,0 +1,16 @@
+package io.realm.kotlin.mongodb.auth
+
+import io.realm.kotlin.mongodb.App
+import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.types.ObjectId
+
+public interface ApiKeyAuth {
+    public suspend fun create(name: String): ApiKey
+    public suspend fun delete(id: ObjectId)
+    public suspend fun disable(id: ObjectId)
+    public suspend fun enable(id: ObjectId)
+    public suspend fun fetch(id: ObjectId): ApiKey
+    public suspend fun fetchAll(): List<ApiKey>
+    public val user: User
+    public val app: App
+}

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
@@ -1,5 +1,7 @@
 package io.realm.kotlin.mongodb.auth
 
+import io.realm.kotlin.mongodb.App
+import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.types.ObjectId
 
 public interface ApiKeyAuth {
@@ -7,6 +9,8 @@ public interface ApiKeyAuth {
     public suspend fun delete(id: ObjectId)
     public suspend fun disable(id: ObjectId)
     public suspend fun enable(id: ObjectId)
-    public suspend fun fetch(id: ObjectId): ApiKey
+    public suspend fun fetch(id: ObjectId): ApiKey?
     public suspend fun fetchAll(): List<ApiKey>
+    public val user: User
+    public val app: App
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/auth/ApiKeyAuth.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.realm.kotlin.mongodb.auth
 
 import io.realm.kotlin.mongodb.App

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -11,7 +11,7 @@ import io.realm.kotlin.mongodb.auth.ApiKeyAuth
 import io.realm.kotlin.types.ObjectId
 import kotlinx.coroutines.channels.Channel
 
-internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: UserImpl) : ApiKeyAuth {
+internal class ApiKeyAuthImpl(val app: AppImpl, val user: UserImpl) : ApiKeyAuth {
 
     override suspend fun create(name: String): ApiKey {
         Channel<Result<ApiKey>>(1).use { channel ->

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.channels.Channel
 internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: UserImpl) : ApiKeyAuth {
 
     private fun unwrap(apiKeyData: ApiKeyWrapper): ApiKey {
-         return ApiKey(
+        return ApiKey(
             ObjectIdImpl(apiKeyData.id),
             apiKeyData.value,
             apiKeyData.name,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -43,8 +43,9 @@ internal class ApiKeyAuthImpl(val app: AppImpl, val user: UserImpl) : ApiKeyAuth
                     // No-op
                 }.freeze()
             )
-            return channel.receive()
-                .getOrThrow()
+            return channel.receive().getOrElse({
+                // No-op
+            })
         }
     }
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -84,7 +84,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                 app.nativePointer,
                 user.nativePointer,
                 id as ObjectIdWrapper,
-                channelResultCallback<ApiKeyWrapper, ApiKey>(channel) { apiKeyData ->
+                channelResultCallback<ApiKeyWrapper, ApiKey>(channel) { apiKeyData: ApiKeyWrapper ->
                     ApiKey(
                         ObjectIdImpl(apiKeyData.id),
                         apiKeyData.value,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -49,7 +49,18 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
     }
 
     override suspend fun disable(id: ObjectId) {
-        TODO("Not yet implemented")
+        Channel<Result<Unit>>(1).use { channel ->
+            RealmInterop.realm_app_user_apikey_provider_client_disable_apikey(
+                app.nativePointer,
+                user.nativePointer,
+                id as ObjectIdWrapper,
+                channelResultCallback<Unit, Unit>(channel) {
+                    // No-op
+                }.freeze()
+            )
+            return channel.receive()
+                .getOrThrow()
+        }
     }
 
     override suspend fun enable(id: ObjectId) {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -117,14 +117,14 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
         }
     }
 
-    override suspend fun fetch(id: ObjectId): ApiKey {
+    override suspend fun fetch(id: ObjectId): ApiKey? {
         try {
-            Channel<Result<ApiKey>>(1).use { channel ->
+            Channel<Result<ApiKey?>>(1).use { channel ->
                 RealmInterop.realm_app_user_apikey_provider_client_fetch_apikey(
                     app.nativePointer,
                     user.nativePointer,
                     id as ObjectIdWrapper,
-                    channelResultCallback<ApiKeyWrapper, ApiKey>(channel) { apiKeyData: ApiKeyWrapper ->
+                    channelResultCallback<ApiKeyWrapper, ApiKey?>(channel) { apiKeyData: ApiKeyWrapper ->
                         unwrap(apiKeyData)
                     }.freeze()
                 )
@@ -133,7 +133,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
             }
         } catch (ex: ServiceException) {
             if (ex.message?.contains("[Service][ApiKeyNotFound(35)] API key not found.") == true) {
-                throw IllegalArgumentException(ex.message!!)
+                return null
             } else {
                 throw ex
             }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -104,15 +104,18 @@ internal class ApiKeyAuthImpl(val app: AppImpl, val user: UserImpl) : ApiKeyAuth
                 app.nativePointer,
                 user.nativePointer,
                 channelResultCallback<Array<ApiKeyWrapper>, List<ApiKey>>(channel) { apiKeys: Array<ApiKeyWrapper> ->
-                    // TODO Find a way to avoid copying the array twice
+                    val result = mutableListOf<ApiKey>()
                     apiKeys.map { keyWrapper: ApiKeyWrapper ->
-                        ApiKey(
-                            ObjectIdImpl(keyWrapper.id),
-                            keyWrapper.value,
-                            keyWrapper.name,
-                            !keyWrapper.disabled
+                        result.add(
+                            ApiKey(
+                                ObjectIdImpl(keyWrapper.id),
+                                keyWrapper.value,
+                                keyWrapper.name,
+                                !keyWrapper.disabled
+                            )
                         )
-                    }.toList()
+                    }
+                    result
                 }.freeze()
             )
             return channel.receive()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -64,7 +64,18 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
     }
 
     override suspend fun enable(id: ObjectId) {
-        TODO("Not yet implemented")
+        Channel<Result<Unit>>(1).use { channel ->
+            RealmInterop.realm_app_user_apikey_provider_client_enable_apikey(
+                app.nativePointer,
+                user.nativePointer,
+                id as ObjectIdWrapper,
+                channelResultCallback<Unit, Unit>(channel) {
+                    // No-op
+                }.freeze()
+            )
+            return channel.receive()
+                .getOrThrow()
+        }
     }
 
     override suspend fun fetch(id: ObjectId): ApiKey {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -1,6 +1,7 @@
 package io.realm.kotlin.mongodb.internal
 
 import io.realm.kotlin.internal.ObjectIdImpl
+import io.realm.kotlin.internal.interop.ObjectIdWrapper
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
 import io.realm.kotlin.internal.platform.freeze
@@ -33,7 +34,18 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
     }
 
     override suspend fun delete(id: ObjectId) {
-        TODO("Not yet implemented")
+        Channel<Result<Unit>>(1).use { channel ->
+            RealmInterop.realm_app_user_apikey_provider_client_delete_apikey(
+                app.nativePointer,
+                user.nativePointer,
+                id as ObjectIdWrapper,
+                channelResultCallback<Unit, Unit>(channel) {
+                    // No-op
+                }.freeze()
+            )
+            return channel.receive()
+                .getOrThrow()
+        }
     }
 
     override suspend fun disable(id: ObjectId) {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -11,7 +11,7 @@ import io.realm.kotlin.mongodb.auth.ApiKeyAuth
 import io.realm.kotlin.types.ObjectId
 import kotlinx.coroutines.channels.Channel
 
-internal class ApiKeyAuthImpl(val app: AppImpl, val user: UserImpl) : ApiKeyAuth {
+internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: UserImpl) : ApiKeyAuth {
 
     override suspend fun create(name: String): ApiKey {
         Channel<Result<ApiKey>>(1).use { channel ->

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -1,0 +1,55 @@
+package io.realm.kotlin.mongodb.internal
+
+import io.realm.kotlin.internal.ObjectIdImpl
+import io.realm.kotlin.internal.interop.RealmInterop
+import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
+import io.realm.kotlin.internal.platform.freeze
+import io.realm.kotlin.internal.util.use
+import io.realm.kotlin.mongodb.auth.ApiKey
+import io.realm.kotlin.mongodb.auth.ApiKeyAuth
+import io.realm.kotlin.types.ObjectId
+import kotlinx.coroutines.channels.Channel
+
+internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: UserImpl) : ApiKeyAuth {
+
+    override suspend fun create(name: String): ApiKey {
+        Channel<Result<ApiKey>>(1).use { channel ->
+            RealmInterop.realm_app_user_apikey_provider_client_create_apikey(
+                app.nativePointer,
+                user.nativePointer,
+                name,
+                channelResultCallback<ApiKeyWrapper, ApiKey>(channel) { apiKeyData ->
+                    ApiKey(
+                        ObjectIdImpl(apiKeyData.id),
+                        apiKeyData.value,
+                        apiKeyData.name,
+                        !apiKeyData.disabled
+                    )
+                }.freeze()
+            )
+            return channel.receive()
+                .getOrThrow()
+        }
+    }
+
+    override suspend fun delete(id: ObjectId) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun disable(id: ObjectId) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun enable(id: ObjectId) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetch(id: ObjectId): ApiKey {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetchAll(): List<ApiKey> {
+        // wait with this
+        TODO("Not yet implemented")
+    }
+}

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.realm.kotlin.mongodb.internal
 
 import io.realm.kotlin.internal.ObjectIdImpl

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -54,6 +54,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     .getOrThrow()
             }
         } catch (ex: ServiceException) {
+            // TODO in the future, change to comparing error codes rather than messages
             if (ex.message?.contains("[Service][InvalidParameter(6)] can only contain ASCII letters, numbers, underscores, and hyphens.") == true ||
                 ex.message?.contains("[Service][Unknown(-1)] 'name' is a required string.") == true
             ) {
@@ -78,10 +79,11 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                 return channel.receive().getOrThrow()
             }
         } catch (ex: AppException) {
-            if (ex.message?.contains("[Service][Unknown(-1)] expected Authorization header with JWT (Bearer schema).") == true) {
-                throw ex
-            } else {
+            // TODO in the future, change to comparing error codes rather than messages
+            if (ex.message?.contains("[Service][ApiKeyNotFound(35)] API key not found.") == true) {
                 // No-op
+            } else {
+                throw ex
             }
         }
     }
@@ -101,6 +103,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     .getOrThrow()
             }
         } catch (ex: ServiceException) {
+            // TODO in the future, change to comparing error codes rather than messages
             if (ex.message?.contains("[Service][ApiKeyNotFound(35)] API key not found.") == true) {
                 throw IllegalArgumentException(ex.message!!)
             } else {
@@ -124,6 +127,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     .getOrThrow()
             }
         } catch (ex: ServiceException) {
+            // TODO in the future, change to comparing error codes rather than messages
             if (ex.message?.contains("[Service][ApiKeyNotFound(35)] API key not found.") == true) {
                 throw IllegalArgumentException(ex.message!!)
             } else {
@@ -147,6 +151,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     .getOrThrow()
             }
         } catch (ex: ServiceException) {
+            // TODO in the future, change to comparing error codes rather than messages
             if (ex.message?.contains("[Service][ApiKeyNotFound(35)] API key not found.") == true) {
                 return null
             } else {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
@@ -26,6 +26,7 @@ import io.realm.kotlin.mongodb.AuthenticationProvider
 import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.UserIdentity
+import io.realm.kotlin.mongodb.auth.ApiKeyAuth
 import io.realm.kotlin.mongodb.exceptions.CredentialsCannotBeLinkedException
 import io.realm.kotlin.mongodb.exceptions.ServiceException
 import kotlinx.coroutines.channels.Channel
@@ -35,7 +36,9 @@ public class UserImpl(
     public val nativePointer: RealmUserPointer,
     override val app: AppImpl
 ) : User {
-
+    override val apiKeyAuth: ApiKeyAuth by lazy {
+        ApiKeyAuthImpl(app, this)
+    }
     override val state: User.State
         get() = fromCoreState(RealmInterop.realm_user_get_state(nativePointer))
 

--- a/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/migration/RealmMigrationTests.kt
+++ b/packages/test-base/src/androidTest/kotlin/io/realm/kotlin/test/shared/migration/RealmMigrationTests.kt
@@ -272,7 +272,7 @@ class RealmMigrationTests {
                 )
                 .build()
 
-        assertFailsWithMessage<IllegalStateException>("Primary key property 'class_PrimaryKeyString.primaryKey' has duplicate values after migration.") {
+        assertFailsWithMessage<IllegalStateException>("Primary key property 'PrimaryKeyString.primaryKey' has duplicate values after migration.") {
             Realm.open(newConfiguration)
         }
     }

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -219,7 +219,7 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    @Ignore("Wait for https://github.com/realm/realm-kotlin/issues/1076 to be resolved before wrapping this up")
+    @Ignore("There seems to be a bug in the endpoint used for this test, need to wait until it is completed")
     fun callMethodsWithApiKeysDisabled() {
     }
 

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -4,6 +4,7 @@ import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.auth.ApiKeyAuth
 import io.realm.kotlin.mongodb.exceptions.AppException
+import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.types.ObjectId
@@ -12,7 +13,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -57,16 +57,20 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    fun create_throwsWithInvalidName(): Unit = runBlocking {
-        assertFailsWith<IllegalArgumentException> {
-            provider.create("%s")
+    fun create_throwsWithInvalidName() {
+        assertFailsWithMessage<IllegalArgumentException>("[Service][InvalidParameter(6)] can only contain ASCII letters, numbers, underscores, and hyphens.") {
+            runBlocking {
+                provider.create("%s")
+            }
         }
     }
 
     @Test
-    fun create_throwsWithNoName(): Unit = runBlocking {
-        assertFailsWith<IllegalArgumentException> {
-            provider.create("")
+    fun create_throwsWithNoName() {
+        assertFailsWithMessage<IllegalArgumentException>("[Service][Unknown(-1)] 'name' is a required string.") {
+            runBlocking {
+                provider.create("")
+            }
         }
     }
 
@@ -81,9 +85,11 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    fun fetch_nonExistingKeyThrows(): Unit = runBlocking {
-        assertFailsWith<IllegalArgumentException> {
-            provider.fetch(ObjectId.create())
+    fun fetch_nonExistingKeyThrows() {
+        assertFailsWithMessage<IllegalArgumentException>("[Service][ApiKeyNotFound(35)] API key not found.") {
+            runBlocking {
+                provider.fetch(ObjectId.create())
+            }
         }
     }
 
@@ -104,12 +110,14 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    fun delete(): Unit = runBlocking {
-        val key1 = provider.create("foo")
-        assertNotNull(provider.fetch(key1.id))
-        provider.delete(key1.id)
-        assertFailsWith<IllegalArgumentException> {
-            provider.fetch(key1.id)
+    fun delete() {
+        assertFailsWithMessage<IllegalArgumentException>("[Service][ApiKeyNotFound(35)] API key not found.") {
+            runBlocking {
+                val key1 = provider.create("foo")
+                assertNotNull(provider.fetch(key1.id))
+                provider.delete(key1.id)
+                provider.fetch(key1.id)
+            }
         }
     }
 
@@ -144,9 +152,11 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    fun enable_nonExistingKeyThrows(): Unit = runBlocking {
-        assertFailsWith<IllegalArgumentException> {
-            provider.enable(ObjectId.create())
+    fun enable_nonExistingKeyThrows() {
+        assertFailsWithMessage<IllegalArgumentException>("[Service][ApiKeyNotFound(35)] API key not found.") {
+            runBlocking {
+                provider.enable(ObjectId.create())
+            }
         }
     }
 
@@ -167,9 +177,11 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    fun disable_nonExistingKeyThrows(): Unit = runBlocking {
-        assertFailsWith<IllegalArgumentException> {
-            provider.disable(ObjectId.create())
+    fun disable_nonExistingKeyThrows() {
+        assertFailsWithMessage<IllegalArgumentException>("[Service][ApiKeyNotFound(35)] API key not found.") {
+            runBlocking {
+                provider.disable(ObjectId.create())
+            }
         }
     }
 

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -47,7 +47,7 @@ class ApiKeyAuthTests {
     @Test
     fun create_throwsWithInvalidName(): Unit = runBlocking {
         // worth creating a more specific exception?
-        assertFailsWith<ServiceException> {
+        assertFailsWith<IllegalArgumentException> {
             provider.create("%s")
         }
     }
@@ -55,7 +55,7 @@ class ApiKeyAuthTests {
     @Test
     fun create_throwsWithNoName(): Unit = runBlocking {
         // worth creating a more specific exception?
-        assertFailsWith<ServiceException> {
+        assertFailsWith<IllegalArgumentException> {
             provider.create("")
         }
     }
@@ -131,7 +131,7 @@ class ApiKeyAuthTests {
 
     @Test
     fun enable_nonExistingKeyThrows(): Unit = runBlocking {
-        assertFailsWith<ServiceException> {
+        assertFailsWith<IllegalArgumentException> {
             provider.enable(ObjectId.create())
         }
     }
@@ -154,7 +154,7 @@ class ApiKeyAuthTests {
 
     @Test
     fun disable_nonExistingKeyThrows(): Unit = runBlocking {
-        assertFailsWith<ServiceException> {
+        assertFailsWith<IllegalArgumentException> {
             provider.disable(ObjectId.create())
         }
     }

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -215,7 +215,7 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    @Ignore("TODO: wait for https://jira.mongodb.org/browse/BAAS-17508 to complete before implementing")
+    @Ignore // TODO wait for https://jira.mongodb.org/browse/BAAS-17508 to complete before implementing
     fun callMethodsWithApiKeysDisabled() {
     }
 

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -102,7 +102,7 @@ class ApiKeyAuthTests {
     fun delete_nonExisitingKeyThrows(): Unit = runBlocking {
         // worth creating a more specific exception?
         assertFailsWith<ServiceException> {
-            provider.fetch(ObjectId.create())
+            provider.delete(ObjectId.create())
         }
     }
 

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -1,0 +1,51 @@
+package io.realm.kotlin.test.mongodb.shared
+
+import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.mongodb.Credentials
+import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.mongodb.auth.EmailPasswordAuth
+import io.realm.kotlin.mongodb.exceptions.AppException
+import io.realm.kotlin.mongodb.exceptions.AuthException
+import io.realm.kotlin.mongodb.exceptions.BadRequestException
+import io.realm.kotlin.mongodb.exceptions.UserAlreadyConfirmedException
+import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
+import io.realm.kotlin.mongodb.exceptions.UserNotFoundException
+import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
+import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.util.BaasApp
+import io.realm.kotlin.test.mongodb.util.Service
+import io.realm.kotlin.test.mongodb.util.TestAppInitializer.addEmailProvider
+import io.realm.kotlin.test.util.TestHelper
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class ApiKeyAuthTests {
+    private lateinit var app: TestApp
+    private lateinit var user: User
+    @BeforeTest
+    fun setup() {
+        app = TestApp(appName = TEST_APP_PARTITION)
+        user = app.createUserAndLogin()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (this::app.isInitialized) {
+            app.close()
+        }
+    }
+
+    @Test
+    fun create() = runBlocking {
+        val key = user.apiKeyAuth.create("foo")
+        assertEquals("foo", key.name)
+    }
+
+}

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -2,20 +2,30 @@ package io.realm.kotlin.test.mongodb.shared
 
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.mongodb.auth.ApiKeyAuth
+import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.types.ObjectId
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ApiKeyAuthTests {
     private lateinit var app: TestApp
     private lateinit var user: User
+    private lateinit var provider: ApiKeyAuth
     @BeforeTest
     fun setup() {
         app = TestApp(appName = TEST_APP_PARTITION)
         user = app.createUserAndLogin()
+        provider = user.apiKeyAuth
     }
 
     @AfterTest
@@ -25,28 +35,123 @@ class ApiKeyAuthTests {
         }
     }
 
-    // TODO Just for checking JNI. Create proper test
     @Test
     fun create() = runBlocking {
-        val key = user.apiKeyAuth.create("foo")
+        val key = provider.create("foo")
         assertEquals("foo", key.name)
+        assertNotNull(key.value)
+        assertNotNull(key.id)
+        assertTrue(key.enabled)
+    }
+
+    @Test
+    fun create_throwsWithInvalidName(): Unit = runBlocking {
+        // worth creating a more specific exception?
+        assertFailsWith<ServiceException> {
+            provider.create("%s")
+        }
+    }
+
+    @Test
+    fun create_throwsWithNoName(): Unit = runBlocking {
+        // worth creating a more specific exception?
+        assertFailsWith<ServiceException> {
+            provider.create("")
+        }
     }
 
     @Test
     fun fetch() = runBlocking {
-        val key = user.apiKeyAuth.create("foo")
-        val test = user.apiKeyAuth.fetch(key.id)
-        assertEquals("foo", test.name)
+        val key1 = provider.create("foo")
+        val key2 = provider.fetch(key1.id)
+        assertEquals(key1.id, key2.id)
+        assertEquals(key1.name, key2.name)
+        assertNull(key2.value)
+        assertEquals(key1.enabled, key2.enabled)
     }
 
-    // TODO Just for checking JNI. Create proper test
+    @Test
+    fun fetch_nonExistingKeyThrows(): Unit = runBlocking {
+        // worth creating a more specific exception?
+        assertFailsWith<ServiceException> {
+            provider.fetch(ObjectId.create())
+        }
+    }
+
     @Test
     fun fetchAll() = runBlocking {
-        user.apiKeyAuth.create("foo")
-        user.apiKeyAuth.create("bar")
-        user.apiKeyAuth.create("baz")
+        val key1 = provider.create("foo")
+        val key2 = provider.create("bar")
+        val keys = provider.fetchAll()
+        assertEquals(2, keys.size)
+        assertTrue(keys.any { it.id == key1.id })
+        assertTrue(keys.any { it.id == key2.id })
+    }
 
-        val keys = user.apiKeyAuth.fetchAll()
-        assertEquals(3, keys.size)
+    @Test
+    fun delete(): Unit = runBlocking {
+        val key1 = provider.create("foo")
+        assertNotNull(provider.fetch(key1.id))
+        provider.delete(key1.id)
+        assertFailsWith<ServiceException> {
+            provider.fetch(key1.id)
+        }
+    }
+
+    @Test
+    fun delete_nonExisitingKeyThrows(): Unit = runBlocking {
+        // worth creating a more specific exception?
+        assertFailsWith<ServiceException> {
+            provider.fetch(ObjectId.create())
+        }
+    }
+
+    @Test
+    fun enable(): Unit = runBlocking {
+        val key = provider.create("foo")
+        provider.disable(key.id)
+        assertFalse(provider.fetch(key.id).enabled)
+        provider.enable(key.id)
+        assertTrue(provider.fetch(key.id).enabled)
+    }
+
+    @Test
+    fun enable_alreadyEnabled() = runBlocking {
+        val key = provider.create("foo")
+        provider.disable(key.id)
+        assertFalse(provider.fetch(key.id).enabled)
+        provider.enable(key.id)
+        assertTrue(provider.fetch(key.id).enabled)
+        provider.enable(key.id)
+        assertTrue(provider.fetch(key.id).enabled)
+    }
+    @Test
+    fun enable_nonExistingKeyThrows(): Unit = runBlocking {
+        assertFailsWith<ServiceException> {
+            provider.enable(ObjectId.create())
+        }
+    }
+
+    @Test
+    fun disable() = runBlocking {
+        val key = provider.create("foo")
+        provider.disable(key.id)
+        assertFalse(provider.fetch(key.id).enabled)
+    }
+
+    @Test
+    fun disable_alreadyDisabled() = runBlocking {
+        val key = provider.create("foo")
+        provider.disable(key.id)
+        assertFalse(provider.fetch(key.id).enabled)
+        provider.disable(key.id)
+        assertFalse(provider.fetch(key.id).enabled)
+    }
+
+    @Test
+    fun disable_nonExistingKeyThrows(): Unit = runBlocking {
+        assertFailsWith<ServiceException> {
+            provider.disable(ObjectId.create())
+        }
     }
 }

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -16,16 +16,12 @@
 package io.realm.kotlin.test.mongodb.shared
 
 import io.realm.kotlin.internal.platform.runBlocking
-import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.auth.ApiKeyAuth
-import io.realm.kotlin.mongodb.exceptions.AppException
 import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import io.realm.kotlin.test.mongodb.TestApp
-import io.realm.kotlin.test.mongodb.util.TestAppInitializer.addEmailProvider
-import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initializePartitionSync
 import io.realm.kotlin.types.ObjectId
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -219,7 +215,7 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    @Ignore("There seems to be a bug in the endpoint used for this test, need to wait until it is completed")
+    @Ignore("TODO: wait for https://jira.mongodb.org/browse/BAAS-17508 to complete before implementing")
     fun callMethodsWithApiKeysDisabled() {
     }
 

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -1,30 +1,13 @@
 package io.realm.kotlin.test.mongodb.shared
 
 import io.realm.kotlin.internal.platform.runBlocking
-import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
-import io.realm.kotlin.mongodb.auth.EmailPasswordAuth
-import io.realm.kotlin.mongodb.exceptions.AppException
-import io.realm.kotlin.mongodb.exceptions.AuthException
-import io.realm.kotlin.mongodb.exceptions.BadRequestException
-import io.realm.kotlin.mongodb.exceptions.UserAlreadyConfirmedException
-import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
-import io.realm.kotlin.mongodb.exceptions.UserNotFoundException
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import io.realm.kotlin.test.mongodb.TestApp
-import io.realm.kotlin.test.mongodb.util.BaasApp
-import io.realm.kotlin.test.mongodb.util.Service
-import io.realm.kotlin.test.mongodb.util.TestAppInitializer.addEmailProvider
-import io.realm.kotlin.test.util.TestHelper
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
-import kotlin.test.fail
 
 class ApiKeyAuthTests {
     private lateinit var app: TestApp
@@ -49,6 +32,13 @@ class ApiKeyAuthTests {
         assertEquals("foo", key.name)
     }
 
+    @Test
+    fun fetch() = runBlocking {
+        val key = user.apiKeyAuth.create("foo")
+        val test = user.apiKeyAuth.fetch(key.id)
+        assertEquals("foo", test.name)
+    }
+
     // TODO Just for checking JNI. Create proper test
     @Test
     fun fetchAll() = runBlocking {
@@ -59,5 +49,4 @@ class ApiKeyAuthTests {
         val keys = user.apiKeyAuth.fetchAll()
         assertEquals(3, keys.size)
     }
-
 }

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -85,12 +85,8 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    fun fetch_nonExistingKeyThrows() {
-        assertFailsWithMessage<IllegalArgumentException>("[Service][ApiKeyNotFound(35)] API key not found.") {
-            runBlocking {
-                provider.fetch(ObjectId.create())
-            }
-        }
+    fun fetch_nonExistingKeyThrows() = runBlocking {
+        assertNull(provider.fetch(ObjectId.create()))
     }
 
     @Test
@@ -110,15 +106,11 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    fun delete() {
-        assertFailsWithMessage<IllegalArgumentException>("[Service][ApiKeyNotFound(35)] API key not found.") {
-            runBlocking {
-                val key1 = provider.create("foo")
-                assertNotNull(provider.fetch(key1.id))
-                provider.delete(key1.id)
-                provider.fetch(key1.id)
-            }
-        }
+    fun delete() = runBlocking {
+        val key1 = provider.create("foo")
+        assertNotNull(provider.fetch(key1.id))
+        provider.delete(key1.id)
+        assertNull(provider.fetch(key1.id))
     }
 
     @Test
@@ -210,5 +202,16 @@ class ApiKeyAuthTests {
     @Test
     @Ignore("Wait for https://github.com/realm/realm-kotlin/issues/1076 to be resolved before wrapping this up")
     fun callMethodsWithApiKeysDisabled() {
+    }
+
+    @Test
+    fun getUser() {
+        assertEquals(app.currentUser, provider.user)
+    }
+
+    @Test
+    fun getApp() {
+        // Testapp is a pair of <App, AdminApp>
+        assertEquals(app.app, provider.app)
     }
 }

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -99,11 +99,14 @@ class ApiKeyAuthTests {
     }
 
     @Test
-    fun delete_nonExisitingKeyThrows(): Unit = runBlocking {
+    fun delete_nonExisitingKeyNoOps(): Unit = runBlocking {
         // worth creating a more specific exception?
-        assertFailsWith<ServiceException> {
-            provider.delete(ObjectId.create())
-        }
+        provider.create("foo")
+        val keys = provider.fetchAll()
+        assertEquals(1, keys.size)
+        provider.delete(ObjectId.create())
+        val keysAfterInvalidDelete = provider.fetchAll()
+        assertEquals(1, keysAfterInvalidDelete.size)
     }
 
     @Test

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -42,10 +42,22 @@ class ApiKeyAuthTests {
         }
     }
 
+    // TODO Just for checking JNI. Create proper test
     @Test
     fun create() = runBlocking {
         val key = user.apiKeyAuth.create("foo")
         assertEquals("foo", key.name)
+    }
+
+    // TODO Just for checking JNI. Create proper test
+    @Test
+    fun fetchAll() = runBlocking {
+        user.apiKeyAuth.create("foo")
+        user.apiKeyAuth.create("bar")
+        user.apiKeyAuth.create("baz")
+
+        val keys = user.apiKeyAuth.fetchAll()
+        assertEquals(3, keys.size)
     }
 
 }

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -1,16 +1,34 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.realm.kotlin.test.mongodb.shared
 
 import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.auth.ApiKeyAuth
 import io.realm.kotlin.mongodb.exceptions.AppException
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.util.TestAppInitializer.addEmailProvider
+import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initializePartitionSync
 import io.realm.kotlin.types.ObjectId
-import org.junit.Ignore
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -211,7 +211,8 @@ class ApiKeyAuthTests {
 
     @Test
     fun getApp() {
-        // Testapp is a pair of <App, AdminApp>
+        // Testapp is a pair of <App, AdminApp>, that's why further delving needs to be done to
+        // get the actual app
         assertEquals(app.app, provider.app)
     }
 }

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -20,6 +20,7 @@ import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.auth.ApiKeyAuth
 import io.realm.kotlin.mongodb.exceptions.AppException
+import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import io.realm.kotlin.test.mongodb.TestApp
@@ -210,7 +211,7 @@ class ApiKeyAuthTests {
                         Method.DISABLE -> provider.disable(ObjectId.create())
                     }
                     fail("$method should have thrown an exception")
-                } catch (error: AppException) {
+                } catch (error: ServiceException) {
                     assertEquals("[Service][Unknown(-1)] expected Authorization header with JWT (Bearer schema).", error.message)
                 }
             }

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ApiKeyAuthTests.kt
@@ -64,7 +64,7 @@ class ApiKeyAuthTests {
     fun fetch() = runBlocking {
         val key1 = provider.create("foo")
         val key2 = provider.fetch(key1.id)
-        assertEquals(key1.id, key2.id)
+        assertEquals(key1.id, key2!!.id)
         assertEquals(key1.name, key2.name)
         assertNull(key2.value)
         assertEquals(key1.enabled, key2.enabled)
@@ -113,21 +113,22 @@ class ApiKeyAuthTests {
     fun enable(): Unit = runBlocking {
         val key = provider.create("foo")
         provider.disable(key.id)
-        assertFalse(provider.fetch(key.id).enabled)
+        assertFalse(provider.fetch(key.id)!!.enabled)
         provider.enable(key.id)
-        assertTrue(provider.fetch(key.id).enabled)
+        assertTrue(provider.fetch(key.id)!!.enabled)
     }
 
     @Test
     fun enable_alreadyEnabled() = runBlocking {
         val key = provider.create("foo")
         provider.disable(key.id)
-        assertFalse(provider.fetch(key.id).enabled)
+        assertFalse(provider.fetch(key.id)!!.enabled)
         provider.enable(key.id)
-        assertTrue(provider.fetch(key.id).enabled)
+        assertTrue(provider.fetch(key.id)!!.enabled)
         provider.enable(key.id)
-        assertTrue(provider.fetch(key.id).enabled)
+        assertTrue(provider.fetch(key.id)!!.enabled)
     }
+
     @Test
     fun enable_nonExistingKeyThrows(): Unit = runBlocking {
         assertFailsWith<ServiceException> {
@@ -139,16 +140,16 @@ class ApiKeyAuthTests {
     fun disable() = runBlocking {
         val key = provider.create("foo")
         provider.disable(key.id)
-        assertFalse(provider.fetch(key.id).enabled)
+        assertFalse(provider.fetch(key.id)!!.enabled)
     }
 
     @Test
     fun disable_alreadyDisabled() = runBlocking {
         val key = provider.create("foo")
         provider.disable(key.id)
-        assertFalse(provider.fetch(key.id).enabled)
+        assertFalse(provider.fetch(key.id)!!.enabled)
         provider.disable(key.id)
-        assertFalse(provider.fetch(key.id).enabled)
+        assertFalse(provider.fetch(key.id)!!.enabled)
     }
 
     @Test

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/CredentialsTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/mongodb/shared/CredentialsTests.kt
@@ -21,6 +21,8 @@ import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.AuthenticationProvider
 import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.GoogleAuthType
+import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.mongodb.auth.ApiKey
 import io.realm.kotlin.mongodb.exceptions.AppException
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
@@ -219,16 +221,14 @@ class CredentialsTests {
                         assertNotNull(nonReusableUser)
                         assertNotEquals(reusableUser.identity, nonReusableUser.identity)
                     }
-                    AuthenticationProvider.API_KEY -> { /* Ignore, see https://github.com/realm/realm-kotlin/issues/432 */ }
-//                    AuthenticationProvider.API_KEY -> {
-//                        // Log in, create an API key, log out, log in with the key, compare users
-//                        val user: User =
-//                            app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
-//                        val key: ApiKey = user.apiKeys.create("my-key");
-//                        user.logOut()
-//                        val apiKeyUser = app.login(Credentials.apiKey(key.value!!))
-//                        assertEquals(user.id, apiKeyUser.id)
-//                    }
+                    AuthenticationProvider.API_KEY -> {
+                        // Log in, create an API key, log out, log in with the key, compare users
+                        val user: User = app.createUserAndLogIn(TestHelper.randomEmail(), "password1234")
+                        val key: ApiKey = user.apiKeyAuth.create("my-key")
+                        user.logOut()
+                        val apiKeyUser = app.login(Credentials.apiKey(key.value!!))
+                        assertEquals(user.id, apiKeyUser.id)
+                    }
 
 // TODO Enable this when https://github.com/realm/realm-kotlin/issues/741 is complete.
 


### PR DESCRIPTION
Early version of #432, some optimisations still needs to be done, and discussions about error handling needs to be made as well.

This depends on us being able to merge changes from `jm/named-apikey-callbacks` in core.

need to update `CredentialsTests` and `CHANGELOG.md`