### PR TITLE
Update to upcoming Core 12.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,3 @@
-## 1.6.0 (YYYY-MM-DD)
-
-### Breaking Changes
-* None.
-
-### Enhancements
-* None.
-
-### Fixed
-* None.
-
-### Compatibility
-* This release is compatible with the following Kotlin releases:
-  * Kotlin 1.7.20 and above.
-  * Ktor 2.1.2 and above.
-  * Coroutines 1.6.4 and above. 
-  * AtomicFu 0.18.3 and above.
-  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
-* Minimum Gradle version: 6.7.1.
-* Minimum Android Gradle Plugin version: 4.0.0.
-* Minimum Android SDK: 16.
-
-### Internal
-* None.
-
-
 ## 1.5.1 (YYYY-MM-DD)
 
 ### Breaking Changes
@@ -49,7 +23,7 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* Updated to Realm Core 12.12.0, commit 2436633ce50f9769d4efd878cb04ca90ec9af965.
+* Updated to Realm Core 12.12.0, commit 292f534a8ae687a86d799b14e06a94985e49c3c6.
 
 
 ## 1.5.0 (2022-11-11)


### PR DESCRIPTION
Adds query validation back + capabilities for shutting down sync client thread on JVM