### PR TITLE
Fix compilation error in main after merging `RealmAny`

### DIFF
--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -266,13 +266,14 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                                 declaration.locationOf()
                             )
                         }
-                        fields[name] = SchemaProperty(
+                        val schemaProperty = SchemaProperty(
                             propertyType = PropertyType.RLM_PROPERTY_TYPE_MIXED,
                             declaration = declaration,
                             collectionType = CollectionType.NONE
                         )
+                        fields[name] = schemaProperty
                         modifyAccessor(
-                            property = declaration,
+                            property = schemaProperty,
                             getFunction = getRealmAny,
                             fromRealmValue = null,
                             toPublic = null,


### PR DESCRIPTION
Fixed handling of `RealmAny` properties in accessor modifier after `@PersistedName` task was merged.