### PR TITLE
Remove forward as patch workaround

### DIFF
--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AppServicesClient.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/AppServicesClient.kt
@@ -36,7 +36,6 @@ import io.ktor.serialization.kotlinx.json.json
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initialize
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerialName
@@ -228,7 +227,10 @@ class AppServicesClient(
         httpClient.close()
     }
 
-    suspend fun getOrCreateApp(appName: String, initializer: suspend AppServicesClient.(app: BaasApp, service: Service) -> Unit): BaasApp =
+    suspend fun getOrCreateApp(
+        appName: String,
+        initializer: suspend AppServicesClient.(app: BaasApp, service: Service) -> Unit
+    ): BaasApp =
         getApp(appName) ?: createApp(appName) {
             initialize(this, initializer)
         }
@@ -256,22 +258,6 @@ class AppServicesClient(
 
     val BaasApp.url: String
         get() = "$groupUrl/apps/${this._id}"
-
-    suspend fun BaasApp.sendPatchRequest(url: String, requestBody: String) =
-        repeat(2) {
-            httpClient.request("$baseUrl/app/${this.clientAppId}/endpoint/forwardAsPatch") {
-                this.method = HttpMethod.Post
-                setBody(
-                    buildJsonObject {
-                        put("url", url)
-                        put("body", requestBody)
-                    }
-                )
-                contentType(ContentType.Application.Json)
-            }
-
-            delay(1000)
-        }
 
     suspend fun BaasApp.addFunction(function: Function): Function =
         withContext(dispatcher) {
@@ -342,10 +328,11 @@ class AppServicesClient(
 
     suspend fun BaasApp.setCustomUserData(userDataConfig: String) =
         withContext(dispatcher) {
-            sendPatchRequest(
-                url = "$url/custom_user_data",
-                requestBody = userDataConfig
-            )
+            httpClient.request("$url/custom_user_data") {
+                this.method = HttpMethod.Patch
+                setBody(Json.parseToJsonElement(userDataConfig))
+                contentType(ContentType.Application.Json)
+            }
         }
 
     suspend fun BaasApp.addEndpoint(endpoint: String) =
@@ -381,10 +368,11 @@ class AppServicesClient(
     suspend fun AuthProvider.updateConfig(block: MutableMap<String, JsonElement>.() -> Unit) {
         mutableMapOf<String, JsonElement>().apply {
             block()
-            app!!.sendPatchRequest(
-                url,
-                JsonObject(mapOf("config" to JsonObject(this))).toString()
-            )
+            httpClient.request(url) {
+                this.method = HttpMethod.Patch
+                setBody(JsonObject(mapOf("config" to JsonObject(this@apply))))
+                contentType(ContentType.Application.Json)
+            }
         }
     }
 
@@ -393,10 +381,11 @@ class AppServicesClient(
 
     suspend fun Service.setSyncConfig(config: String) =
         withContext(dispatcher) {
-            app!!.sendPatchRequest(
-                url = "$url/config",
-                requestBody = config
-            )
+            httpClient.request("$url/config") {
+                this.method = HttpMethod.Patch
+                setBody(Json.parseToJsonElement(config))
+                contentType(ContentType.Application.Json)
+            }
         }
 
     suspend fun Service.addRule(rule: String): JsonObject =
@@ -481,7 +470,11 @@ class AppServicesClient(
         } ?: mapOf("state" to JsonPrimitive(syncEnabled))
 
         val configObj = JsonObject(mapOf("sync" to JsonObject(content)))
-        sendPatchRequest(url, configObj.toString())
+        httpClient.request(url) {
+            this.method = HttpMethod.Patch
+            setBody(configObj)
+            contentType(ContentType.Application.Json)
+        }
     }
 
     suspend fun BaasApp.pauseSync() =

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/KtorTestMethods.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/KtorTestMethods.kt
@@ -23,11 +23,7 @@ import kotlin.native.concurrent.SharedImmutable
 val TEST_METHODS = listOf(
     HttpMethod.Get,
     HttpMethod.Post,
-    // PATCH is currently broken on macOS if you read the content, which
-    // our NetworkTransport does: https://youtrack.jetbrains.com/issue/KTOR-4101/JsonFeature:-HttpClient-always-timeout-when-sending-PATCH-reques
-    // So for now, ignore PATCH in our tests. User API's does not use this anyway, only
-    // the AdminAPI, which has a work-around.
-    // HttpMethod.Patch,
+    HttpMethod.Patch,
     HttpMethod.Put,
     HttpMethod.Delete,
 )

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/TestAppInitializer.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/TestAppInitializer.kt
@@ -285,30 +285,6 @@ object TestAppInitializer {
         )
     }
 
-    // Enables forward as patch functionality as a HTTPS endpoint on the baas app.
-    private suspend fun AppServicesClient.enableForwardAsPatch(app: BaasApp) = with(app) {
-        addFunction(forwardAsPatch).let { function: Function ->
-            addEndpoint(
-                """
-                {
-                  "route": "/forwardAsPatch",
-                  "function_name": "${function.name}",
-                  "function_id": "${function._id}",
-                  "http_method": "POST",
-                  "validation_method": "NO_VALIDATION",
-                  "secret_id": "",
-                  "secret_name": "",
-                  "create_user_on_auth": false,
-                  "fetch_custom_user_data": false,
-                  "respond_result": false,
-                  "disabled": false,
-                  "return_type": "JSON"
-                }       
-                """.trimIndent()
-            )
-        }
-    }
-
     suspend fun AppServicesClient.addEmailProvider(
         app: BaasApp,
         autoConfirm: Boolean = true,
@@ -342,8 +318,6 @@ object TestAppInitializer {
         app: BaasApp,
         block: suspend AppServicesClient.(app: BaasApp, service: Service) -> Unit
     ) = with(app) {
-        enableForwardAsPatch(app)
-
         addFunction(insertDocument)
         addFunction(queryDocument)
         addFunction(deleteDocument)
@@ -382,35 +356,6 @@ object TestAppInitializer {
 
         setDevelopmentMode(true)
     }
-
-    private val forwardAsPatch = Function(
-        name = "forwardAsPatch",
-        runAsSystem = true,
-        source =
-        """
-        exports = async function (request, response) {
-            try {
-              if(request.body === undefined) {
-                throw new Error(`Request body was not defined.`)
-              }
-              const forwardRequest = JSON.parse(request.body.text());
-              
-              const forwardResponse = await context.http.patch({
-                url: forwardRequest.url,
-                body: JSON.parse(forwardRequest.body),
-                headers: context.request.requestHeaders,
-                encodeBodyAsJSON: true
-              });
-              
-              response.setStatusCode(forwardResponse.statusCode);
-          } catch (error) {
-            response.setStatusCode(400);
-            response.setBody(error.message);
-          }
-        }
-        
-        """.trimIndent()
-    )
 
     private val insertDocument = Function(
         name = "insertDocument",


### PR DESCRIPTION
After upgrading to Ktor2 the workaround for sending Patch requests on Mac is no longer needed.