### PR TITLE
Add error message for unsupported class types and objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This release will bump the Realm file format from version 22 to 23. Opening a fi
 * Add support for `Realm.copyFromRealm()`. All RealmObjects, RealmResults, RealmList and RealmSets now also have a `copyFromRealm()` extension method.
 * [Sync] `App.close()` have been added so it is possible to close underlying ressources used by the app instance.
 * [Sync] Add support for progress listeners with `SyncSession.progress`. (Issue [#428](https://github.com/realm/realm-kotlin/issues/428))
+* Add better error messages when inheriting `RealmObject` with unsupported class types. (Issue [#1086](https://github.com/realm/realm-kotlin/issues/1086))
 
 ### Fixed
 * Internal dispatcher threads would leak when closing Realms. (Issue [#818](https://github.com/realm/realm-kotlin/issues/818))

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -35,6 +35,7 @@ import org.jetbrains.kotlin.ir.util.companionObject
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.isAnonymousObject
 import org.jetbrains.kotlin.ir.util.isEnumClass
+import org.jetbrains.kotlin.ir.util.isObject
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.primaryConstructor
@@ -55,17 +56,18 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
 
     override fun lower(irClass: IrClass) {
         if (irClass.isBaseRealmObject) {
-            // We don't support data class
+            // Throw error with classes that we do not support
             if (irClass.isData) {
                 error("Data class '${irClass.kotlinFqName}' is not currently supported. Only normal classes can inherit from 'RealmObject' or 'EmbeddedRealmObject'.")
             }
-            // We don't support object
-            if (irClass.isAnonymousObject) {
-                error("Object '${irClass.parent.kotlinFqName}' is not supported. Only normal classes can inherit from 'RealmObject' or 'EmbeddedRealmObject'.")
-            }
-            // We don't support enum class
             if (irClass.isEnumClass) {
                 error("Enum class '${irClass.kotlinFqName}' is not supported. Only normal classes can inherit from 'RealmObject' or 'EmbeddedRealmObject'.")
+            }
+            if (irClass.isObject) {
+                error("Object declarations are not supported. Only normal classes can inherit from 'RealmObject' or 'EmbeddedRealmObject'.")
+            }
+            if (irClass.isAnonymousObject) {
+                error("Anonymous objects are not supported. Only normal classes can inherit from 'RealmObject' or 'EmbeddedRealmObject'.")
             }
             // For native we add @ModelObject(irClass.Companion::class) as associated object to be
             // able to resolve the companion object during runtime due to absence of

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -33,6 +33,8 @@ import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.starProjectedType
 import org.jetbrains.kotlin.ir.util.companionObject
 import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.util.isAnonymousObject
+import org.jetbrains.kotlin.ir.util.isEnumClass
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.primaryConstructor

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -57,9 +57,13 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
             if (irClass.isData) {
                 error("Data class '${irClass.kotlinFqName}' is not currently supported.")
             }
+            // We don't support object
+            if (irClass.isAnonymousObject) {
+                error("Object '${irClass.parent.kotlinFqName}' is not supported. Only normal classes can inherit from 'RealmObject' or 'EmbeddedRealmObject'.")
+            }
             // We don't support enum class
             if (irClass.isEnumClass) {
-                error("Enum class '${irClass.kotlinFqName}' is not currently supported.")
+                error("Enum class '${irClass.kotlinFqName}' is not supported. Only normal classes can inherit from 'RealmObject' or 'EmbeddedRealmObject'.")
             }
             // For native we add @ModelObject(irClass.Companion::class) as associated object to be
             // able to resolve the companion object during runtime due to absence of

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -57,6 +57,10 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
             if (irClass.isData) {
                 error("Data class '${irClass.kotlinFqName}' is not currently supported.")
             }
+            // We don't support enum class
+            if (irClass.isEnumClass) {
+                error("Enum class '${irClass.kotlinFqName}' is not currently supported.")
+            }
             // For native we add @ModelObject(irClass.Companion::class) as associated object to be
             // able to resolve the companion object during runtime due to absence of
             // kotlin.reflect.full.companionObjectInstance

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -55,7 +55,7 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
         if (irClass.isBaseRealmObject) {
             // We don't support data class
             if (irClass.isData) {
-                error("Data class '${irClass.kotlinFqName}' is not currently supported.")
+                error("Data class '${irClass.kotlinFqName}' is not currently supported. Only normal classes can inherit from 'RealmObject' or 'EmbeddedRealmObject'.")
             }
             // We don't support object
             if (irClass.isAnonymousObject) {

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -95,6 +95,22 @@ class ModelDefinitionTests {
             )
         )
         assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using enum class")
-        assertTrue(result.messages.contains("Enum class 'Foo' is not currently supported"))
+        assertTrue(result.messages.contains("Enum class 'Foo' is not supported."))
+    }
+
+    @Test
+    fun `object`() {
+        val result = Compiler.compileFromSource(
+            plugins = listOf(Registrar()),
+            source = SourceFile.kotlin(
+                "object_class.kt",
+                """
+                        import io.realm.kotlin.types.RealmObject
+                        val Foo = object: RealmObject {}
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using enum class")
+        assertTrue(result.messages.contains("Object 'Foo' is not supported."))
     }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -99,7 +99,7 @@ class ModelDefinitionTests {
     }
 
     @Test
-    fun `object`() {
+    fun `anonymous_object`() {
         val result = Compiler.compileFromSource(
             plugins = listOf(Registrar()),
             source = SourceFile.kotlin(
@@ -110,7 +110,7 @@ class ModelDefinitionTests {
                 """.trimIndent()
             )
         )
-        assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using enum class")
+        assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using objects")
         assertTrue(result.messages.contains("Object 'Foo' is not supported."))
     }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -81,4 +81,20 @@ class ModelDefinitionTests {
         assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using data class")
         assertTrue(result.messages.contains("Data class 'Foo' is not currently supported"))
     }
+
+    @Test
+    fun `enum_class_with_default_constructor`() {
+        val result = Compiler.compileFromSource(
+            plugins = listOf(Registrar()),
+            source = SourceFile.kotlin(
+                "enum_class.kt",
+                """
+                        import io.realm.kotlin.types.RealmObject
+                        enum class Foo : RealmObject { NORTH, SOUTH }
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using enum class")
+        assertTrue(result.messages.contains("Enum class 'Foo' is not currently supported"))
+    }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -99,18 +99,34 @@ class ModelDefinitionTests {
     }
 
     @Test
+    fun `object_declaration`() {
+        val result = Compiler.compileFromSource(
+            plugins = listOf(Registrar()),
+            source = SourceFile.kotlin(
+                "object_declaration.kt",
+                """
+                        import io.realm.kotlin.types.RealmObject
+                        object Foo : RealmObject
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using object declaration")
+        assertTrue(result.messages.contains("Object declarations are not supported."))
+    }
+
+    @Test
     fun `anonymous_object`() {
         val result = Compiler.compileFromSource(
             plugins = listOf(Registrar()),
             source = SourceFile.kotlin(
-                "object_class.kt",
+                "anonymous_object.kt",
                 """
                         import io.realm.kotlin.types.RealmObject
                         val Foo = object: RealmObject {}
                 """.trimIndent()
             )
         )
-        assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using objects")
-        assertTrue(result.messages.contains("Object 'Foo' is not supported."))
+        assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using anonymous objects")
+        assertTrue(result.messages.contains("Anonymous objects are not supported."))
     }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -83,7 +83,7 @@ class ModelDefinitionTests {
     }
 
     @Test
-    fun `enum_class_with_default_constructor`() {
+    fun `enum_class`() {
         val result = Compiler.compileFromSource(
             plugins = listOf(Registrar()),
             source = SourceFile.kotlin(


### PR DESCRIPTION
Similar to https://github.com/realm/realm-kotlin/pull/698 but for enum classes, object declarations, and anonymous objects.

Closes https://github.com/realm/realm-kotlin/issues/1086