### PR TITLE
Ensure realm has been initialized before checking isClosed.

### DIFF
--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/BsonObjectIdTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/BsonObjectIdTests.kt
@@ -52,7 +52,7 @@ class BsonObjectIdTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/ByteArrayTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/ByteArrayTests.kt
@@ -49,7 +49,7 @@ class ByteArrayTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CopyFromRealmTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CopyFromRealmTests.kt
@@ -82,7 +82,7 @@ class CopyFromRealmTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/ObjectIdTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/ObjectIdTests.kt
@@ -53,7 +53,7 @@ class ObjectIdTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/QueryTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/QueryTests.kt
@@ -85,7 +85,7 @@ class QueryTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInMemoryTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInMemoryTests.kt
@@ -42,7 +42,7 @@ class RealmInMemoryTests {
     @AfterTest
     fun tearDown() {
         PlatformUtils.deleteTempDir(tmpDir)
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
     }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInstantTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInstantTests.kt
@@ -32,7 +32,7 @@ class RealmInstantTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmSchemaTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmSchemaTests.kt
@@ -69,7 +69,7 @@ public class RealmSchemaTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/nonlatin/NonLatinTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/nonlatin/NonLatinTests.kt
@@ -45,7 +45,7 @@ class NonLatinTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SubscriptionSetTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SubscriptionSetTests.kt
@@ -71,7 +71,7 @@ class SubscriptionSetTests {
 
     @AfterTest
     fun tearDown() {
-        if (!realm.isClosed()) {
+        if (this::realm.isInitialized && !realm.isClosed()) {
             realm.close()
         }
         if (this::app.isInitialized) {


### PR DESCRIPTION
For realms declared using `lateinit var realm: Realm`, this PR replaces:

```kt
@AfterTest
fun tearDown() {
    if (!realm.isClosed()) {
        realm.close()
    }
    PlatformUtils.deleteTempDir(tmpDir)
}
```

with:

```kt
@AfterTest
fun tearDown() {
    if (this::realm.isInitialized && !realm.isClosed()) {
        realm.close()
    }
    PlatformUtils.deleteTempDir(tmpDir)
}
```