### PR TITLE
Improve error message when forgetting plugin.

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
@@ -16,6 +16,7 @@
 
 package io.realm.kotlin
 
+import io.realm.kotlin.internal.MISSING_PLUGIN_MESSAGE
 import io.realm.kotlin.internal.REALM_FILE_EXTENSION
 import io.realm.kotlin.internal.RealmInteropBridge
 import io.realm.kotlin.internal.platform.PATH_SEPARATOR
@@ -192,7 +193,7 @@ public interface Configuration {
                     throw IllegalArgumentException(
                         "Only subclasses of RealmObject and " +
                             "EmbeddedRealmObject are allowed in the schema. Found: ${clazz.qualifiedName}. " +
-                            "For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins (see https://www.mongodb.com/docs/realm/sdk/kotlin/install/kotlin-multiplatform/#installation)."
+                            "If ${clazz.qualifiedName} is a valid subclass: $MISSING_PLUGIN_MESSAGE"
                     )
                 }
             }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
@@ -191,7 +191,8 @@ public interface Configuration {
                 if (clazz.realmObjectCompanionOrNull() == null) {
                     throw IllegalArgumentException(
                         "Only subclasses of RealmObject and " +
-                            "EmbeddedRealmObject are allowed in the schema. Found: ${clazz.qualifiedName}"
+                            "EmbeddedRealmObject are allowed in the schema. Found: ${clazz.qualifiedName}. " +
+                            "For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins (see https://www.mongodb.com/docs/realm/sdk/kotlin/install/kotlin-multiplatform/#installation)."
                     )
                 }
             }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmUtils.kt
@@ -49,14 +49,19 @@ internal typealias RealmObjectIdentifier = Triple<ClassKey, ObjectKey, VersionId
 internal typealias ManagedToUnmanagedObjectCache = MutableMap<RealmObjectIdentifier, BaseRealmObject>
 
 /**
+ * Message that can be used when throwing if there is a situation where we except certain interfaces
+ * to be present, because they should have been added by the compiler plugin. But they where not.
+ * If this message does not need to be altered or concatenated, throw [MISSING_PLUGIN] instead.
+ */
+public const val MISSING_PLUGIN_MESSAGE: String = "This class has not been modified " +
+    "by the Realm Compiler Plugin. Has the Realm Gradle Plugin been applied to the project " +
+    "with this model class?"
+
+/**
  * Exception that can be thrown if there is a situation where we except certain interfaces to be
  * present, because they should have been added by the compiler plugin. But they where not.
  */
-public val MISSING_PLUGIN: Throwable = IllegalStateException(
-    "This class has not been modified " +
-        "by the Realm Compiler Plugin. Has the Realm Gradle Plugin been applied to the project " +
-        "with this model class?"
-)
+public val MISSING_PLUGIN: Throwable = IllegalStateException(MISSING_PLUGIN_MESSAGE)
 
 /**
  * Add a check and error message for code that never be reached because it should have been

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
@@ -638,10 +638,10 @@ class SyncConfigTests {
     fun unsupportedSchemaTypesThrowException_partitionBasedSync() {
         val user = createTestUser()
         val unsupportedSchemaType = setOf(DynamicRealmObject::class)
-        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins") {
+        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. If io.realm.kotlin.dynamic.DynamicRealmObject is a valid subclass: This class has not been modified by the Realm Compiler Plugin. Has the Realm Gradle Plugin been applied to the project with this model class?") {
             SyncConfiguration.create(user, "", unsupportedSchemaType)
         }
-        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins") {
+        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. If io.realm.kotlin.dynamic.DynamicRealmObject is a valid subclass: This class has not been modified by the Realm Compiler Plugin. Has the Realm Gradle Plugin been applied to the project with this model class?") {
             SyncConfiguration.Builder(user, "", unsupportedSchemaType)
         }
     }
@@ -650,10 +650,10 @@ class SyncConfigTests {
     fun unsupportedSchemaTypesThrowException_flexibleSync() {
         val user = createTestUser()
         val unsupportedSchemaType = setOf(DynamicRealmObject::class)
-        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins") {
+        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. If io.realm.kotlin.dynamic.DynamicRealmObject is a valid subclass: This class has not been modified by the Realm Compiler Plugin. Has the Realm Gradle Plugin been applied to the project with this model class?") {
             SyncConfiguration.create(user, unsupportedSchemaType)
         }
-        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins") {
+        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. If io.realm.kotlin.dynamic.DynamicRealmObject is a valid subclass: This class has not been modified by the Realm Compiler Plugin. Has the Realm Gradle Plugin been applied to the project with this model class?") {
             SyncConfiguration.Builder(user, unsupportedSchemaType)
         }
     }

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncConfigTests.kt
@@ -638,10 +638,10 @@ class SyncConfigTests {
     fun unsupportedSchemaTypesThrowException_partitionBasedSync() {
         val user = createTestUser()
         val unsupportedSchemaType = setOf(DynamicRealmObject::class)
-        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject") {
+        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins") {
             SyncConfiguration.create(user, "", unsupportedSchemaType)
         }
-        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject") {
+        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins") {
             SyncConfiguration.Builder(user, "", unsupportedSchemaType)
         }
     }
@@ -650,10 +650,10 @@ class SyncConfigTests {
     fun unsupportedSchemaTypesThrowException_flexibleSync() {
         val user = createTestUser()
         val unsupportedSchemaType = setOf(DynamicRealmObject::class)
-        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject") {
+        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins") {
             SyncConfiguration.create(user, unsupportedSchemaType)
         }
-        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject") {
+        assertFailsWithMessage(IllegalArgumentException::class, "Only subclasses of RealmObject and EmbeddedRealmObject are allowed in the schema. Found: io.realm.kotlin.dynamic.DynamicRealmObject. For Kotlin Multiplatform, make sure to add 'io.realm.kotlin' to your list of plugins") {
             SyncConfiguration.Builder(user, unsupportedSchemaType)
         }
     }


### PR DESCRIPTION
## Description

Closes #1060.

If KMM users forget to add the Kotlin plugin, the error message is now more appropriate.

##  TODO

* [ ] <s>Changelog entry</s>
* [x] Tests (if applicable)