### PR TITLE
Fix SyncSession crashing when accessed after receiving remote changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [Sync] The sync variant `io.realm.kotlin:library-sync:1.4.0`, now support Apple Silicon targets, ie. `macosArm64()`, `iosArm64()` and `iosSimulatorArm64`.
 
 ### Fixed
-* None.
+* [Sync] Using the SyncSession after receiving changes from the server would sometimes crash. Issue [#1068](https://github.com/realm/realm-kotlin/issues/1068)
 
 ### Compatibility
 * This release is compatible with the following Kotlin releases:

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
@@ -37,6 +37,7 @@ internal class SyncedRealmContext<T : BaseRealm>(realm: T) {
     //  When we introduce a public DynamicRealm, this can also be a `DynamicRealmImpl`
     //  And we probably need to modify the SyncSessionImpl to take either of these two.
     private val baseRealm = realm as RealmImpl
+    // Warning: Should only be accessed when constructing the object. Otherwise it might be cleaned up.
     private val dbPointer = baseRealm.realmReference.dbPointer
     internal val config: SyncConfiguration = baseRealm.configuration as SyncConfiguration
     internal val session: SyncSession by lazy {
@@ -45,6 +46,9 @@ internal class SyncedRealmContext<T : BaseRealm>(realm: T) {
     internal val subscriptions: SubscriptionSet<T> by lazy {
         SubscriptionSetImpl<T>(realm, RealmInterop.realm_sync_get_latest_subscriptionset(dbPointer))
     }
+
+//    internal val session: SyncSession = SyncSessionImpl(baseRealm, RealmInterop.realm_sync_session_get(dbPointer))
+//    internal val subscriptions: SubscriptionSet<T> = SubscriptionSetImpl(realm, RealmInterop.realm_sync_get_latest_subscriptionset(dbPointer))
 }
 
 /**

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
@@ -31,15 +31,12 @@ import io.realm.kotlin.ext.query
 import io.realm.kotlin.internal.platform.fileExists
 import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.platform.runBlocking
-import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.exceptions.DownloadingRealmTimeOutException
 import io.realm.kotlin.mongodb.exceptions.SyncException
 import io.realm.kotlin.mongodb.exceptions.UnrecoverableSyncException
-import io.realm.kotlin.mongodb.subscriptions
 import io.realm.kotlin.mongodb.sync.InitialSubscriptionsCallback
-import io.realm.kotlin.mongodb.sync.InitialSubscriptionsConfiguration
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncSession
 import io.realm.kotlin.mongodb.sync.SyncSession.ErrorHandler
@@ -58,7 +55,6 @@ import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.TestHelper.randomEmail
 import io.realm.kotlin.test.util.use
 import io.realm.kotlin.types.BaseRealmObject
-import io.realm.kotlin.types.RealmObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
@@ -1108,7 +1108,7 @@ class SyncedRealmTests {
         //    the first time should still work.
         try {
             realm1.syncSession.pause()
-            assertEquals(SyncSession.State.INACTIVE, realm.syncSession.state)
+            assertEquals(SyncSession.State.INACTIVE, realm1.syncSession.state)
         } finally {
             realm1.close()
             flexApp.close()

--- a/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
+++ b/packages/test-sync/src/androidTest/kotlin/io/realm/kotlin/test/shared/SyncedRealmTests.kt
@@ -1108,6 +1108,7 @@ class SyncedRealmTests {
         //    the first time should still work.
         try {
             realm1.syncSession.pause()
+            assertEquals(SyncSession.State.INACTIVE, realm.syncSession.state)
         } finally {
             realm1.close()
             flexApp.close()


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/1068

Note, when creating this patch I discovered another bug: https://github.com/realm/realm-kotlin/issues/1070.

A test has been written that catch this but it is marked as `@Ignore` for now.
