### PR TITLE
Allow white spaces in realm file path on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Added proguard consumer files to Android debug artifacts. (Issue [#1150](https://github.com/realm/realm-kotlin/issues/1150))
 * Fixed bug when creating `RealmInstant` instaces with `RealmInstant.now()` in Kotlin Native. (Issue [#1182](https://github.com/realm/realm-kotlin/issues/1182))
+* Fixed issue with spaces in realm file path on iOS (Issue [#1194](https://github.com/realm/realm-kotlin/issues/1194))
 
 ### Compatibility
 * This release is compatible with the following Kotlin releases:

--- a/packages/cinterop/src/androidAndroidTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/androidAndroidTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -17,7 +17,6 @@
 package io.realm.kotlin.test
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.kotlin.internal.interop.CoreErrorConverter
 import io.realm.kotlin.internal.interop.RealmCoreException
 import io.realm.kotlin.internal.interop.RealmCoreInvalidQueryException
@@ -681,7 +680,8 @@ class CinteropTest {
 
     @Test
     fun parentChildRelationship() {
-        val context = InstrumentationRegistry.getInstrumentation().context
+        val path =
+            Files.createTempDirectory("android_tests").absolutePathString() + "/c_api_test.realm"
 
         System.loadLibrary("realmc")
         println(realmc.realm_get_library_version())
@@ -749,7 +749,7 @@ class CinteropTest {
 
         val config: Long = realmc.realm_config_new()
 
-        realmc.realm_config_set_path(config, context.filesDir.absolutePath + "/c_api_link.realm")
+        realmc.realm_config_set_path(config, path)
         realmc.realm_config_set_schema(config, realmSchemaNew)
         realmc.realm_config_set_schema_mode(config, realm_schema_mode_e.RLM_SCHEMA_MODE_AUTOMATIC)
         realmc.realm_config_set_schema_version(config, 1)

--- a/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -114,7 +114,7 @@ public actual fun prepareRealmDirectoryPath(directoryPath: String): String {
 public actual fun prepareRealmFilePath(directoryPath: String, filename: String): String {
     val dir = NSURL.fileURLWithPath(directoryPath, isDirectory = true)
     preparePath(directoryPath, dir)
-    return NSURL.fileURLWithPath(filename, dir).absoluteString?.removePrefix("file://")
+    return NSURL.fileURLWithPath(filename, dir).path
         ?: throw IllegalArgumentException("Could not resolve path components: '$directoryPath' and '$filename'.")
 }
 

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmConfigurationTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmConfigurationTests.kt
@@ -141,7 +141,7 @@ class RealmConfigurationTests {
             .build()
         assertEquals("$realmDir/${Realm.DEFAULT_FILE_NAME}", config.path)
         // Just verifying that we can open the realm
-        Realm.open(config).use {  }
+        Realm.open(config).use { }
     }
 
     @Test
@@ -235,7 +235,7 @@ class RealmConfigurationTests {
             .build()
         assertEquals("$tmpDir/$name", config.path)
         // Just verifying that we can open the realm
-        Realm.open(config).use {  }
+        Realm.open(config).use { }
     }
 
     @Test

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmConfigurationTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmConfigurationTests.kt
@@ -134,6 +134,17 @@ class RealmConfigurationTests {
     }
 
     @Test
+    fun directory_withSpace() {
+        val realmDir = tmpDir + "/dir with space"
+        val config = RealmConfiguration.Builder(schema = setOf(Sample::class))
+            .directory(realmDir)
+            .build()
+        assertEquals("$realmDir/${Realm.DEFAULT_FILE_NAME}", config.path)
+        // Just verifying that we can open the realm
+        Realm.open(config).use {  }
+    }
+
+    @Test
     fun directory_endsWithSeparator() {
         val realmDir = appFilesDirectory() + "/"
         val config = RealmConfiguration.Builder(schema = setOf(Sample::class))
@@ -213,6 +224,18 @@ class RealmConfigurationTests {
         ) {
             builder.name("${PATH_SEPARATOR}foo.realm")
         }
+    }
+
+    @Test
+    fun name_withSpace() {
+        val name = "name with space.realm"
+        val config = RealmConfiguration.Builder(schema = setOf(Sample::class))
+            .directory(tmpDir)
+            .name(name)
+            .build()
+        assertEquals("$tmpDir/$name", config.path)
+        // Just verifying that we can open the realm
+        Realm.open(config).use {  }
     }
 
     @Test

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
@@ -39,6 +39,7 @@ import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
+import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.async
@@ -185,6 +186,7 @@ class SyncSessionTests {
     @Test
     fun session_localRealmThrows() {
         val config = RealmConfiguration.Builder(schema = setOf(ParentPk::class, ChildPk::class))
+            .directory(PlatformUtils.createTempDir())
             .build()
         Realm.open(config).use { realm ->
             assertFailsWith<IllegalStateException> { realm.syncSession }


### PR DESCRIPTION
Closes #1194 