### PR TITLE
Pretend to build Core as a submodule for MacOS

### DIFF
--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -451,6 +451,7 @@ fun Task.build_C_API_Macos_Universal(releaseBuild: Boolean = false) {
                 "-DREALM_NO_TESTS=1",
                 "-DREALM_BUILD_LIB_ONLY=true",
                 "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64",
+                "-DREALM_CORE_SUBMODULE_BUILD=true",
                 "-G",
                 "Xcode",
                 ".."
@@ -500,6 +501,7 @@ fun Task.build_C_API_Simulator(arch: String, releaseBuild: Boolean = false) {
                 "-DREALM_ENABLE_SYNC=1",
                 "-DREALM_NO_TESTS=ON",
                 "-DREALM_BUILD_LIB_ONLY=true",
+                "-DREALM_CORE_SUBMODULE_BUILD=true",
                 "-G",
                 "Xcode",
                 ".."
@@ -549,6 +551,7 @@ fun Task.build_C_API_iOS_Arm64(releaseBuild: Boolean = false) {
                 "-DREALM_ENABLE_SYNC=1",
                 "-DREALM_NO_TESTS=ON",
                 "-DREALM_BUILD_LIB_ONLY=true",
+                "-DREALM_CORE_SUBMODULE_BUILD=true",
                 "-G",
                 "Xcode",
                 ".."

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -360,31 +360,6 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 
 // Enable passing output argument pointers as long[]
 %apply int64_t[] {void **};
-// Type map for int64_t has an erroneous cast, don't know how to fix it except with this
-%typemap(in) void** ( jlong *jarr ){
-    // Original
-    %#if defined(__ANDROID__) && defined(__aarch64__) // Android arm64-v8a
-        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long **)&$1, $input)) return $null;
-    %#elif defined(__ANDROID__) // Android armeabi-v7a, x86_64 and x86
-        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
-    %#elif defined(__aarch64__) // macos M1
-        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (jlong **)&$1, $input)) return $null;
-    %#else
-        if (!SWIG_JavaArrayInLonglong(jenv, &jarr, (long long **)&$1, $input)) return $null;
-    %#endif
-}
-%typemap(argout) void** {
-    // Original
-    %#if defined(__ANDROID__) && defined(__aarch64__)
-        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long*)$1, $input);
-    %#elif defined(__ANDROID__)
-        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong*)$1, $input);
-    %#elif defined(__aarch64__)
-        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (jlong *)$1, $input);
-    %#else
-        SWIG_JavaArrayArgoutLonglong(jenv, jarr$argnum, (long long *)$1, $input);
-    %#endif
-}
 %apply void** {realm_object_t**, realm_list_t**, size_t*, realm_class_key_t*,
                realm_property_key_t*, realm_user_t**, realm_set_t**};
 


### PR DESCRIPTION
This prevents generating parser files which made it harder to switch Git Submodule versions. This fix was verified locally to work.