### PR TITLE
Increase test timeout

### DIFF
--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
@@ -695,7 +695,7 @@ class SyncedRealmTests {
         // Increment counter asynchronously after download initial data (1)
         val increment1 = async {
             Realm.open(config1).use { realm ->
-                realm.syncSession.downloadAllServerChanges(1.seconds)
+                realm.syncSession.downloadAllServerChanges(30.seconds)
                 realm.write {
                     realm.query<SyncObjectWithAllTypes>()
                         .first()
@@ -711,7 +711,7 @@ class SyncedRealmTests {
         // Increment counter asynchronously after download initial data (2)
         val increment2 = async {
             Realm.open(config2).use { realm ->
-                realm.syncSession.downloadAllServerChanges(1.seconds)
+                realm.syncSession.downloadAllServerChanges(30.seconds)
                 realm.write {
                     realm.query<SyncObjectWithAllTypes>()
                         .first()


### PR DESCRIPTION
The MutableRealmInt test was failing sporadically on CI due to the download sometimes not completing in time. Increasing the timeout should fix this.