### PR TITLE
Allow indexes on boolean properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Added proguard consumer files to Android debug artifacts. (Issue [#1150](https://github.com/realm/realm-kotlin/issues/1150))
 * Fixed bug when creating `RealmInstant` instaces with `RealmInstant.now()` in Kotlin Native. (Issue [#1182](https://github.com/realm/realm-kotlin/issues/1182))
+* Allow `@Index` on `Boolean` fields. (Issue [#1193](https://github.com/realm/realm-kotlin/issues/1193))
 
 ### Compatibility
 * This release is compatible with the following Kotlin releases:

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/Index.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/Index.kt
@@ -29,8 +29,8 @@ import org.mongodb.kbson.BsonObjectId
  *
  * Multiple fields in a RealmObject class can have this annotation.
  *
- * This annotation applies to the following primitive types: [String], [Byte], [Char], [Short],
- * [Int], [Long], [RealmInstant], [ObjectId], [BsonObjectId], [RealmUUID] as well as their nullable
- * variants.
+ * This annotation applies to the following primitive types: [String], [Boolean], [Byte], [Char],
+ * [Short], [Int], [Long], [RealmInstant], [ObjectId], [BsonObjectId], [RealmUUID] as well as their
+ * nullable variants.
  */
 public annotation class Index

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -192,6 +192,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
     }
     private val indexableTypes = with(pluginContext.irBuiltIns) {
         setOf(
+            booleanType,
             byteType,
             charType,
             shortType,

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/TypeDescriptor.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/TypeDescriptor.kt
@@ -79,7 +79,7 @@ public object TypeDescriptor {
             listSupport = true,
             setSupport = true,
             primaryKeySupport = false,
-            indexSupport = false,
+            indexSupport = true,
             canBeNull = nullabilityForAll,
             canBeNotNull = nullabilityForAll
         ),


### PR DESCRIPTION
This PR would remove our compiler plugin check that erroneously guarded against marking boolean properties as indexed.

Closes #1193 