### PR TITLE
Add support for loading native library code from a custom location on JVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * None.
 
 ### Enhancements
-* Add support for in-memory Realms.
+* Realm will now use `System.loadLibrary()` first when loading native code on JVM, adding support for 3rd party JVM installers. If this fails, it will fallback to the current method of loading the native library from the JAR file. (Issue [#1105](https://github.com/realm/realm-kotlin/issues/1105)). 
+* Added support for in-memory Realms.
 * [Sync] Added support for API key authentication. (Issue [#432](https://github.com/realm/realm-kotlin/issues/432))
 * Added support for reverse relationships through the `linkingObjects` delegate. See the function documentation for more details. (Issue [#1021](https://github.com/realm/realm-kotlin/pull/1021))
 * Added support for `BsonObjectId` and its typealias `org.mongodb.kbson.ObjectId` as a replacement for `ObjectId`. `io.realm.kotlin.types.ObjectId` is still functional but has been marked as deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* Realm will now use `System.loadLibrary()` first when loading native code on JVM, adding support for 3rd party JVM installers. If this fails, it will fallback to the current method of loading the native library from the JAR file. (Issue [#1105](https://github.com/realm/realm-kotlin/issues/1105)). 
+* Realm will now use `System.loadLibrary()` first when loading native code on JVM, adding support for 3rd party JVM installers. If this fails, it will fallback to the current method of extracting and loading the native library from the JAR file. (Issue [#1105](https://github.com/realm/realm-kotlin/issues/1105)). 
 * Added support for in-memory Realms.
 * [Sync] Added support for API key authentication. (Issue [#432](https://github.com/realm/realm-kotlin/issues/432))
 * Added support for reverse relationships through the `linkingObjects` delegate. See the function documentation for more details. (Issue [#1021](https://github.com/realm/realm-kotlin/pull/1021))

--- a/packages/cinterop/src/jvmMain/kotlin/io/realm/kotlin/jvm/SoLoader.kt
+++ b/packages/cinterop/src/jvmMain/kotlin/io/realm/kotlin/jvm/SoLoader.kt
@@ -41,10 +41,24 @@ class SoLoader {
         readLibrariesHashes()
     }
 
+    @Suppress("unused") // Called using reflection. See /packages/jni-swig-stub/realm.i
     fun load() {
-        // load the libraries in the order of dependency specified in 'dynamic_libraries.properties'
-        for (lib in libs) {
-            load(libraryName = lib.first, expectedHash = lib.second)
+        // First attempt to load the native library code using `System.loadLibrary()`. This is the
+        // default way of shipping dependencies to JVM Desktop apps, but it does require that the
+        // author of these apps have extracted the library from our JAR file and manually placed it
+        // in the location defined by "java.libraries.path".
+        //
+        // If this fails, we will fallback to finding the native code inside the JAR file and
+        // store it in the users cache directory.
+        //
+        // See https://github.com/realm/realm-kotlin/issues/1105 for more information.
+        try {
+            System.loadLibrary("realmc")
+        } catch (ex: UnsatisfiedLinkError) {
+            // Load the libraries in the order of dependency specified in 'dynamic_libraries.properties'
+            for (lib in libs) {
+                load(libraryName = lib.first, expectedHash = lib.second)
+            }
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/1105

This PR adds support for bundling Realm inside apps distributed using 3rd party JVM installers like [Hydraulic Conveyor](https://conveyor.hydraulic.dev/4.0/).

It does this by changing how we load the native library. After this change we first attempt to load the library using `System.loadLibrary(name)` which will search all paths defined by `java.libraries.path`. If this fails we will fall back to finding the native library inside the JAR file as before this change.

We make no attempt at detecting if the correct native code is linked as users might have modified the binary, so any checks we employ could fail. But that also means that it is up to developers to make sure that the correct native file is loaded. I will create a ticket in Docs to make sure this is documented.

This change was tested manually on Mac. 

According to https://stackoverflow.com/questions/37203247/while-loading-jni-library-how-the-mapping-happens-with-the-actual-library-name our current naming strategy should be good enough for people to just copy/paste the file from our JAR. If not, they would be responsible for naming it to something that `System.loadLibrary` would find using `System.mapLibraryName(name)`.



