### PR TITLE
Fix `Long` overflow when comparing current time to `RealmInstant.MAX` and `MIN` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Added proguard consumer files to Android debug artifacts. (Issue [#1150](https://github.com/realm/realm-kotlin/issues/1150))
+* Fixed bug when creating `RealmInstant` instaces with `RealmInstant.now()` in Kotlin Native. (Issue [#1182](https://github.com/realm/realm-kotlin/issues/1182))
 
 ### Compatibility
 * This release is compatible with the following Kotlin releases:

--- a/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -20,7 +20,6 @@ import platform.Foundation.timeIntervalSince1970
 import platform.posix.pthread_threadid_np
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KType
-import kotlin.time.Duration.Companion.nanoseconds
 
 @Suppress("MayBeConst") // Cannot make expect/actual const
 public actual val RUNTIME: String = "Native"

--- a/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -56,11 +56,12 @@ public actual fun epochInSeconds(): Long =
  */
 @Suppress("MagicNumber")
 internal actual fun currentTime(): RealmInstant {
-    val secs = NSDate().timeIntervalSince1970
+    val secs: Double = NSDate().timeIntervalSince1970
     return when {
-        // We can't convert the MIN value to ms as it will cause Long overflow so we have to compare directly against seconds
+        // We can't convert the MIN value to ms - it is initialized with Long.MIN_VALUE and
+        // multiplying it by 1000 will cause overflow. We have to compare directly against seconds
         secs < RealmInstant.MIN.epochSeconds -> RealmInstant.MIN
-        // Similarly here, compare to seconds instead
+        // Similarly here, compare to seconds instead to avoid overflow with Long.MAX_VALUE
         secs > RealmInstant.MAX.epochSeconds -> RealmInstant.MAX
         else -> {
             val millis = (secs * 1000 + if (secs > 0) 0.5 else -0.5).toLong()

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInstantTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInstantTests.kt
@@ -4,9 +4,11 @@ import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.entities.Sample
 import io.realm.kotlin.ext.query
+import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.query.find
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.types.RealmInstant
+import kotlinx.coroutines.delay
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -15,6 +17,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 class RealmInstantTests {
 
@@ -151,16 +156,29 @@ class RealmInstantTests {
         assertEquals("RealmInstant(epochSeconds=42, nanosecondsOfSecond=420)", ts.toString())
     }
 
-    /**
-     * When this method was implemented the unix epoch time was 1664980145.
-     * Nanoseconds are too granular to perform tests on especially since the
-     * darwin implementation rounds the timestamp to a precision of milliseconds.
-     */
     @Test
     fun now() {
-        val ts = RealmInstant.now()
-        assertTrue(ts.epochSeconds > 1664980145)
-        assertTrue(ts.nanosecondsOfSecond >= 0)
+        runBlocking {
+            // Get two different instants with some time in between calls
+            val ts1 = RealmInstant.now()
+            delay(100.milliseconds)
+            val ts2 = RealmInstant.now()
+
+            // When this method was implemented the unix epoch time was 1664980145.
+            // Nanoseconds are too granular to perform tests on especially since the
+            // Darwin implementation rounds the timestamp to a precision of milliseconds.
+            assertTrue(ts1.epochSeconds > 1664980145)
+            assertTrue(ts1.nanosecondsOfSecond >= 0)
+            assertTrue(ts2.epochSeconds > 1664980145)
+            assertTrue(ts2.nanosecondsOfSecond >= 0)
+
+
+            // Assert the second instant is greater than the first one, also using Duration
+            assertTrue(ts2 > ts1)
+            val duration1 = ts1.epochSeconds.seconds + ts1.nanosecondsOfSecond.nanoseconds
+            val duration2 = ts2.epochSeconds.seconds + ts2.nanosecondsOfSecond.nanoseconds
+            assertTrue(duration2 > duration1)
+        }
     }
 
     @Test

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInstantTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInstantTests.kt
@@ -167,11 +167,11 @@ class RealmInstantTests {
             // When this method was implemented the unix epoch time was 1664980145.
             // Nanoseconds are too granular to perform tests on especially since the
             // Darwin implementation rounds the timestamp to a precision of milliseconds.
-            assertTrue(ts1.epochSeconds > 1664980145)
+            val baselineEpoch = 1664980145
+            assertTrue(ts1.epochSeconds > baselineEpoch)
             assertTrue(ts1.nanosecondsOfSecond >= 0)
-            assertTrue(ts2.epochSeconds > 1664980145)
+            assertTrue(ts2.epochSeconds > baselineEpoch)
             assertTrue(ts2.nanosecondsOfSecond >= 0)
-
 
             // Assert the second instant is greater than the first one, also using Duration
             assertTrue(ts2 > ts1)


### PR DESCRIPTION
Closes #1182 

We were hoping that converting the `RealmInstant.MAX` and `MIN` values to milliseconds would allow us to compare them to the current milliseconds value returned by `NSDate().timeIntervalSince1970`. However, the `MAX` and `MIN` values use `Long.MAX` and `Long.MIN` respectively and by multiplying them by `1000` we were overflowing causing the value to be `0` and always return `RealmInstant.MAX`.

This has been solved by comparing the value returned by `NSDate().timeIntervalSince1970` to the `MAX` and `MIN` values in seconds.