### PR TITLE
`RealmDictionary` - compiler plugin support

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmDictionaryExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmDictionaryExt.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.ext
+
+import io.realm.kotlin.types.RealmDictionary
+import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.RealmSet
+
+/**
+ * Instantiates an **unmanaged** [RealmDictionary].
+ */
+public fun <T> realmDictionaryOf(vararg elements: T): RealmDictionary<T> = TODO()
+
+/**
+ * Makes an unmanaged in-memory copy of the elements in a managed [RealmDictionary]. This is a deep
+ * copy that will copy all referenced objects.
+ *
+ * @param depth limit of the deep copy. All object references after this depth will be `null`.
+ * [RealmList]s and [RealmSet]s containing objects will be empty. Starting depth is 0.
+ * @returns an in-memory copy of all input objects.
+ * @throws IllegalArgumentException if depth < 0 or, or the list is not valid to copy.
+ */
+public inline fun <T : RealmObject> RealmDictionary<T>.copyFromRealm(
+    depth: UInt = UInt.MAX_VALUE
+): Set<T> {
+    TODO()
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmDictionaryExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmDictionaryExt.kt
@@ -16,27 +16,24 @@
 
 package io.realm.kotlin.ext
 
-import io.realm.kotlin.types.RealmDictionary
-import io.realm.kotlin.types.RealmList
-import io.realm.kotlin.types.RealmObject
-import io.realm.kotlin.types.RealmSet
+// TODO will be added in the next PR
 
-/**
- * Instantiates an **unmanaged** [RealmDictionary].
- */
-public fun <T> realmDictionaryOf(vararg elements: T): RealmDictionary<T> = TODO()
+// /**
+//  * Instantiates an **unmanaged** [RealmDictionary].
+//  */
+// public fun <T> realmDictionaryOf(vararg elements: T): RealmDictionary<T> = TODO()
 
-/**
- * Makes an unmanaged in-memory copy of the elements in a managed [RealmDictionary]. This is a deep
- * copy that will copy all referenced objects.
- *
- * @param depth limit of the deep copy. All object references after this depth will be `null`.
- * [RealmList]s and [RealmSet]s containing objects will be empty. Starting depth is 0.
- * @returns an in-memory copy of all input objects.
- * @throws IllegalArgumentException if depth < 0 or, or the list is not valid to copy.
- */
-public inline fun <T : RealmObject> RealmDictionary<T>.copyFromRealm(
-    depth: UInt = UInt.MAX_VALUE
-): Set<T> {
-    TODO()
-}
+// /**
+//  * Makes an unmanaged in-memory copy of the elements in a managed [RealmDictionary]. This is a deep
+//  * copy that will copy all referenced objects.
+//  *
+//  * @param depth limit of the deep copy. All object references after this depth will be `null`.
+//  * [RealmList]s and [RealmSet]s containing objects will be empty. Starting depth is 0.
+//  * @returns an in-memory copy of all input objects.
+//  * @throws IllegalArgumentException if depth < 0 or, or the list is not valid to copy.
+//  */
+// public inline fun <T : RealmObject> RealmDictionary<T>.copyFromRealm(
+//     depth: UInt = UInt.MAX_VALUE
+// ): Set<T> {
+//     TODO()
+// }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectHelper.kt
@@ -55,7 +55,6 @@ import io.realm.kotlin.types.ManagedRealmDictionary
 import io.realm.kotlin.types.MutableRealmInt
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmAny
-import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
@@ -537,8 +536,8 @@ internal object RealmObjectHelper {
     }
 
     internal inline fun <reified R : Any> getDictionary(
-        obj: RealmObjectReference<out BaseRealmObject>,
-        propertyName: String
+//        obj: RealmObjectReference<out BaseRealmObject>,
+//        propertyName: String
     ): ManagedRealmDictionary<R?> {
         TODO()
     }
@@ -620,11 +619,11 @@ internal object RealmObjectHelper {
     }
 
     internal inline fun <reified T : Any> setDictionary(
-        obj: RealmObjectReference<out BaseRealmObject>,
-        col: String,
-        dictionary: RealmDictionary<T>,
-        updatePolicy: UpdatePolicy = UpdatePolicy.ALL,
-        cache: UnmanagedToManagedObjectCache = mutableMapOf()
+//        obj: RealmObjectReference<out BaseRealmObject>,
+//        col: String,
+//        dictionary: RealmDictionary<T>,
+//        updatePolicy: UpdatePolicy = UpdatePolicy.ALL,
+//        cache: UnmanagedToManagedObjectCache = mutableMapOf()
     ) {
         TODO()
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectHelper.kt
@@ -51,9 +51,11 @@ import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.schema.RealmStorageType
 import io.realm.kotlin.types.BaseRealmObject
 import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.ManagedRealmDictionary
 import io.realm.kotlin.types.MutableRealmInt
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmAny
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
@@ -534,6 +536,13 @@ internal object RealmObjectHelper {
         }
     }
 
+    internal inline fun <reified R : Any> getDictionary(
+        obj: RealmObjectReference<out BaseRealmObject>,
+        propertyName: String
+    ): ManagedRealmDictionary<R?> {
+        TODO()
+    }
+
     internal fun setValueTransportByKey(
         obj: RealmObjectReference<out BaseRealmObject>,
         key: PropertyKey,
@@ -608,6 +617,16 @@ internal object RealmObjectHelper {
                 it.operator.addAll(set, updatePolicy, cache)
             }
         }
+    }
+
+    internal inline fun <reified T : Any> setDictionary(
+        obj: RealmObjectReference<out BaseRealmObject>,
+        col: String,
+        dictionary: RealmDictionary<T>,
+        updatePolicy: UpdatePolicy = UpdatePolicy.ALL,
+        cache: UnmanagedToManagedObjectCache = mutableMapOf()
+    ) {
+        TODO()
     }
 
     @Suppress("LongParameterList")

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectHelper.kt
@@ -55,6 +55,7 @@ import io.realm.kotlin.types.ManagedRealmDictionary
 import io.realm.kotlin.types.MutableRealmInt
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmAny
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
@@ -535,9 +536,11 @@ internal object RealmObjectHelper {
         }
     }
 
+    // TODO remove suppress in next PR, needed to avoid static analysis task failing
+    @Suppress("UnusedPrivateMember")
     internal inline fun <reified R : Any> getDictionary(
-//        obj: RealmObjectReference<out BaseRealmObject>,
-//        propertyName: String
+        obj: RealmObjectReference<out BaseRealmObject>,
+        propertyName: String
     ): ManagedRealmDictionary<R?> {
         TODO()
     }
@@ -618,12 +621,14 @@ internal object RealmObjectHelper {
         }
     }
 
+    // TODO remove suppress in next PR, needed to avoid static analysis task failing
+    @Suppress("UnusedPrivateMember")
     internal inline fun <reified T : Any> setDictionary(
-//        obj: RealmObjectReference<out BaseRealmObject>,
-//        col: String,
-//        dictionary: RealmDictionary<T>,
-//        updatePolicy: UpdatePolicy = UpdatePolicy.ALL,
-//        cache: UnmanagedToManagedObjectCache = mutableMapOf()
+        obj: RealmObjectReference<out BaseRealmObject>,
+        col: String,
+        dictionary: RealmDictionary<T>,
+        updatePolicy: UpdatePolicy = UpdatePolicy.ALL,
+        cache: UnmanagedToManagedObjectCache = mutableMapOf()
     ) {
         TODO()
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
@@ -30,4 +30,3 @@ public class ManagedRealmDictionary<E> : AbstractMutableMap<String, E>(), RealmD
         TODO("Not yet implemented")
     }
 }
-

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
@@ -20,9 +20,9 @@ public interface RealmMap<K, V> : MutableMap<K, V>
 
 public interface RealmDictionary<E> : RealmMap<String, E>
 
-public class UnmanagedRealmDictionary<E> : RealmDictionary<E>, MutableMap<String, E> by mutableMapOf()
+internal class UnmanagedRealmDictionary<E> : RealmDictionary<E>, MutableMap<String, E> by mutableMapOf()
 
-public class ManagedRealmDictionary<E> : AbstractMutableMap<String, E>(), RealmDictionary<E> {
+internal class ManagedRealmDictionary<E> : AbstractMutableMap<String, E>(), RealmDictionary<E> {
     override val entries: MutableSet<MutableMap.MutableEntry<String, E>>
         get() = TODO("Not yet implemented")
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.types
+
+public interface RealmMap<K, V> : MutableMap<K, V>
+
+public interface RealmDictionary<E> : RealmMap<String, E>
+
+public class UnmanagedRealmDictionary<E> : RealmDictionary<E>, MutableMap<String, E> by mutableMapOf()
+
+public class ManagedRealmDictionary<E> : AbstractMutableMap<String, E>(), RealmDictionary<E> {
+    override val entries: MutableSet<MutableMap.MutableEntry<String, E>>
+        get() = TODO("Not yet implemented")
+
+    override fun put(key: String, value: E): E? {
+        TODO("Not yet implemented")
+    }
+}
+

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmSet.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmSet.kt
@@ -21,6 +21,7 @@ import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.notifications.InitialSet
 import io.realm.kotlin.notifications.SetChange
 import io.realm.kotlin.notifications.UpdatedSet
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -723,7 +723,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
         val type: IrType? = when (collectionType) {
             CollectionType.NONE -> backingField.type
             CollectionType.LIST,
-            CollectionType.SET -> getCollectionElementType(backingField.type)
+            CollectionType.SET,
             CollectionType.DICTIONARY -> getCollectionElementType(backingField.type)
         }
         val getter = property.declaration.getter

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -266,13 +266,14 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                                 declaration.locationOf()
                             )
                         }
-                        fields[name] = SchemaProperty(
+                        val schemaProperty = SchemaProperty(
                             propertyType = PropertyType.RLM_PROPERTY_TYPE_MIXED,
                             declaration = declaration,
                             collectionType = CollectionType.NONE
                         )
+                        fields[name] = schemaProperty
                         modifyAccessor(
-                            property = declaration,
+                            property = schemaProperty,
                             getFunction = getRealmAny,
                             fromRealmValue = null,
                             toPublic = null,

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -972,11 +972,11 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
         val descriptorType = declaration.symbol.descriptor.type
         val collectionGenericType = descriptorType.arguments[0].type
 
-        // No embedded objects for sets
         val supertypes = collectionGenericType.constructor.supertypes
         val isEmbedded = inheritsFromRealmObject(supertypes, RealmObjectType.EMBEDDED)
 
         if (inheritsFromRealmObject(supertypes)) {
+            // No embedded objects for sets
             if (collectionType == CollectionType.SET && isEmbedded) {
                 logError(
                     "Error in field ${declaration.name} - ${collectionType.description} does not support embedded realm objects element types.",
@@ -987,8 +987,8 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
 
             val isNullable = collectionGenericType.isNullable()
 
-            // Unlike lists and sets, dictionaries of objects/embedded objects may contain null values
-            if (collectionType != CollectionType.DICTIONARY) {
+            // Lists of objects/embedded objects and sets of object may NOT contain null values, but dictionaries may
+            if (collectionType == CollectionType.SET || collectionType == CollectionType.LIST) {
                 if (isNullable) {
                     logError(
                         "Error in field ${declaration.name} - ${collectionType.description} does not support nullable realm objects element types.",

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -21,6 +21,7 @@ import io.realm.kotlin.compiler.FqNames.IGNORE_ANNOTATION
 import io.realm.kotlin.compiler.FqNames.KBSON_OBJECT_ID
 import io.realm.kotlin.compiler.FqNames.REALM_ANY
 import io.realm.kotlin.compiler.FqNames.REALM_BACKLINKS
+import io.realm.kotlin.compiler.FqNames.REALM_DICTIONARY
 import io.realm.kotlin.compiler.FqNames.REALM_EMBEDDED_BACKLINKS
 import io.realm.kotlin.compiler.FqNames.REALM_INSTANT
 import io.realm.kotlin.compiler.FqNames.REALM_LIST
@@ -43,10 +44,12 @@ import io.realm.kotlin.compiler.Names.REALM_ACCESSOR_HELPER_GET_REALM_ANY
 import io.realm.kotlin.compiler.Names.REALM_ACCESSOR_HELPER_GET_STRING
 import io.realm.kotlin.compiler.Names.REALM_ACCESSOR_HELPER_GET_UUID
 import io.realm.kotlin.compiler.Names.REALM_ACCESSOR_HELPER_SET_VALUE
+import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_GET_DICTIONARY
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_GET_LIST
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_GET_MUTABLE_INT
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_GET_OBJECT
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_GET_SET
+import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_SET_DICTIONARY
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_SET_EMBEDDED_REALM_OBJECT
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_SET_LIST
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_SET_OBJECT
@@ -120,6 +123,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
     private val realmObjectHelper: IrClass = pluginContext.lookupClassOrThrow(REALM_OBJECT_HELPER)
     private val realmListClass: IrClass = pluginContext.lookupClassOrThrow(REALM_LIST)
     private val realmSetClass: IrClass = pluginContext.lookupClassOrThrow(REALM_SET)
+    private val realmDictionaryClass: IrClass = pluginContext.lookupClassOrThrow(REALM_DICTIONARY)
     private val realmInstantClass: IrClass = pluginContext.lookupClassOrThrow(REALM_INSTANT)
     private val realmBacklinksClass: IrClass = pluginContext.lookupClassOrThrow(REALM_BACKLINKS)
     private val realmEmbeddedBacklinksClass: IrClass = pluginContext.lookupClassOrThrow(REALM_EMBEDDED_BACKLINKS)
@@ -174,6 +178,10 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
         realmObjectHelper.lookupFunction(REALM_OBJECT_HELPER_GET_SET)
     private val setSet: IrSimpleFunction =
         realmObjectHelper.lookupFunction(REALM_OBJECT_HELPER_SET_SET)
+    private val getDictionary: IrSimpleFunction =
+        realmObjectHelper.lookupFunction(REALM_OBJECT_HELPER_GET_DICTIONARY)
+    private val setDictionary: IrSimpleFunction =
+        realmObjectHelper.lookupFunction(REALM_OBJECT_HELPER_SET_DICTIONARY)
 
     // Top level SDK->Core converters
     private val byteToLong: IrSimpleFunction =
@@ -581,6 +589,10 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                         logDebug("RealmSet property named ${declaration.name} is ${if (nullable) "" else "not "}nullable")
                         processCollectionField(CollectionType.SET, fields, name, declaration)
                     }
+                    propertyType.isRealmDictionary() -> {
+                        logDebug("RealmDictionary property named ${declaration.name} is ${if (nullable) "" else "not "}nullable")
+                        processCollectionField(CollectionType.DICTIONARY, fields, name, declaration)
+                    }
                     propertyType.isSubtypeOfClass(embeddedRealmObjectInterface) -> {
                         logDebug("Object property named ${declaration.name} is embedded and ${if (nullable) "" else "not "}nullable")
                         val schemaProperty = SchemaProperty(
@@ -638,7 +650,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
         val type = declaration.symbol.descriptor.type
         if (type.arguments[0] is StarProjectionImpl) {
             logError(
-                "Error in field ${declaration.name} - ${collectionType.description}s cannot use a '*' projection.",
+                "Error in field ${declaration.name} - ${collectionType.description} cannot use a '*' projection.",
                 declaration.locationOf()
             )
             return
@@ -677,7 +689,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                     getFunction = when (collectionType) {
                         CollectionType.LIST -> getList
                         CollectionType.SET -> getSet
-                        CollectionType.DICTIONARY -> TODO("Dictionaries are not supported yet")
+                        CollectionType.DICTIONARY -> getDictionary
                         else -> throw UnsupportedOperationException("Only collections or dictionaries are supposed to modify the getter for '$name'")
                     },
                     fromRealmValue = null,
@@ -685,7 +697,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                     setFunction = when (collectionType) {
                         CollectionType.LIST -> setList
                         CollectionType.SET -> setSet
-                        CollectionType.DICTIONARY -> TODO("Dictionaries are not supported yet")
+                        CollectionType.DICTIONARY -> setDictionary
                         else -> throw UnsupportedOperationException("Only collections or dictionaries are supposed to modify the setter for '$name'")
                     },
                     fromPublic = null,
@@ -712,7 +724,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
             CollectionType.NONE -> backingField.type
             CollectionType.LIST,
             CollectionType.SET -> getCollectionElementType(backingField.type)
-            else -> error("Collection type '$collectionType' not supported.")
+            CollectionType.DICTIONARY -> getCollectionElementType(backingField.type)
         }
         val getter = property.declaration.getter
         val setter = property.declaration.setter
@@ -891,6 +903,12 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
         return propertyClassId == realmSetClassId
     }
 
+    private fun IrType.isRealmDictionary(): Boolean {
+        val propertyClassId = this.classifierOrFail.descriptor.classId
+        val realmDictionaryClassId = realmDictionaryClass.descriptor.classId
+        return propertyClassId == realmDictionaryClassId
+    }
+
     private fun IrType.isRealmInstant(): Boolean {
         val propertyClassId = this.classifierOrFail.descriptor.classId
         val realmInstantClassId = realmInstantClass.descriptor.classId
@@ -957,26 +975,32 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
         // No embedded objects for sets
         val supertypes = collectionGenericType.constructor.supertypes
         val isEmbedded = inheritsFromRealmObject(supertypes, RealmObjectType.EMBEDDED)
-        if (collectionType == CollectionType.SET && isEmbedded) {
-            logError(
-                "Error in field ${declaration.name} - ${collectionType.description}s do not support embedded realm objects element types.",
-                declaration.locationOf()
-            )
-            return null
-        }
 
         if (inheritsFromRealmObject(supertypes)) {
-            // Nullable objects are not supported
-            if (collectionGenericType.isNullable()) {
+            if (collectionType == CollectionType.SET && isEmbedded) {
                 logError(
-                    "Error in field ${declaration.name} - ${collectionType.description}s do not support nullable realm objects element types.",
+                    "Error in field ${declaration.name} - ${collectionType.description} does not support embedded realm objects element types.",
                     declaration.locationOf()
                 )
                 return null
             }
+
+            val isNullable = collectionGenericType.isNullable()
+
+            // Unlike lists and sets, dictionaries of objects/embedded objects may contain null values
+            if (collectionType != CollectionType.DICTIONARY) {
+                if (isNullable) {
+                    logError(
+                        "Error in field ${declaration.name} - ${collectionType.description} does not support nullable realm objects element types.",
+                        declaration.locationOf()
+                    )
+                    return null
+                }
+            }
+
             return CoreType(
                 propertyType = PropertyType.RLM_PROPERTY_TYPE_OBJECT,
-                nullable = false
+                nullable = isNullable
             )
         }
 
@@ -993,13 +1017,13 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
         val genericPropertyType = getPropertyTypeFromKotlinType(collectionGenericType)
         return if (genericPropertyType == null) {
             logError(
-                "Unsupported type for ${collectionType.description}s: '$collectionGenericType'",
+                "Unsupported type for ${collectionType.description}: '$collectionGenericType'",
                 declaration.locationOf()
             )
             null
         } else if (genericPropertyType == PropertyType.RLM_PROPERTY_TYPE_MIXED && !collectionGenericType.isNullable()) {
             logError(
-                "Unsupported type for ${collectionType.description}s: Only '${collectionType.description}<RealmAny?>' is supported.",
+                "Unsupported type for ${collectionType.description}: Only '${collectionType.description}<RealmAny?>' is supported.",
                 declaration.locationOf()
             )
             return null

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
@@ -62,6 +62,8 @@ internal object Names {
     val REALM_OBJECT_HELPER_SET_LIST = Name.identifier("setList")
     val REALM_OBJECT_HELPER_GET_SET = Name.identifier("getSet")
     val REALM_OBJECT_HELPER_SET_SET = Name.identifier("setSet")
+    val REALM_OBJECT_HELPER_GET_DICTIONARY = Name.identifier("getDictionary")
+    val REALM_OBJECT_HELPER_SET_DICTIONARY = Name.identifier("setDictionary")
     val REALM_OBJECT_HELPER_GET_MUTABLE_INT = Name.identifier("getMutableInt")
 
     // Schema related names
@@ -72,6 +74,7 @@ internal object Names {
     val PROPERTY_COLLECTION_TYPE_NONE = Name.identifier("RLM_COLLECTION_TYPE_NONE")
     val PROPERTY_COLLECTION_TYPE_LIST = Name.identifier("RLM_COLLECTION_TYPE_LIST")
     val PROPERTY_COLLECTION_TYPE_SET = Name.identifier("RLM_COLLECTION_TYPE_SET")
+    val PROPERTY_COLLECTION_TYPE_DICTIONARY = Name.identifier("RLM_COLLECTION_TYPE_DICTIONARY")
 }
 
 internal object FqNames {
@@ -113,6 +116,7 @@ internal object FqNames {
     // Realm data types
     val REALM_LIST = FqName("io.realm.kotlin.types.RealmList")
     val REALM_SET = FqName("io.realm.kotlin.types.RealmSet")
+    val REALM_DICTIONARY = FqName("io.realm.kotlin.types.RealmDictionary")
     val REALM_INSTANT = FqName("io.realm.kotlin.types.RealmInstant")
     val REALM_BACKLINKS = FqName("io.realm.kotlin.types.BacklinksDelegate")
     val REALM_EMBEDDED_BACKLINKS = FqName("io.realm.kotlin.types.EmbeddedBacklinksDelegate")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -37,6 +37,7 @@ import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_INTERNAL_INTERFACE
 import io.realm.kotlin.compiler.FqNames.REALM_UUID
 import io.realm.kotlin.compiler.Names.CLASS_INFO_CREATE
 import io.realm.kotlin.compiler.Names.OBJECT_REFERENCE
+import io.realm.kotlin.compiler.Names.PROPERTY_COLLECTION_TYPE_DICTIONARY
 import io.realm.kotlin.compiler.Names.PROPERTY_COLLECTION_TYPE_LIST
 import io.realm.kotlin.compiler.Names.PROPERTY_COLLECTION_TYPE_NONE
 import io.realm.kotlin.compiler.Names.PROPERTY_COLLECTION_TYPE_SET
@@ -568,8 +569,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                         CollectionType.NONE -> PROPERTY_COLLECTION_TYPE_NONE
                                         CollectionType.LIST -> PROPERTY_COLLECTION_TYPE_LIST
                                         CollectionType.SET -> PROPERTY_COLLECTION_TYPE_SET
-                                        else ->
-                                            error("Unsupported collection type '${value.collectionType}' for field ${entry.key}")
+                                        CollectionType.DICTIONARY -> PROPERTY_COLLECTION_TYPE_DICTIONARY
                                     }
                                     putValueArgument(
                                         arg++,
@@ -592,7 +592,8 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                                     PROPERTY_COLLECTION_TYPE_NONE ->
                                                         backingField.type
                                                     PROPERTY_COLLECTION_TYPE_LIST,
-                                                    PROPERTY_COLLECTION_TYPE_SET ->
+                                                    PROPERTY_COLLECTION_TYPE_SET,
+                                                    PROPERTY_COLLECTION_TYPE_DICTIONARY ->
                                                         getCollectionElementType(backingField.type)
                                                             ?: error("Could not get collection type from ${backingField.type}")
                                                     else ->

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/TypeDescriptor.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/TypeDescriptor.kt
@@ -274,11 +274,26 @@ public object TypeDescriptor {
             acc
         }
 
+    // TODO add supported types for collections based on nullability since RealmAny can only be nullable
+    fun elementTypesForDictionary(classifiers: Collection<KClassifier>): MutableSet<ElementType> =
+        classifiers.fold(mutableSetOf()) { acc, classifier ->
+            val realmFieldType = TypeDescriptor.classifiers[classifier]
+                ?: error("Unmapped classifier $classifier")
+            if (realmFieldType.canBeNull.contains(CollectionType.RLM_COLLECTION_TYPE_DICTIONARY)) {
+                acc.add(ElementType(classifier, true))
+            }
+            if (realmFieldType.canBeNotNull.contains(CollectionType.RLM_COLLECTION_TYPE_DICTIONARY)) {
+                acc.add(ElementType(classifier, false))
+            }
+            acc
+        }
+
     // Convenience variables holding collections of the various supported types
     val elementClassifiers: Set<KClassifier> = classifiers.keys
     val elementTypes = elementTypes(elementClassifiers)
     val elementTypesForList = elementTypesForList(elementClassifiers)
     val elementTypesForSet = elementTypesForSet(elementClassifiers)
+    val elementTypesForDictionary = elementTypesForSet(elementClassifiers)
 
     // Convenience variables holding collection of various groups of Realm field types
     val allSingularFieldTypes = elementTypes.map {

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/EmbeddedTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/EmbeddedTests.kt
@@ -45,23 +45,23 @@ class EmbeddedTests {
         assertTrue(result.messages.contains("Embedded object is not allowed to have a primary key"))
     }
 
-//    @Test
-//    fun `embedded object lists cannot be nullable`() {
-//        val result = Compiler.compileFromSource(
-//            source = SourceFile.kotlin(
-//                "embeddedRealmObjectNullableList.kt",
-//                """
-//                    import io.realm.kotlin.types.EmbeddedRealmObject
-//                    import io.realm.kotlin.types.RealmList
-//                    import io.realm.kotlin.ext.realmListOf
-//
-//                    class A : EmbeddedRealmObject {
-//                        var embeddedList: RealmList<A?> = realmListOf()
-//                    }
-//                """.trimIndent()
-//            )
-//        )
-//        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-//        assertTrue(result.messages.contains("RealmList does not support nullable realm objects element types"))
-//    }
+    @Test
+    fun `embedded object lists cannot be nullable`() {
+        val result = Compiler.compileFromSource(
+            source = SourceFile.kotlin(
+                "embeddedRealmObjectNullableList.kt",
+                """
+                    import io.realm.kotlin.types.EmbeddedRealmObject
+                    import io.realm.kotlin.types.RealmList
+                    import io.realm.kotlin.ext.realmListOf
+
+                    class A : EmbeddedRealmObject {
+                        var embeddedList: RealmList<A?> = realmListOf()
+                    }
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("RealmList does not support nullable realm objects element types"))
+    }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/EmbeddedTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/EmbeddedTests.kt
@@ -45,23 +45,23 @@ class EmbeddedTests {
         assertTrue(result.messages.contains("Embedded object is not allowed to have a primary key"))
     }
 
-    @Test
-    fun `embedded object lists cannot be nullable`() {
-        val result = Compiler.compileFromSource(
-            source = SourceFile.kotlin(
-                "embeddedRealmObjectNullableList.kt",
-                """
-                    import io.realm.kotlin.types.EmbeddedRealmObject
-                    import io.realm.kotlin.types.RealmList
-                    import io.realm.kotlin.ext.realmListOf
-
-                    class A : EmbeddedRealmObject {
-                        var embeddedList: RealmList<A?> = realmListOf()
-                    }
-                """.trimIndent()
-            )
-        )
-        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("RealmLists do not support nullable realm objects element types"))
-    }
+//    @Test
+//    fun `embedded object lists cannot be nullable`() {
+//        val result = Compiler.compileFromSource(
+//            source = SourceFile.kotlin(
+//                "embeddedRealmObjectNullableList.kt",
+//                """
+//                    import io.realm.kotlin.types.EmbeddedRealmObject
+//                    import io.realm.kotlin.types.RealmList
+//                    import io.realm.kotlin.ext.realmListOf
+//
+//                    class A : EmbeddedRealmObject {
+//                        var embeddedList: RealmList<A?> = realmListOf()
+//                    }
+//                """.trimIndent()
+//            )
+//        )
+//        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+//        assertTrue(result.messages.contains("RealmList does not support nullable realm objects element types"))
+//    }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/Utils.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/Utils.kt
@@ -35,15 +35,11 @@ fun getCode(
     return COLLECTION_CODE.format(
         collectionType.description,
         formattedContentType,
-        formattedFieldNullability,
-        "TODO()" // There is no need to use an actual default initializer when testing compilation
+        formattedFieldNullability
     )
 }
 
 private val COLLECTION_CODE = """
-import io.realm.kotlin.ext.realmDictionaryOf
-import io.realm.kotlin.ext.realmListOf
-import io.realm.kotlin.ext.realmSetOf
 import io.realm.kotlin.types.EmbeddedRealmObject
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmAny
@@ -64,6 +60,6 @@ class SampleClass : RealmObject {
     // 2nd parameter indicates the contained type: string, long, etc. - nullability must be handled here
     // 3rd parameter indicates nullability of the field itself
     // 4th parameter indicates the default value: realmListOf, realmSetOf or realmDictionaryOf
-    var collection: %1${'$'}s<%2${'$'}s>%3${'$'}s = %4${'$'}s
+    var collection: %1${'$'}s<%2${'$'}s>%3${'$'}s = TODO() // There is no need to use an actual default initializer when testing compilation
 }
 """.trimIndent()

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/Utils.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/Utils.kt
@@ -9,22 +9,21 @@ fun createFileAndCompile(fileName: String, code: String): KotlinCompilation.Resu
     Compiler.compileFromSource(SourceFile.kotlin(fileName, code))
 
 /**
- * Generates a formatted string containing code that can be built by the compiler.
- * Use it to generate different types of scenarios for nullability of contained type and the field
- * itself.
+ * Generates a formatted string containing code related to lists, sets and dictionaries that can be
+ * built by the compiler. Use it to generate different types of scenarios for nullability of
+ * the element type and the collection field itself.
  */
 fun getCode(
     collectionType: CollectionType,
-    contentType: String = "",
-    nullableContent: Boolean = false,
-    nullableField: Boolean = false,
-    userStarProjection: Boolean = false
+    elementType: String = "*",
+    nullableElementType: Boolean = false,
+    nullableField: Boolean = false
 ): String {
-    val formattedContentType = when (userStarProjection) {
-        true -> "*"
-        false -> when (nullableContent) {
-            true -> "$contentType?"
-            false -> contentType
+    val formattedContentType = when (elementType) {
+        "*" -> elementType
+        else -> when (nullableElementType) {
+            true -> "$elementType?"
+            false -> elementType
         }
     }
     val formattedFieldNullability = when (nullableField) {
@@ -56,10 +55,9 @@ import java.lang.Exception
 class A
 class EmbeddedClass : EmbeddedRealmObject
 class SampleClass : RealmObject {
-    // 1st parameter indicates the collection type: list, set or dictionary
-    // 2nd parameter indicates the contained type: string, long, etc. - nullability must be handled here
+    // 1st parameter indicates the collection type: RealmList, RealmSet, RealmDictionary
+    // 2nd parameter indicates the contained type: String, Long, etc. - nullability must be handled here
     // 3rd parameter indicates nullability of the field itself
-    // 4th parameter indicates the default value: realmListOf, realmSetOf or realmDictionaryOf
     var collection: %1${'$'}s<%2${'$'}s>%3${'$'}s = TODO() // There is no need to use an actual default initializer when testing compilation
 }
 """.trimIndent()

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/Utils.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/Utils.kt
@@ -2,7 +2,99 @@ package io.realm.kotlin.test.compiler
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
+import io.realm.kotlin.compiler.CollectionType
 import io.realm.kotlin.test.util.Compiler
 
 fun createFileAndCompile(fileName: String, code: String): KotlinCompilation.Result =
     Compiler.compileFromSource(SourceFile.kotlin(fileName, code))
+
+/**
+ * Generates a formatted string containing code that can be built by the compiler.
+ * Use it to generate different types of scenarios for nullability of contained type and the field
+ * itself.
+ */
+fun getCode(
+    collectionType: CollectionType,
+    contentType: String,
+    nullableContent: Boolean,
+    nullableField: Boolean
+): String {
+    val formattedContentType = when (nullableContent) {
+        true -> "${contentType}?"
+        false -> contentType
+    }
+    val formattedFieldNullability = when (nullableField) {
+        true -> "?"
+        false -> ""
+    }
+    val formattedDefaultValue = when (collectionType) {
+        CollectionType.LIST -> "realmListOf<$formattedContentType>()"
+        CollectionType.SET -> "realmSetOf<$formattedContentType>()"
+        CollectionType.DICTIONARY -> "realmDictionaryOf<$formattedContentType>()"
+        else -> throw IllegalArgumentException("Only collections can be used here")
+    }
+    // See comments in COLLECTION_CODE for meaning of parameters
+    return COLLECTION_CODE.format(
+        collectionType.description,
+        formattedContentType,
+        formattedFieldNullability,
+        formattedDefaultValue
+    )
+}
+
+/**
+ * Generates a formatted string containing code that can be built by the compiler to test
+ * collections that use a start projection.
+ */
+fun getCodeForStarProjection(collectionType: CollectionType): String =
+    STAR_PROJECTION_CODE.format(collectionType.description)
+
+private val COLLECTION_CODE = """
+import io.realm.kotlin.ext.realmDictionaryOf
+import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.ext.realmSetOf
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.ObjectId
+import io.realm.kotlin.types.RealmAny
+import io.realm.kotlin.types.RealmDictionary
+import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.RealmSet
+import io.realm.kotlin.types.RealmUUID
+import org.mongodb.kbson.BsonObjectId
+
+import java.lang.Exception
+
+class A
+class EmbeddedClass : EmbeddedRealmObject
+class SampleClass : RealmObject {
+    // 1st parameter indicates the collection type: list, set or dictionary
+    // 2nd parameter indicates the contained type: string, long, etc. - nullability must be handled here
+    // 3rd parameter indicates nullability of the field itself
+    // 4th parameter indicates the default value: realmListOf, realmSetOf or realmDictionaryOf
+    var collection: %1${'$'}s<%2${'$'}s>%3${'$'}s = %4${'$'}s
+}
+""".trimIndent()
+
+private val STAR_PROJECTION_CODE = """
+import io.realm.kotlin.ext.realmDictionaryOf
+import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.ext.realmSetOf
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.ObjectId
+import io.realm.kotlin.types.RealmAny
+import io.realm.kotlin.types.RealmDictionary
+import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.RealmSet
+import io.realm.kotlin.types.RealmUUID
+import org.mongodb.kbson.BsonObjectId
+
+import java.lang.Exception
+
+class StarProjectionClass : RealmObject {
+    var collection: %s<*> = TODO()
+}
+""".trimIndent()

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/Utils.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/Utils.kt
@@ -15,39 +15,30 @@ fun createFileAndCompile(fileName: String, code: String): KotlinCompilation.Resu
  */
 fun getCode(
     collectionType: CollectionType,
-    contentType: String,
-    nullableContent: Boolean,
-    nullableField: Boolean
+    contentType: String = "",
+    nullableContent: Boolean = false,
+    nullableField: Boolean = false,
+    userStarProjection: Boolean = false
 ): String {
-    val formattedContentType = when (nullableContent) {
-        true -> "${contentType}?"
-        false -> contentType
+    val formattedContentType = when (userStarProjection) {
+        true -> "*"
+        false -> when (nullableContent) {
+            true -> "$contentType?"
+            false -> contentType
+        }
     }
     val formattedFieldNullability = when (nullableField) {
         true -> "?"
         false -> ""
-    }
-    val formattedDefaultValue = when (collectionType) {
-        CollectionType.LIST -> "realmListOf<$formattedContentType>()"
-        CollectionType.SET -> "realmSetOf<$formattedContentType>()"
-        CollectionType.DICTIONARY -> "realmDictionaryOf<$formattedContentType>()"
-        else -> throw IllegalArgumentException("Only collections can be used here")
     }
     // See comments in COLLECTION_CODE for meaning of parameters
     return COLLECTION_CODE.format(
         collectionType.description,
         formattedContentType,
         formattedFieldNullability,
-        formattedDefaultValue
+        "TODO()" // There is no need to use an actual default initializer when testing compilation
     )
 }
-
-/**
- * Generates a formatted string containing code that can be built by the compiler to test
- * collections that use a start projection.
- */
-fun getCodeForStarProjection(collectionType: CollectionType): String =
-    STAR_PROJECTION_CODE.format(collectionType.description)
 
 private val COLLECTION_CODE = """
 import io.realm.kotlin.ext.realmDictionaryOf
@@ -74,27 +65,5 @@ class SampleClass : RealmObject {
     // 3rd parameter indicates nullability of the field itself
     // 4th parameter indicates the default value: realmListOf, realmSetOf or realmDictionaryOf
     var collection: %1${'$'}s<%2${'$'}s>%3${'$'}s = %4${'$'}s
-}
-""".trimIndent()
-
-private val STAR_PROJECTION_CODE = """
-import io.realm.kotlin.ext.realmDictionaryOf
-import io.realm.kotlin.ext.realmListOf
-import io.realm.kotlin.ext.realmSetOf
-import io.realm.kotlin.types.EmbeddedRealmObject
-import io.realm.kotlin.types.ObjectId
-import io.realm.kotlin.types.RealmAny
-import io.realm.kotlin.types.RealmDictionary
-import io.realm.kotlin.types.RealmInstant
-import io.realm.kotlin.types.RealmList
-import io.realm.kotlin.types.RealmObject
-import io.realm.kotlin.types.RealmSet
-import io.realm.kotlin.types.RealmUUID
-import org.mongodb.kbson.BsonObjectId
-
-import java.lang.Exception
-
-class StarProjectionClass : RealmObject {
-    var collection: %s<*> = TODO()
 }
 """.trimIndent()

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/dictionary/DictionaryTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/dictionary/DictionaryTests.kt
@@ -21,7 +21,6 @@ import com.tschuchort.compiletesting.SourceFile
 import io.realm.kotlin.compiler.CollectionType
 import io.realm.kotlin.test.compiler.createFileAndCompile
 import io.realm.kotlin.test.compiler.getCode
-import io.realm.kotlin.test.compiler.getCodeForStarProjection
 import io.realm.kotlin.test.util.Compiler.compileFromSource
 import io.realm.kotlin.test.util.TypeDescriptor
 import io.realm.kotlin.types.RealmAny
@@ -192,7 +191,7 @@ class DictionaryTests {
         val result = compileFromSource(
             SourceFile.kotlin(
                 "starProjectionDictionary.kt",
-                getCodeForStarProjection(CollectionType.DICTIONARY)
+                getCode(CollectionType.DICTIONARY, userStarProjection = true)
             )
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/dictionary/DictionaryTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/dictionary/DictionaryTests.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.test.compiler.dictionary
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.realm.kotlin.compiler.CollectionType
+import io.realm.kotlin.test.compiler.createFileAndCompile
+import io.realm.kotlin.test.compiler.getCode
+import io.realm.kotlin.test.compiler.getCodeForStarProjection
+import io.realm.kotlin.test.util.Compiler.compileFromSource
+import io.realm.kotlin.test.util.TypeDescriptor
+import io.realm.kotlin.types.RealmAny
+import io.realm.kotlin.types.RealmObject
+import org.junit.Test
+import kotlin.reflect.KClass
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Cannot trigger these from within the IDE due to https://youtrack.jetbrains.com/issue/KT-46195
+// Execute the tests from the CLI with `./gradlew jvmTest`
+class DictionaryTests {
+
+    private val baseSupportedPrimitiveClasses = TypeDescriptor.elementTypesForDictionary
+        .filter { it.classifier != RealmObject::class } // Cannot have "pure" RealmDictionary<RealmObject>
+
+    private val nonNullableTypes = baseSupportedPrimitiveClasses
+        .filter { it.classifier != RealmAny::class } // No non-nullable RealmDictionary<RealmAny> allowed
+        .map { (it.classifier as KClass<*>).simpleName!! }
+        .toSet() // Remove duplicates from nullable types
+        .plus(listOf("SampleClass", "EmbeddedClass")) // Add object classes manually - see name in code strings in Utils.kt
+
+    private val supportedPrimitiveTypes = baseSupportedPrimitiveClasses
+        .map { (it.classifier as KClass<*>).simpleName!! }
+        .toSet() // Remove duplicates from nullable types
+
+    // ------------------------------------------------
+    // RealmDictionary<E>
+    // ------------------------------------------------
+
+    // - supported types
+    @Test
+    fun `non-nullable dictionary`() {
+        // TODO optimize: see comment in TypeDescriptor.elementTypesForDictionary
+        nonNullableTypes.forEach { nonNullableType ->
+            val result = createFileAndCompile(
+                "nonNullableDictionary.kt",
+                getCode(
+                    collectionType = CollectionType.DICTIONARY,
+                    contentType = nonNullableType,
+                    nullableContent = false,
+                    nullableField = false
+                )
+            )
+            assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        }
+    }
+
+    // - RealmAny fails if non-nullable (mixed is always non-null)
+    // - Other unsupported types fail too (nullability is irrelevant in this case)
+    @Test
+    fun `unsupported non-nullable dictionary - fails`() {
+        val unsupportedNonNullableTypes =
+            listOf(Exception::class.simpleName!!, RealmAny::class.simpleName!!)
+        unsupportedNonNullableTypes.forEach { nonNullableType ->
+            val result = createFileAndCompile(
+                "unsupportedNonNullableDictionary.kt",
+                getCode(
+                    collectionType = CollectionType.DICTIONARY,
+                    contentType = nonNullableType,
+                    nullableContent = false,
+                    nullableField = false
+                )
+            )
+            assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+            assertTrue(result.messages.contains("Unsupported type for RealmDictionary"))
+        }
+    }
+
+    // - Other unsupported types fail too
+    @Test
+    fun `unsupported type in dictionary - fails`() {
+        val result = compileFromSource(
+            SourceFile.kotlin(
+                "unsupportedTypeDictionary.kt",
+                getCode(
+                    collectionType = CollectionType.DICTIONARY,
+                    contentType = "A",
+                    nullableContent = false,
+                    nullableField = false
+                )
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("Unsupported type for RealmDictionary: 'A'"))
+    }
+
+    // ------------------------------------------------
+    // RealmDictionary<E?>
+    // ------------------------------------------------
+
+    // - supported types
+    @Test
+    fun `nullable primitive type dictionary`() {
+        supportedPrimitiveTypes.forEach { nullableType ->
+            val result = createFileAndCompile(
+                "nullableTypeDictionary.kt",
+                getCode(
+                    collectionType = CollectionType.DICTIONARY,
+                    contentType = nullableType,
+                    nullableContent = true,
+                    nullableField = false
+                )
+            )
+            assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        }
+    }
+
+    // - RealmObject works
+    // Unlike lists and sets, dictionaries of objects/embedded objects may contain null values.
+    @Test
+    fun `nullable RealmObject dictionary`() {
+        val result = createFileAndCompile(
+            "nullableRealmObjectDictionary.kt",
+            getCode(
+                collectionType = CollectionType.DICTIONARY,
+                contentType = "SampleClass",
+                nullableContent = true,
+                nullableField = false
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    // - EmbeddedRealmObject works
+    // Unlike lists and sets, dictionaries of objects/embedded objects may contain null values.
+    @Test
+    fun `nullable EmbeddedRealmObject dictionary`() {
+        val result = createFileAndCompile(
+            "nullableEmbeddedRealmObjectDictionary.kt",
+            getCode(
+                collectionType = CollectionType.DICTIONARY,
+                contentType = "EmbeddedClass",
+                nullableContent = true,
+                nullableField = false
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    // ------------------------------------------------
+    // RealmDictionary<E>?
+    // ------------------------------------------------
+
+    // - nullable dictionary field fails
+    @Test
+    fun `nullable dictionaries - fails`() {
+        supportedPrimitiveTypes.forEach { primitiveType ->
+            val result = createFileAndCompile(
+                "nullableDictionary.kt",
+                getCode(
+                    collectionType = CollectionType.DICTIONARY,
+                    contentType = primitiveType,
+                    nullableContent = false,
+                    nullableField = true
+                )
+            )
+            assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+            assertTrue(result.messages.contains("a RealmDictionary field cannot be marked as nullable"))
+        }
+    }
+
+    // - star projection fails
+    @Test
+    fun `star projection dictionary - fails`() {
+        // Test that a star-projected dictionary fails to compile
+        // It is not possible to test a dictionary missing generics since this would not even compile
+        val result = compileFromSource(
+            SourceFile.kotlin(
+                "starProjectionDictionary.kt",
+                getCodeForStarProjection(CollectionType.DICTIONARY)
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains("RealmDictionary cannot use a '*' projection"))
+    }
+}

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/dictionary/DictionaryTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/dictionary/DictionaryTests.kt
@@ -60,8 +60,8 @@ class DictionaryTests {
                 "nonNullableDictionary.kt",
                 getCode(
                     collectionType = CollectionType.DICTIONARY,
-                    contentType = nonNullableType,
-                    nullableContent = false,
+                    elementType = nonNullableType,
+                    nullableElementType = false,
                     nullableField = false
                 )
             )
@@ -80,8 +80,8 @@ class DictionaryTests {
                 "unsupportedNonNullableDictionary.kt",
                 getCode(
                     collectionType = CollectionType.DICTIONARY,
-                    contentType = nonNullableType,
-                    nullableContent = false,
+                    elementType = nonNullableType,
+                    nullableElementType = false,
                     nullableField = false
                 )
             )
@@ -98,8 +98,8 @@ class DictionaryTests {
                 "unsupportedTypeDictionary.kt",
                 getCode(
                     collectionType = CollectionType.DICTIONARY,
-                    contentType = "A",
-                    nullableContent = false,
+                    elementType = "A",
+                    nullableElementType = false,
                     nullableField = false
                 )
             )
@@ -120,8 +120,8 @@ class DictionaryTests {
                 "nullableTypeDictionary.kt",
                 getCode(
                     collectionType = CollectionType.DICTIONARY,
-                    contentType = nullableType,
-                    nullableContent = true,
+                    elementType = nullableType,
+                    nullableElementType = true,
                     nullableField = false
                 )
             )
@@ -137,8 +137,8 @@ class DictionaryTests {
             "nullableRealmObjectDictionary.kt",
             getCode(
                 collectionType = CollectionType.DICTIONARY,
-                contentType = "SampleClass",
-                nullableContent = true,
+                elementType = "SampleClass",
+                nullableElementType = true,
                 nullableField = false
             )
         )
@@ -153,8 +153,8 @@ class DictionaryTests {
             "nullableEmbeddedRealmObjectDictionary.kt",
             getCode(
                 collectionType = CollectionType.DICTIONARY,
-                contentType = "EmbeddedClass",
-                nullableContent = true,
+                elementType = "EmbeddedClass",
+                nullableElementType = true,
                 nullableField = false
             )
         )
@@ -173,8 +173,8 @@ class DictionaryTests {
                 "nullableDictionary.kt",
                 getCode(
                     collectionType = CollectionType.DICTIONARY,
-                    contentType = primitiveType,
-                    nullableContent = false,
+                    elementType = primitiveType,
+                    nullableElementType = false,
                     nullableField = true
                 )
             )
@@ -191,7 +191,7 @@ class DictionaryTests {
         val result = compileFromSource(
             SourceFile.kotlin(
                 "starProjectionDictionary.kt",
-                getCode(CollectionType.DICTIONARY, userStarProjection = true)
+                getCode(CollectionType.DICTIONARY)
             )
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/list/ListTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/list/ListTests.kt
@@ -33,7 +33,7 @@ import kotlin.test.assertTrue
 class ListTests {
 
     private val baseSupportedPrimitiveClasses = TypeDescriptor.elementTypesForList
-        .filter { it.classifier != RealmObject::class } // Cannot have "pure" RealmSet<RealmObject>
+        .filter { it.classifier != RealmObject::class } // Cannot have "pure" RealmList<RealmObject>
 
     private val nonNullableTypes = baseSupportedPrimitiveClasses
         .filter { it.classifier != RealmAny::class } // No non-nullable RealmList<RealmAny> allowed
@@ -52,7 +52,7 @@ class ListTests {
     // - supported types
     @Test
     fun `non-nullable list`() {
-        // TODO optimize: see comment in TypeDescriptor.elementTypesForList to avoid this filter
+        // TODO optimize: see comment in TypeDescriptor.elementTypesForList
         nonNullableTypes.forEach { nonNullableType ->
             val result = createFileAndCompile(
                 "nonNullableList.kt",
@@ -73,7 +73,7 @@ class ListTests {
                 NON_NULLABLE_LIST_CODE.format(it)
             )
             assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-            assertTrue(result.messages.contains("Unsupported type for RealmLists"))
+            assertTrue(result.messages.contains("Unsupported type for RealmList"))
         }
     }
 
@@ -82,7 +82,7 @@ class ListTests {
     fun `unsupported type in list - fails`() {
         val result = compileFromSource(SourceFile.kotlin("nullableList.kt", UNSUPPORTED_TYPE))
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("Unsupported type for RealmLists: 'A'"))
+        assertTrue(result.messages.contains("Unsupported type for RealmList: 'A'"))
     }
 
     // ------------------------------------------------
@@ -109,7 +109,7 @@ class ListTests {
             NULLABLE_TYPE_CODE.format("NullableTypeList")
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("RealmLists do not support nullable realm objects element types"))
+        assertTrue(result.messages.contains("RealmList does not support nullable realm objects element types"))
     }
 
     // ------------------------------------------------
@@ -134,7 +134,7 @@ class ListTests {
         // It is not possible to test a list missing generics since this would not even compile
         val result = compileFromSource(SourceFile.kotlin("nullableList.kt", STAR_PROJECTION))
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("RealmLists cannot use a '*' projection"))
+        assertTrue(result.messages.contains("RealmList cannot use a '*' projection"))
     }
 }
 

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/set/SetTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/set/SetTests.kt
@@ -52,7 +52,7 @@ class SetTests {
     // - supported types
     @Test
     fun `non-nullable set`() {
-        // TODO optimize: see comment in TypeDescriptor.elementTypesForSet to avoid this filter
+        // TODO optimize: see comment in TypeDescriptor.elementTypesForSet
         nonNullableTypes.forEach { nonNullableType ->
             val result = createFileAndCompile(
                 "nonNullableSet.kt",
@@ -62,7 +62,7 @@ class SetTests {
         }
     }
 
-    // - RealmAny fails - mixed is always non-null
+    // - RealmAny fails if non-nullable - mixed is always non-null
     @Test
     fun `unsupported non-nullable set - fails`() {
         val unsupportedNonNullableTypes =
@@ -77,12 +77,12 @@ class SetTests {
         }
     }
 
-    // - other unsupported types fails
+    // - Other unsupported types fail too
     @Test
     fun `unsupported type in set - fails`() {
         val result = compileFromSource(SourceFile.kotlin("nullableSet.kt", UNSUPPORTED_TYPE))
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("Unsupported type for RealmSets: 'A'"))
+        assertTrue(result.messages.contains("Unsupported type for RealmSet: 'A'"))
     }
 
     // - Embedded objects fail
@@ -90,7 +90,7 @@ class SetTests {
     fun `unsupported type in set - EmbeddedRealmObject fails`() {
         val result = compileFromSource(SourceFile.kotlin("nullableSet.kt", EMBEDDED_TYPE))
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("RealmSets do not support embedded realm objects element types"))
+        assertTrue(result.messages.contains("RealmSet does not support embedded realm objects element types"))
     }
 
     // ------------------------------------------------
@@ -113,7 +113,7 @@ class SetTests {
         val result =
             createFileAndCompile("nullableTypeSet.kt", NULLABLE_TYPE_CODE.format("NullableTypeSet"))
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("RealmSets do not support nullable realm objects element types"))
+        assertTrue(result.messages.contains("RealmSet does not support nullable realm objects element types"))
     }
 
     // ------------------------------------------------
@@ -138,7 +138,7 @@ class SetTests {
         // It is not possible to test a set missing generics since this would not even compile
         val result = compileFromSource(SourceFile.kotlin("nullableSet.kt", STAR_PROJECTION))
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("RealmSets cannot use a '*' projection"))
+        assertTrue(result.messages.contains("RealmSet cannot use a '*' projection"))
     }
 }
 


### PR DESCRIPTION
- Added draft interface for `RealmDictionary` and support for it in the compiler plugin.
- Added compiler plugin tests for dictionaries - I will align tests for lists, sets and dictionaries in an upcoming PR since there is a lot of similarities among them