### PR TITLE
Add missing proguard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 * Close underlying realm if it is no longer referenced by any Kotlin object. (Issue [#671](https://github.com/realm/realm-kotlin/issues/671))
 * Fixes crash during migration if Proguard was enabled. (Issue [#1106](https://github.com/realm/realm-kotlin/issues/1106))
+* Adds missing Proguard rules for Embedded objects. (Issue [#1106](https://github.com/realm/realm-kotlin/issues/1107))
 
 ### Compatibility
 * This release is compatible with the following Kotlin releases:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 * Close underlying realm if it is no longer referenced by any Kotlin object. (Issue [#671](https://github.com/realm/realm-kotlin/issues/671))
+* Fixes crash during migration if Proguard was enabled. (Issue [#1106](https://github.com/realm/realm-kotlin/issues/1106))
 
 ### Compatibility
 * This release is compatible with the following Kotlin releases:

--- a/packages/library-base/proguard-rules-consumer-common.pro
+++ b/packages/library-base/proguard-rules-consumer-common.pro
@@ -1,7 +1,10 @@
 # Keep all classes implemeting the RealmObject interface
 -keep class io.realm.kotlin.types.RealmObject
 -keep class * implements io.realm.kotlin.types.RealmObject { *; }
-#-keep class **.$* implements io.realm.kotlin.RealmObject { *; }
+
+# Keep all classes implemeting the EmbeddedRealmObject interface
+-keep class io.realm.kotlin.types.EmbeddedRealmObject
+-keep class * implements io.realm.kotlin.types.EmbeddedRealmObject { *; }
 
 # Preserve all native method names and the names of their classes.
 -keepclasseswithmembernames,includedescriptorclasses class * {

--- a/packages/library-base/proguard-rules-consumer-common.pro
+++ b/packages/library-base/proguard-rules-consumer-common.pro
@@ -90,6 +90,9 @@
 -keep class io.realm.kotlin.internal.interop.AsyncOpenCallback {
     *;
 }
+-keep class io.realm.kotlin.internal.interop.NativePointer {
+    *;
+}
 
 # Preserve Function<X> methods as they back various functional interfaces called from JNI
 -keep class kotlin.jvm.functions.Function* {


### PR DESCRIPTION
Adds an entry for `NativePointer` into proguard. This a crash when performing a migration.