### PR TITLE
Add support for encrypting user metadata used by Sync.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added support for reverse relationships through the `linkingObjects` delegate. See the function documentation for more details. (Issue [#1021](https://github.com/realm/realm-kotlin/pull/1021))
 * Added support for `BsonObjectId` and its typealias `org.mongodb.kbson.ObjectId` as a replacement for `ObjectId`. `io.realm.kotlin.types.ObjectId` is still functional but has been marked as deprecated.
 * [Sync] Added support for `BsonObjectId` as partition value.
+* [Sync] Added support for encrypting the user metadata used by Sync. (Issue [#413](https://github.com/realm/realm-kotlin/issues/413))
 
 ### Fixed
 * Close underlying realm if it is no longer referenced by any Kotlin object. (Issue [#671](https://github.com/realm/realm-kotlin/issues/671))

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -392,6 +392,11 @@ expect object RealmInterop {
         metadataMode: MetadataMode
     )
 
+    fun realm_sync_client_config_set_metadata_encryption_key(
+        syncClientConfig: RealmSyncClientConfigurationPointer,
+        encryptionKey: ByteArray
+    )
+
     fun realm_sync_config_new(
         user: RealmUserPointer,
         partition: String

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -959,6 +959,16 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_sync_client_config_set_metadata_encryption_key(
+        syncClientConfig: RealmSyncClientConfigurationPointer,
+        encryptionKey: ByteArray
+    ) {
+        realmc.realm_sync_client_config_set_metadata_encryption_key(
+            syncClientConfig.cptr(),
+            encryptionKey
+        )
+    }
+
     actual fun realm_network_transport_new(networkTransport: NetworkTransport): RealmNetworkTransportPointer {
         return LongPointerWrapper(realmc.realm_network_transport_new(networkTransport))
     }

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -2046,6 +2046,19 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_sync_client_config_set_metadata_encryption_key(
+        syncClientConfig: RealmSyncClientConfigurationPointer,
+        encryptionKey: ByteArray
+    ) {
+        memScoped {
+            val encryptionKeyPointer = encryptionKey.refTo(0).getPointer(memScope)
+            realm_wrapper.realm_sync_client_config_set_metadata_encryption_key(
+                syncClientConfig.cptr(),
+                encryptionKeyPointer as CPointer<uint8_tVar>
+            )
+        }
+    }
+
     actual fun realm_sync_config_set_error_handler(
         syncConfig: RealmSyncConfigurationPointer,
         errorHandler: SyncErrorCallback

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -350,6 +350,9 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 %apply int8_t[] {uint8_t *out_key};
 %apply int8_t[] {const uint8_t* data};
 
+// Enable passing uint8_t [64] parameter for realm_sync_client_config_set_metadata_encryption_key as Byte[]
+%apply int8_t[] {uint8_t [64]};
+
 %typemap(freearg) const uint8_t* data;
 %typemap(out) const uint8_t* data %{
     $result = SWIG_JavaArrayOutSchar(jenv, (signed char *)result, arg1->size);
@@ -428,9 +431,6 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 //  corresponding typemap. Other usages will possible incur in leaking values, like in
 //  realm_convert_with_path.
 %ignore realm_convert_with_path;
-
-// Still missing from sync implementation
-%ignore "realm_sync_client_config_set_metadata_encryption_key";
 
 // Swig doesn't understand __attribute__ so eliminate it
 #define __attribute__(x)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -52,8 +52,8 @@ public interface AppConfiguration {
     //  requires ktor as api dependency
     public val baseUrl: String
     public val encryptionKey: ByteArray?
-    public val networkTransport: NetworkTransport
     public val metadataMode: MetadataMode
+    public val networkTransport: NetworkTransport
     public val syncRootDirectory: String
 
     public companion object {
@@ -103,8 +103,8 @@ public interface AppConfiguration {
         private var userLoggers: List<RealmLogger> = listOf()
 
         /**
-         * Sets the encryption key used to encrypt user metadata only. Individual Realms need to
-         * use [SyncConfiguration.Builder.encryptionKey] to encrypt them.
+         * Sets the encryption key used to encrypt the user metadata Realm only. Individual
+         * Realms need to use [SyncConfiguration.Builder.encryptionKey] to encrypt them.
          *
          * @param key a 64 byte encryption key.
          * @return the Builder instance used.
@@ -228,6 +228,9 @@ public interface AppConfiguration {
                 appId = appId,
                 baseUrl = baseUrl,
                 encryptionKey = encryptionKey,
+                metadataMode = if (encryptionKey == null)
+                    MetadataMode.RLM_SYNC_CLIENT_METADATA_MODE_PLAINTEXT
+                    else MetadataMode.RLM_SYNC_CLIENT_METADATA_MODE_ENCRYPTED,
                 networkTransport = networkTransport,
                 syncRootDirectory = syncRootDirectory,
                 log = appLogger

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -230,7 +230,7 @@ public interface AppConfiguration {
                 encryptionKey = encryptionKey,
                 metadataMode = if (encryptionKey == null)
                     MetadataMode.RLM_SYNC_CLIENT_METADATA_MODE_PLAINTEXT
-                    else MetadataMode.RLM_SYNC_CLIENT_METADATA_MODE_ENCRYPTED,
+                else MetadataMode.RLM_SYNC_CLIENT_METADATA_MODE_ENCRYPTED,
                 networkTransport = networkTransport,
                 syncRootDirectory = syncRootDirectory,
                 log = appLogger

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -123,11 +123,14 @@ public interface AppConfiguration {
          * [DEFAULT_BASE_URL].
          *
          * @param baseUrl the base url for the App Services Application.
+         * @return the Builder instance used.
          */
         public fun baseUrl(baseUrl: String): Builder = apply { this.baseUrl = baseUrl }
 
         /**
          * The dispatcher used to execute internal tasks; most notably remote HTTP requests.
+         *
+         * @return the Builder instance used.
          */
         public fun dispatcher(dispatcher: CoroutineDispatcher): Builder = apply { this.dispatcher = dispatcher }
 
@@ -138,6 +141,7 @@ public interface AppConfiguration {
          * @param customLoggers any custom loggers to send log events to. A default system logger is
          * installed by default that will redirect to the common logging framework on the platform, i.e.
          * LogCat on Android and NSLog on iOS.
+         * @return the Builder instance used.
          */
         public fun log(level: LogLevel = LogLevel.WARN, customLoggers: List<RealmLogger> = emptyList()): Builder =
             apply {
@@ -172,6 +176,7 @@ public interface AppConfiguration {
          * ```
          *
          * @param rootDir the directory where a `mongodb-realm` directory will be created.
+         * @return the Builder instance used.
          */
         public fun syncRootDirectory(rootDir: String): Builder = apply {
             val directoryExists = directoryExists(rootDir)
@@ -194,6 +199,7 @@ public interface AppConfiguration {
          * been configured, no log events will be reported, regardless of the configured
          * log level.
          *
+         * @return the Builder instance used.
          * @see [RealmConfiguration.Builder.log]
          */
         internal fun removeSystemLogger(): Builder = apply { this.removeSystemLogger = true }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
@@ -37,6 +37,7 @@ import io.realm.kotlin.mongodb.AppConfiguration.Companion.DEFAULT_BASE_URL
 public class AppConfigurationImpl constructor(
     override val appId: String,
     override val baseUrl: String = DEFAULT_BASE_URL,
+    override val encryptionKey: ByteArray?,
     override val networkTransport: NetworkTransport,
     override val metadataMode: MetadataMode = MetadataMode.RLM_SYNC_CLIENT_METADATA_MODE_PLAINTEXT,
     override val syncRootDirectory: String,
@@ -106,5 +107,12 @@ public class AppConfigurationImpl constructor(
                     syncClientConfig,
                     syncRootDirectory
                 )
+
+                if (encryptionKey != null) {
+                    RealmInterop.realm_sync_client_config_set_metadata_encryption_key(
+                        syncClientConfig,
+                        encryptionKey
+                    )
+                }
             }
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
@@ -34,12 +34,13 @@ import io.realm.kotlin.mongodb.AppConfiguration
 import io.realm.kotlin.mongodb.AppConfiguration.Companion.DEFAULT_BASE_URL
 
 // TODO Public due to being a transitive dependency to AppImpl
+@Suppress("LongParameterList")
 public class AppConfigurationImpl constructor(
     override val appId: String,
     override val baseUrl: String = DEFAULT_BASE_URL,
     override val encryptionKey: ByteArray?,
+    override val metadataMode: MetadataMode,
     override val networkTransport: NetworkTransport,
-    override val metadataMode: MetadataMode = MetadataMode.RLM_SYNC_CLIENT_METADATA_MODE_PLAINTEXT,
     override val syncRootDirectory: String,
     public val log: RealmLog
 ) : AppConfiguration {

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
@@ -20,6 +20,7 @@ import io.realm.kotlin.internal.platform.appFilesDirectory
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.AppConfiguration
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
+import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
@@ -302,10 +303,14 @@ class AppConfigurationTests {
         val builder = AppConfiguration.Builder(APP_ID)
 
         val tooShortKey = ByteArray(1)
-        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooShortKey) }
+        assertFailsWithMessage<IllegalArgumentException>("The provided key must be") {
+            builder.encryptionKey(tooShortKey)
+        }
 
         val tooLongKey = ByteArray(65)
-        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooLongKey) }
+        assertFailsWithMessage<IllegalArgumentException>("The provided key must be") {
+            builder.encryptionKey(tooLongKey)
+        }
     }
 
 //

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
@@ -26,10 +26,12 @@ import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
 // private const val CUSTOM_HEADER_NAME = "Foo"
@@ -393,6 +395,37 @@ class AppConfigurationTests {
 //        assertTrue(headerSet.get())
 //        looperThread.testComplete()
 //    }
+
+    @Test
+    fun encryptionKey() {
+        val key = TestHelper.getRandomKey()
+        val config = AppConfiguration.Builder("app-id")
+            .encryptionKey(key)
+            .build()
+
+        assertContentEquals(key, config.encryptionKey)
+    }
+
+    @Test
+    fun encryptionKey_isCopy() {
+        val key = TestHelper.getRandomKey()
+        val config = AppConfiguration.Builder("app-id")
+            .encryptionKey(key)
+            .build()
+
+        assertNotSame(key, config.encryptionKey)
+    }
+
+    @Test
+    fun encryptionKey_wrongLength() {
+        val builder = AppConfiguration.Builder("app-id")
+
+        val tooShortKey = ByteArray(1)
+        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooShortKey) }
+
+        val tooLongKey = ByteArray(65)
+        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooLongKey) }
+    }
 
     fun equals_same() {
         val appId = "foo"

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
@@ -418,7 +418,7 @@ class AppConfigurationTests {
     }
 
     @Test
-    fun encryptionKey_wrongLength() {
+    fun encryptionKey_illegalValueThrows() {
         val builder = AppConfiguration.Builder(APP_ID)
 
         val tooShortKey = ByteArray(1)

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
@@ -37,6 +37,7 @@ import kotlin.test.assertTrue
 // private const val CUSTOM_HEADER_NAME = "Foo"
 // private const val CUSTOM_HEADER_VALUE = "bar"
 // private const val AUTH_HEADER_NAME = "RealmAuth"
+private const val APP_ID = "app-id"
 
 class AppConfigurationTests {
 
@@ -47,17 +48,17 @@ class AppConfigurationTests {
 
 //    @Test
 //    fun authorizationHeaderName_illegalArgumentsThrows() {
-//        val builder: AppConfiguration.Builder = AppConfiguration.Builder("app-id")
+//        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
 //        assertFailsWith<IllegalArgumentException> { builder.authorizationHeaderName(TestHelper.getNull()) }
 //        assertFailsWith<IllegalArgumentException> { builder.authorizationHeaderName("") }
 //    }
 //
 //    @Test
 //    fun authorizationHeaderName() {
-//        val config1 = AppConfiguration.Builder("app-id").build()
+//        val config1 = AppConfiguration.Builder(APP_ID).build()
 //        assertEquals("Authorization", config1.authorizationHeaderName)
 //
-//        val config2 = AppConfiguration.Builder("app-id")
+//        val config2 = AppConfiguration.Builder(APP_ID)
 //            .authorizationHeaderName("CustomAuth")
 //            .build()
 //        assertEquals("CustomAuth", config2.authorizationHeaderName)
@@ -65,7 +66,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun addCustomRequestHeader_illegalArgumentThrows() {
-//        val builder: AppConfiguration.Builder = AppConfiguration.Builder("app-id")
+//        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
 //        assertFailsWith<IllegalArgumentException> { builder.addCustomRequestHeader("", "val") }
 //        assertFailsWith<IllegalArgumentException> { builder.addCustomRequestHeader(TestHelper.getNull(), "val") }
 //        assertFailsWith<IllegalArgumentException> { builder.addCustomRequestHeader("header", TestHelper.getNull()) }
@@ -73,7 +74,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun addCustomRequestHeader() {
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .addCustomRequestHeader("header1", "val1")
 //            .addCustomRequestHeader("header2", "val2")
 //            .build()
@@ -88,7 +89,7 @@ class AppConfigurationTests {
 //        val inputHeaders: MutableMap<String, String> = LinkedHashMap()
 //        inputHeaders["header1"] = "value1"
 //        inputHeaders["header2"] = "value2"
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .addCustomRequestHeaders(TestHelper.getNull())
 //            .addCustomRequestHeaders(inputHeaders)
 //            .build()
@@ -100,7 +101,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun addCustomHeader_combinesSingleAndMultiple() {
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .addCustomRequestHeader("header3", "val3")
 //            .addCustomRequestHeaders(mapOf(Pair("header1", "val1")))
 //            .build()
@@ -112,21 +113,21 @@ class AppConfigurationTests {
 
     @Test
     fun create() {
-        val config = AppConfiguration.create("app-id")
+        val config = AppConfiguration.create(APP_ID)
         assertIs<AppConfiguration>(config)
-        assertEquals("app-id", config.appId)
+        assertEquals(APP_ID, config.appId)
     }
 
     @Test
     fun syncRootDirectory_default() {
-        val config = AppConfiguration.Builder("app-id").build()
+        val config = AppConfiguration.Builder(APP_ID).build()
         val expectedDefaultRoot = appFilesDirectory()
         assertEquals(expectedDefaultRoot, config.syncRootDirectory)
     }
 
     @Test
     fun syncRootDirectory() {
-        val builder: AppConfiguration.Builder = AppConfiguration.Builder("app-id")
+        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
         val expectedRoot = "${appFilesDirectory()}/myCustomDir"
         val config = builder
             .syncRootDirectory(expectedRoot)
@@ -136,7 +137,7 @@ class AppConfigurationTests {
 
     @Test
     fun syncRootDirectory_writeProtectedDir() {
-        val builder: AppConfiguration.Builder = AppConfiguration.Builder("app-id")
+        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
         val dir = "/"
         assertFailsWith<IllegalArgumentException> { builder.syncRootDirectory(dir) }
     }
@@ -166,7 +167,7 @@ class AppConfigurationTests {
 
 //    @Test // TODO we need an IO framework to test this properly, see https://github.com/realm/realm-kotlin/issues/699
 //    fun syncRootDirectory_dirIsAFile() {
-//        val builder: AppConfiguration.Builder = AppConfiguration.Builder("app-id")
+//        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
 //        val file = File(tempFolder.newFolder(), "dummyfile")
 //        assertTrue(file.createNewFile())
 //        assertFailsWith<IllegalArgumentException> { builder.syncRootDirectory(file) }
@@ -174,7 +175,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun appName() {
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .appName("app-name")
 //            .build()
 //        assertEquals("app-name", config.appName)
@@ -182,13 +183,13 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun appName_defaultValue() {
-//        val config = AppConfiguration.Builder("app-id").build()
+//        val config = AppConfiguration.Builder(APP_ID).build()
 //        assertEquals(null, config.appName)
 //    }
 //
 //    @Test
 //    fun appName_invalidValuesThrows() {
-//        val builder = AppConfiguration.Builder("app-id")
+//        val builder = AppConfiguration.Builder(APP_ID)
 //
 //        assertFailsWith<java.lang.IllegalArgumentException> { builder.appName(TestHelper.getNull()) }
 //        assertFailsWith<java.lang.IllegalArgumentException> { builder.appName("") }
@@ -196,7 +197,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun appVersion() {
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .appVersion("app-version")
 //            .build()
 //        assertEquals("app-version", config.appVersion)
@@ -204,13 +205,13 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun appVersion_defaultValue() {
-//        val config = AppConfiguration.Builder("app-id").build()
+//        val config = AppConfiguration.Builder(APP_ID).build()
 //        assertEquals(null, config.appVersion)
 //    }
 //
 //    @Test
 //    fun appVersion_invalidValuesThrows() {
-//        val builder = AppConfiguration.Builder("app-id")
+//        val builder = AppConfiguration.Builder(APP_ID)
 //
 //        assertFailsWith<java.lang.IllegalArgumentException> { builder.appVersion(TestHelper.getNull()) }
 //        assertFailsWith<java.lang.IllegalArgumentException> { builder.appVersion("") }
@@ -242,7 +243,7 @@ class AppConfigurationTests {
 //    fun defaultSyncErrorHandler() {
 //        val errorHandler = SyncSession.ErrorHandler { _, _ -> }
 //
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .defaultSyncErrorHandler(errorHandler)
 //            .build()
 //        assertEquals(config.defaultErrorHandler, errorHandler)
@@ -251,7 +252,7 @@ class AppConfigurationTests {
 //    @Test
 //    fun defaultSyncErrorHandler_invalidValuesThrows() {
 //        assertFailsWith<IllegalArgumentException> {
-//            AppConfiguration.Builder("app-id")
+//            AppConfiguration.Builder(APP_ID)
 //                .defaultSyncErrorHandler(TestHelper.getNull())
 //        }
 //
@@ -261,7 +262,7 @@ class AppConfigurationTests {
 //    fun defaultClientResetHandler() {
 //        val handler = SyncSession.ClientResetHandler { _, _ -> }
 //
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .defaultClientResetHandler(handler)
 //            .build()
 //        assertEquals(config.defaultClientResetHandler, handler)
@@ -269,7 +270,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun defaultClientResetHandler_invalidValuesThrows() {
-//        val builder = AppConfiguration.Builder("app-id")
+//        val builder = AppConfiguration.Builder(APP_ID)
 //        assertFailsWith<IllegalArgumentException> {
 //            builder.defaultClientResetHandler(TestHelper.getNull())
 //        }
@@ -279,7 +280,7 @@ class AppConfigurationTests {
 //    fun encryptionKey() {
 //        val key = TestHelper.getRandomKey()
 //
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .encryptionKey(key)
 //            .build()
 //
@@ -288,7 +289,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun encryptionKey_invalidValuesThrows() {
-//        val builder = AppConfiguration.Builder("app-id")
+//        val builder = AppConfiguration.Builder(APP_ID)
 //
 //        assertFailsWith<IllegalArgumentException> {
 //            builder.encryptionKey(TestHelper.getNull())
@@ -301,7 +302,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun requestTimeout() {
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .requestTimeout(1, TimeUnit.SECONDS)
 //            .build()
 //        assertEquals(1000L, config.requestTimeoutMs)
@@ -309,7 +310,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun requestTimeout_invalidValuesThrows() {
-//        val builder = AppConfiguration.Builder("app-id")
+//        val builder = AppConfiguration.Builder(APP_ID)
 //
 //        assertFailsWith<IllegalArgumentException> { builder.requestTimeout(-1, TimeUnit.MILLISECONDS) }
 //        assertFailsWith<IllegalArgumentException> { builder.requestTimeout(1, TestHelper.getNull()) }
@@ -317,7 +318,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun codecRegistry_null() {
-//        val builder: AppConfiguration.Builder = AppConfiguration.Builder("app-id")
+//        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
 //        assertFailsWith<IllegalArgumentException> {
 //            builder.codecRegistry(TestHelper.getNull())
 //        }
@@ -325,14 +326,14 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun defaultFunctionsCodecRegistry() {
-//        val config: AppConfiguration = AppConfiguration.Builder("app-id").build()
+//        val config: AppConfiguration = AppConfiguration.Builder(APP_ID).build()
 //        assertEquals(AppConfiguration.DEFAULT_BSON_CODEC_REGISTRY, config.defaultCodecRegistry)
 //    }
 //
 //    @Test
 //    fun customCodecRegistry() {
 //        val configCodecRegistry = CodecRegistries.fromCodecs(StringCodec())
-//        val config: AppConfiguration = AppConfiguration.Builder("app-id")
+//        val config: AppConfiguration = AppConfiguration.Builder(APP_ID)
 //            .codecRegistry(configCodecRegistry)
 //            .build()
 //        assertEquals(configCodecRegistry, config.defaultCodecRegistry)
@@ -340,7 +341,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun httpLogObfuscator_null() {
-//        val config = AppConfiguration.Builder("app-id")
+//        val config = AppConfiguration.Builder(APP_ID)
 //            .httpLogObfuscator(TestHelper.getNull())
 //            .build()
 //        assertNull(config.httpLogObfuscator)
@@ -348,7 +349,7 @@ class AppConfigurationTests {
 //
 //    @Test
 //    fun defaultLoginInfoObfuscator() {
-//        val config = AppConfiguration.Builder("app-id").build()
+//        val config = AppConfiguration.Builder(APP_ID).build()
 //
 //        val defaultHttpLogObfuscator = HttpLogObfuscator(LOGIN_FEATURE, AppConfiguration.loginObfuscators)
 //        assertEquals(defaultHttpLogObfuscator, config.httpLogObfuscator)
@@ -399,7 +400,7 @@ class AppConfigurationTests {
     @Test
     fun encryptionKey() {
         val key = TestHelper.getRandomKey()
-        val config = AppConfiguration.Builder("app-id")
+        val config = AppConfiguration.Builder(APP_ID)
             .encryptionKey(key)
             .build()
 
@@ -409,7 +410,7 @@ class AppConfigurationTests {
     @Test
     fun encryptionKey_isCopy() {
         val key = TestHelper.getRandomKey()
-        val config = AppConfiguration.Builder("app-id")
+        val config = AppConfiguration.Builder(APP_ID)
             .encryptionKey(key)
             .build()
 
@@ -418,7 +419,7 @@ class AppConfigurationTests {
 
     @Test
     fun encryptionKey_wrongLength() {
-        val builder = AppConfiguration.Builder("app-id")
+        val builder = AppConfiguration.Builder(APP_ID)
 
         val tooShortKey = ByteArray(1)
         assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooShortKey) }

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
@@ -276,29 +276,38 @@ class AppConfigurationTests {
 //        }
 //    }
 //
-//    @Test
-//    fun encryptionKey() {
-//        val key = TestHelper.getRandomKey()
-//
-//        val config = AppConfiguration.Builder(APP_ID)
-//            .encryptionKey(key)
-//            .build()
-//
-//        assertArrayEquals(key, config.encryptionKey)
-//    }
-//
-//    @Test
-//    fun encryptionKey_invalidValuesThrows() {
-//        val builder = AppConfiguration.Builder(APP_ID)
-//
-//        assertFailsWith<IllegalArgumentException> {
-//            builder.encryptionKey(TestHelper.getNull())
-//        }
-//
-//        assertFailsWith<IllegalArgumentException> {
-//            builder.encryptionKey(byteArrayOf(0, 0, 0, 0))
-//        }
-//    }
+
+    @Test
+    fun encryptionKey() {
+        val key = TestHelper.getRandomKey()
+        val config = AppConfiguration.Builder(APP_ID)
+            .encryptionKey(key)
+            .build()
+
+        assertContentEquals(key, config.encryptionKey)
+    }
+
+    @Test
+    fun encryptionKey_isCopy() {
+        val key = TestHelper.getRandomKey()
+        val config = AppConfiguration.Builder(APP_ID)
+            .encryptionKey(key)
+            .build()
+
+        assertNotSame(key, config.encryptionKey)
+    }
+
+    @Test
+    fun encryptionKey_illegalValueThrows() {
+        val builder = AppConfiguration.Builder(APP_ID)
+
+        val tooShortKey = ByteArray(1)
+        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooShortKey) }
+
+        val tooLongKey = ByteArray(65)
+        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooLongKey) }
+    }
+
 //
 //    @Test
 //    fun requestTimeout() {
@@ -396,37 +405,6 @@ class AppConfigurationTests {
 //        assertTrue(headerSet.get())
 //        looperThread.testComplete()
 //    }
-
-    @Test
-    fun encryptionKey() {
-        val key = TestHelper.getRandomKey()
-        val config = AppConfiguration.Builder(APP_ID)
-            .encryptionKey(key)
-            .build()
-
-        assertContentEquals(key, config.encryptionKey)
-    }
-
-    @Test
-    fun encryptionKey_isCopy() {
-        val key = TestHelper.getRandomKey()
-        val config = AppConfiguration.Builder(APP_ID)
-            .encryptionKey(key)
-            .build()
-
-        assertNotSame(key, config.encryptionKey)
-    }
-
-    @Test
-    fun encryptionKey_illegalValueThrows() {
-        val builder = AppConfiguration.Builder(APP_ID)
-
-        val tooShortKey = ByteArray(1)
-        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooShortKey) }
-
-        val tooLongKey = ByteArray(65)
-        assertFailsWith<IllegalArgumentException> { builder.encryptionKey(tooLongKey) }
-    }
 
     fun equals_same() {
         val appId = "foo"

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
@@ -312,7 +312,8 @@ class AppTests {
                 it
                     .encryptionKey(TestHelper.getRandomKey())
                     .syncRootDirectory("${appFilesDirectory()}/foo")
-            })
+            }
+        )
 
         try {
             // Create Realm in order to create the sync metadata Realm

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
@@ -302,42 +302,6 @@ class AppTests {
 //        assertEquals(registry, app.getFunctions(user, registry).defaultCodecRegistry)
 //    }
 //
-//    @Test
-//    fun encryption() {
-//        val context = InstrumentationRegistry.getInstrumentation().targetContext
-//
-//        // Create new test app with a random encryption key
-//        val testApp = TestApp(appName = TEST_APP_2, builder = {
-//            it.encryptionKey(TestHelper.getRandomKey())
-//        })
-//
-//        try {
-//            // Create Realm in order to create the sync metadata Realm
-//            var user = testApp.login(Credentials.anonymous())
-//
-//            val syncConfig = SyncConfiguration
-//                .Builder(user, "foo")
-//                .testSchema(SyncStringOnly::class.java)
-//                .build()
-//
-//            Realm.getInstance(syncConfig).close()
-//
-//            // Create a configuration pointing to the metadata Realm for that app
-//            val metadataDir = File(context.filesDir, "mongodb-realm/${testApp.configuration.appId}/server-utility/metadata/")
-//            val config = RealmConfiguration.Builder()
-//                .name("sync_metadata.realm")
-//                .directory(metadataDir)
-//                .build()
-//            assertTrue(File(config.path).exists())
-//
-//            // Open the metadata realm file without a valid encryption key
-//            assertFailsWith<RealmFileException> {
-//                DynamicRealm.getInstance(config)
-//            }
-//        } finally {
-//            testApp.close()
-//        }
-//    }
 
     @Test
     fun encryption() {

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
@@ -21,6 +21,7 @@ import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.entities.sync.ChildPk
 import io.realm.kotlin.entities.sync.ParentPk
 import io.realm.kotlin.internal.platform.appFilesDirectory
+import io.realm.kotlin.internal.platform.fileExists
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.AppConfiguration
 import io.realm.kotlin.mongodb.AuthenticationProvider
@@ -35,7 +36,6 @@ import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.TestHelper.randomEmail
 import kotlinx.coroutines.runBlocking
-import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -329,7 +329,7 @@ class AppTests {
                 .name(SYNC_METADATA_REALM_NAME)
                 .directory(getMetadataDirectory(app))
                 .build()
-            assertTrue(File(config.path).exists())
+            assertTrue(fileExists(config.path))
 
             // Open the metadata realm file without a valid encryption key
             assertFailsWith<IllegalArgumentException> { Realm.open(config) }

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppTests.kt
@@ -29,6 +29,7 @@ import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.exceptions.InvalidCredentialsException
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
+import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
@@ -324,13 +325,14 @@ class AppTests {
             Realm.open(syncConfig).close()
 
             // Create a configuration pointing to the metadata Realm for that app
+            val lastSetSchemaVersion = 6L
             val metadataDir = "${app.configuration.syncRootDirectory}/mongodb-realm/${app.configuration.appId}/server-utility/metadata/"
             val config = RealmConfiguration
                 .Builder(setOf())
                 .name("sync_metadata.realm")
                 .directory(metadataDir)
+                .schemaVersion(lastSetSchemaVersion)
                 .encryptionKey(key)
-                .deleteRealmIfMigrationNeeded()
                 .build()
             assertTrue(fileExists(config.path))
 
@@ -375,7 +377,9 @@ class AppTests {
 
             // Open the metadata realm file with an invalid encryption key
             assertNotEquals(correctKey, wrongKey)
-            assertFailsWith<IllegalArgumentException> { Realm.open(config) }
+            assertFailsWithMessage<IllegalArgumentException>("Could not open Realm with the given configuration") {
+                Realm.open(config)
+            }
         } finally {
             app.close()
         }
@@ -411,7 +415,9 @@ class AppTests {
             assertTrue(fileExists(config.path))
 
             // Open the metadata realm file without a valid encryption key
-            assertFailsWith<IllegalArgumentException> { Realm.open(config) }
+            assertFailsWithMessage<IllegalArgumentException>("Could not open Realm with the given configuration") {
+                Realm.open(config)
+            }
         } finally {
             app.close()
         }


### PR DESCRIPTION
## Description

Closes #413.

Users can encrypt user metadata via `AppConfiguration.Builder.encryptionKey()` and access their encryption key via `AppConfiguration.encryptionKey`.

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)