### PR TITLE
Remove swig jlong typemap workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* None.
+* Updated to require Swig 4.1.0.
 
 
 ## 1.5.1 (YYYY-MM-DD)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We welcomes all contributions! The only requirement we have is that, like many o
 
 ### Prerequisites
 
-- Swig. On Mac this can be installed using Homebrew: `brew install swig`.
+- Swig 4.1.0 or above. On Mac this can be installed using Homebrew: `brew install swig`.
 - Ccache. On Mac this can be installed using Homebrew: `brew install ccache`.
 - CMake 3.18.1 or above. Can be installed through the Android SDK Manager.
 - Java 11.

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -361,30 +361,39 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 // Enable passing output argument pointers as long[]
 %apply int64_t[] {void **};
 // Type map for int64_t has an erroneous cast, don't know how to fix it except with this
-//%typemap(in) void** ( jlong *jarr ){
-//    // Original
-//    %#if defined(__ANDROID__) && defined(__aarch64__) // Android arm64-v8a
-//        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long **)&$1, $input)) return $null;
-//    %#elif defined(__ANDROID__) // Android armeabi-v7a, x86_64 and x86
-//        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
-//    %#elif defined(__aarch64__) // macos M1
-//        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
-//    %#else
-//        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long long **)&$1, $input)) return $null;
-//    %#endif
-//}
-//%typemap(argout) void** {
-//    // Original
-//    %#if defined(__ANDROID__) && defined(__aarch64__)
-//        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long*)$1, $input);
-//    %#elif defined(__ANDROID__)
-//        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong*)$1, $input);
-//    %#elif defined(__aarch64__)
-//        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong *)$1, $input);
-//    %#else
-//        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long long *)$1, $input);
-//    %#endif
-//}
+%typemap(in) void** ( jlong *jarr ){
+#if SWIG_VERSION>=0x040100
+    // Original
+    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long long **)&$1, $input)) return $null;
+#else
+    %#if defined(__ANDROID__) && defined(__aarch64__) // Android arm64-v8a
+    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long **)&$1, $input)) return $null;
+    %#elif defined(__ANDROID__) // Android armeabi-v7a, x86_64 and x86
+    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
+    %#elif defined(__aarch64__) // macos M1
+    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
+    %#else
+    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long long **)&$1, $input)) return $null;
+    %#endif
+#endif
+}
+%typemap(argout) void** {
+#if SWIG_VERSION>=0x040100
+    // Original
+    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long long *)$1, $input);
+#else
+    %#if defined(__ANDROID__) && defined(__aarch64__)
+    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long*)$1, $input);
+    %#elif defined(__ANDROID__)
+    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong*)$1, $input);
+    %#elif defined(__aarch64__)
+    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong *)$1, $input);
+    %#else
+    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long long *)$1, $input);
+    %#endif
+#endif
+}
+
 %apply void** {realm_object_t**, realm_list_t**, size_t*, realm_class_key_t*,
                realm_property_key_t*, realm_user_t**, realm_set_t**};
 

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -360,40 +360,6 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 
 // Enable passing output argument pointers as long[]
 %apply int64_t[] {void **};
-// Type map for int64_t has an erroneous cast, don't know how to fix it except with this
-%typemap(in) void** ( jlong *jarr ){
-#if SWIG_VERSION>=0x040100
-    // Original
-    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long long **)&$1, $input)) return $null;
-#else
-    %#if defined(__ANDROID__) && defined(__aarch64__) // Android arm64-v8a
-    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long **)&$1, $input)) return $null;
-    %#elif defined(__ANDROID__) // Android armeabi-v7a, x86_64 and x86
-    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
-    %#elif defined(__aarch64__) // macos M1
-    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
-    %#else
-    if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long long **)&$1, $input)) return $null;
-    %#endif
-#endif
-}
-%typemap(argout) void** {
-#if SWIG_VERSION>=0x040100
-    // Original
-    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long long *)$1, $input);
-#else
-    %#if defined(__ANDROID__) && defined(__aarch64__)
-    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long*)$1, $input);
-    %#elif defined(__ANDROID__)
-    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong*)$1, $input);
-    %#elif defined(__aarch64__)
-    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong *)$1, $input);
-    %#else
-    SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long long *)$1, $input);
-    %#endif
-#endif
-}
-
 %apply void** {realm_object_t**, realm_list_t**, size_t*, realm_class_key_t*,
                realm_property_key_t*, realm_user_t**, realm_set_t**};
 

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -361,30 +361,30 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 // Enable passing output argument pointers as long[]
 %apply int64_t[] {void **};
 // Type map for int64_t has an erroneous cast, don't know how to fix it except with this
-%typemap(in) void** ( jlong *jarr ){
-    // Original
-    %#if defined(__ANDROID__) && defined(__aarch64__) // Android arm64-v8a
-        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long **)&$1, $input)) return $null;
-    %#elif defined(__ANDROID__) // Android armeabi-v7a, x86_64 and x86
-        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
-    %#elif defined(__aarch64__) // macos M1
-        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
-    %#else
-        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long long **)&$1, $input)) return $null;
-    %#endif
-}
-%typemap(argout) void** {
-    // Original
-    %#if defined(__ANDROID__) && defined(__aarch64__)
-        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long*)$1, $input);
-    %#elif defined(__ANDROID__)
-        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong*)$1, $input);
-    %#elif defined(__aarch64__)
-        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong *)$1, $input);
-    %#else
-        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long long *)$1, $input);
-    %#endif
-}
+//%typemap(in) void** ( jlong *jarr ){
+//    // Original
+//    %#if defined(__ANDROID__) && defined(__aarch64__) // Android arm64-v8a
+//        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long **)&$1, $input)) return $null;
+//    %#elif defined(__ANDROID__) // Android armeabi-v7a, x86_64 and x86
+//        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
+//    %#elif defined(__aarch64__) // macos M1
+//        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
+//    %#else
+//        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long long **)&$1, $input)) return $null;
+//    %#endif
+//}
+//%typemap(argout) void** {
+//    // Original
+//    %#if defined(__ANDROID__) && defined(__aarch64__)
+//        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long*)$1, $input);
+//    %#elif defined(__ANDROID__)
+//        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong*)$1, $input);
+//    %#elif defined(__aarch64__)
+//        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong *)$1, $input);
+//    %#else
+//        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long long *)$1, $input);
+//    %#endif
+//}
 %apply void** {realm_object_t**, realm_list_t**, size_t*, realm_class_key_t*,
                realm_property_key_t*, realm_user_t**, realm_set_t**};
 


### PR DESCRIPTION
Typemap for jlong has been fixed in Swig 4.1.0 (https://github.com/swig/swig/pull/1934) so remove custom typemap. 

Closes #1144 