### PR TITLE
`RealmDictionary` - 1: basic infrastructure and API stubs

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -63,6 +63,7 @@ interface FrozenRealmT : RealmT
 interface RealmObjectT : CapiT
 interface RealmListT : CapiT
 interface RealmSetT : CapiT
+interface RealmMapT : CapiT
 interface RealmResultsT : CapiT
 interface RealmQueryT : CapiT
 interface RealmCallbackTokenT : CapiT
@@ -82,6 +83,7 @@ typealias FrozenRealmPointer = NativePointer<FrozenRealmT>
 typealias RealmObjectPointer = NativePointer<RealmObjectT>
 typealias RealmListPointer = NativePointer<RealmListT>
 typealias RealmSetPointer = NativePointer<RealmSetT>
+typealias RealmMapPointer = NativePointer<RealmMapT>
 typealias RealmResultsPointer = NativePointer<RealmResultsT>
 typealias RealmQueryPointer = NativePointer<RealmQueryT>
 typealias RealmCallbackTokenPointer = NativePointer<RealmCallbackTokenT>

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/IterableExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/IterableExt.kt
@@ -21,7 +21,7 @@ import io.realm.kotlin.internal.UnmanagedRealmList
 import io.realm.kotlin.internal.UnmanagedRealmSet
 import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmList
-import io.realm.kotlin.types.RealmMapEntrySet
+import io.realm.kotlin.types.RealmDictionaryEntrySet
 import io.realm.kotlin.types.RealmSet
 
 /**
@@ -73,9 +73,9 @@ public fun <T> Iterable<Pair<String, T>>.toRealmDictionary(): RealmDictionary<T>
 
 /**
  * Instantiates an **unmanaged** [RealmDictionary] containing all the elements of the receiver
- * [RealmMapEntrySet].
+ * [RealmDictionaryEntrySet].
  */
-public fun <T> RealmMapEntrySet<String, T>.toRealmDictionary(): RealmDictionary<T> {
+public fun <T> RealmDictionaryEntrySet<T>.toRealmDictionary(): RealmDictionary<T> {
     return when (size) {
         0 -> UnmanagedRealmDictionary()
         else -> map { Pair(it.key, it.value) }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/IterableExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/IterableExt.kt
@@ -20,8 +20,8 @@ import io.realm.kotlin.internal.UnmanagedRealmDictionary
 import io.realm.kotlin.internal.UnmanagedRealmList
 import io.realm.kotlin.internal.UnmanagedRealmSet
 import io.realm.kotlin.types.RealmDictionary
-import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmDictionaryEntrySet
+import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmSet
 
 /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/IterableExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/IterableExt.kt
@@ -16,9 +16,12 @@
 
 package io.realm.kotlin.ext
 
+import io.realm.kotlin.internal.UnmanagedRealmDictionary
 import io.realm.kotlin.internal.UnmanagedRealmList
 import io.realm.kotlin.internal.UnmanagedRealmSet
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmMapEntrySet
 import io.realm.kotlin.types.RealmSet
 
 /**
@@ -47,4 +50,35 @@ public fun <T> Iterable<T>.toRealmSet(): RealmSet<T> {
         }
     }
     return UnmanagedRealmSet<T>().apply { addAll(this@toRealmSet) }
+}
+
+/**
+ * Instantiates an **unmanaged** [RealmDictionary] containing all the elements of this iterable of
+ * [Pair]s of [String]s and [T]s.
+ */
+public fun <T> Iterable<Pair<String, T>>.toRealmDictionary(): RealmDictionary<T> {
+    if (this is Collection) {
+        return when (size) {
+            0 -> UnmanagedRealmDictionary()
+            1 -> realmDictionaryOf(if (this is List) get(0) else iterator().next())
+            else -> UnmanagedRealmDictionary<T>().apply {
+                this.putAll(this@toRealmDictionary)
+            }
+        }
+    }
+    return UnmanagedRealmDictionary<T>().apply {
+        this.putAll(this@toRealmDictionary)
+    }
+}
+
+/**
+ * Instantiates an **unmanaged** [RealmDictionary] containing all the elements of the receiver
+ * [RealmMapEntrySet].
+ */
+public fun <T> RealmMapEntrySet<String, T>.toRealmDictionary(): RealmDictionary<T> {
+    return when (size) {
+        0 -> UnmanagedRealmDictionary()
+        else -> map { Pair(it.key, it.value) }
+            .toRealmDictionary()
+    }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmDictionaryExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmDictionaryExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Realm Inc.
+ * Copyright 2023 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,46 @@
 
 package io.realm.kotlin.ext
 
-// TODO will be added in the next PR
+import io.realm.kotlin.internal.UnmanagedRealmDictionary
+import io.realm.kotlin.internal.asRealmDictionary
+import io.realm.kotlin.types.RealmDictionary
+import io.realm.kotlin.types.RealmMapMutableEntry
 
-// /**
-//  * Instantiates an **unmanaged** [RealmDictionary].
-//  */
-// public fun <T> realmDictionaryOf(vararg elements: T): RealmDictionary<T> = TODO()
+/**
+ * Instantiates an **unmanaged** [RealmDictionary] from a variable number of [Pair]s of [String]
+ * and [T].
+ */
+public fun <T> realmDictionaryOf(vararg elements: Pair<String, T>): RealmDictionary<T> =
+    if (elements.isNotEmpty()) elements.asRealmDictionary() else UnmanagedRealmDictionary()
 
+/**
+ * Instantiates an **unmanaged** [RealmMapMutableEntry] from a [Pair] of [K] and [V]. Entries are
+ * used by the entry set produced by [RealmDictionary.entries]. It is possible to update the entry
+ * which will result in the underlying [RealmDictionary] to be updated too.
+ */
+@Suppress("UnusedPrivateMember") // TODO remove when parameter is used
+public fun <K, V> realmMapEntryOf(pair: Pair<K, V>): RealmMapMutableEntry<K, V> =
+    TODO("Not yet implemented")
+
+/**
+ * Instantiates an **unmanaged** [RealmMapMutableEntry] from a [key]-[value] pair. Entries are used
+ * by the entry set produced by [RealmDictionary.entries]. It is possible to update the entry
+ * which will result in the underlying [RealmDictionary] to be updated too.
+ */
+@Suppress("UnusedPrivateMember") // TODO remove when parameter is used
+public fun <K, V> realmMapEntryOf(key: K, value: V): RealmMapMutableEntry<K, V> =
+    TODO("Not yet implemented")
+
+/**
+ * Instantiates an **unmanaged** [RealmMapMutableEntry] from another [Map.Entry]. Entries are used
+ * by the entry set produced by [RealmDictionary.entries]. It is possible to update the entry
+ * which will result in the underlying [RealmDictionary] to be updated too.
+ */
+@Suppress("UnusedPrivateMember") // TODO remove when parameter is used
+public fun <K, V> realmMapEntryOf(entry: Map.Entry<K, V>): RealmMapMutableEntry<K, V> =
+    TODO("Not yet implemented")
+
+// TODO add support for RealmDictionary<T>.copyFromRealm()
 // /**
 //  * Makes an unmanaged in-memory copy of the elements in a managed [RealmDictionary]. This is a deep
 //  * copy that will copy all referenced objects.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmDictionaryExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmDictionaryExt.kt
@@ -19,6 +19,7 @@ package io.realm.kotlin.ext
 import io.realm.kotlin.internal.UnmanagedRealmDictionary
 import io.realm.kotlin.internal.asRealmDictionary
 import io.realm.kotlin.types.RealmDictionary
+import io.realm.kotlin.types.RealmDictionaryMutableEntry
 import io.realm.kotlin.types.RealmMapMutableEntry
 
 /**
@@ -34,7 +35,7 @@ public fun <T> realmDictionaryOf(vararg elements: Pair<String, T>): RealmDiction
  * which will result in the underlying [RealmDictionary] to be updated too.
  */
 @Suppress("UnusedPrivateMember") // TODO remove when parameter is used
-public fun <K, V> realmMapEntryOf(pair: Pair<K, V>): RealmMapMutableEntry<K, V> =
+public fun <V> realmDictionaryEntryOf(pair: Pair<String, V>): RealmDictionaryMutableEntry<V> =
     TODO("Not yet implemented")
 
 /**
@@ -43,7 +44,7 @@ public fun <K, V> realmMapEntryOf(pair: Pair<K, V>): RealmMapMutableEntry<K, V> 
  * which will result in the underlying [RealmDictionary] to be updated too.
  */
 @Suppress("UnusedPrivateMember") // TODO remove when parameter is used
-public fun <K, V> realmMapEntryOf(key: K, value: V): RealmMapMutableEntry<K, V> =
+public fun <V> realmDictionaryEntryOf(key: String, value: V): RealmDictionaryMutableEntry<V> =
     TODO("Not yet implemented")
 
 /**
@@ -52,7 +53,7 @@ public fun <K, V> realmMapEntryOf(key: K, value: V): RealmMapMutableEntry<K, V> 
  * which will result in the underlying [RealmDictionary] to be updated too.
  */
 @Suppress("UnusedPrivateMember") // TODO remove when parameter is used
-public fun <K, V> realmMapEntryOf(entry: Map.Entry<K, V>): RealmMapMutableEntry<K, V> =
+public fun <V> realmDictionaryEntryOf(entry: Map.Entry<String, V>): RealmDictionaryMutableEntry<V> =
     TODO("Not yet implemented")
 
 // TODO add support for RealmDictionary<T>.copyFromRealm()

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/CollectionOperator.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/CollectionOperator.kt
@@ -16,10 +16,14 @@
 
 package io.realm.kotlin.internal
 
-internal interface CollectionOperator<E> {
+import io.realm.kotlin.internal.interop.CapiT
+import io.realm.kotlin.internal.interop.NativePointer
+
+internal interface CollectionOperator<E, T> {
     val mediator: Mediator
     val realmReference: RealmReference
-    val converter: RealmValueConverter<E>
+    val valueConverter: RealmValueConverter<E>
+    val nativePointer: NativePointer<out CapiT>
 }
 
 internal enum class CollectionOperatorType {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmMapInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmMapInternal.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.internal
+
+import io.realm.kotlin.UpdatePolicy
+import io.realm.kotlin.internal.interop.RealmMapPointer
+import io.realm.kotlin.types.RealmDictionary
+import io.realm.kotlin.types.RealmMap
+import kotlin.reflect.KClass
+
+// ----------------------------------------------------------------------
+// Map
+// ----------------------------------------------------------------------
+
+internal abstract class ManagedRealmMap<K, V>(
+    internal val nativePointer: RealmMapPointer,
+    val operator: MapOperator<K, V>
+) : AbstractMutableMap<K, V>(), RealmMap<K, V> {
+
+    override val entries: MutableSet<MutableMap.MutableEntry<K, V>>
+        get() = TODO("Not yet implemented")
+
+    // TODO missing support for Results Dictionary::get_keys() in C-API: https://github.com/realm/realm-core/issues/6181
+    override val keys: MutableSet<K>
+        get() = TODO("Not yet implemented")
+
+    override val size: Int
+        get() = operator.size
+
+    // TODO update RealmResults to hold primitive values
+    override val values: MutableCollection<V>
+        get() = TODO("Not yet implemented")
+
+    override fun clear() = operator.clear()
+
+    override fun containsKey(key: K): Boolean {
+        // TODO missing support for Dictionary::contains(StringData key) in C-API: https://github.com/realm/realm-core/issues/6181
+        TODO("Not yet implemented")
+    }
+
+    override fun containsValue(value: V): Boolean {
+        // TODO missing support for Dictionary::find_any(Mixed value) in C-API: https://github.com/realm/realm-core/issues/6181
+        TODO("Not yet implemented")
+    }
+
+    override fun get(key: K): V? = TODO("Not yet implemented")
+
+    override fun put(key: K, value: V): V? = TODO("Not yet implemented")
+
+    override fun remove(key: K): V? = TODO("Not yet implemented")
+}
+
+/**
+ * Operator interface abstracting the connection between the API and and the interop layer. It is
+ * used internally by [ManagedRealmMap], [RealmMapEntrySetImpl] and [ManagedRealmMapEntry].
+ */
+internal interface MapOperator<K, V> : CollectionOperator<V, RealmMapPointer> {
+
+    val keyConverter: RealmValueConverter<K>
+    override val nativePointer: RealmMapPointer
+
+    val size: Int
+        get() = TODO("Not yet implemented")
+
+    // This function returns a Pair because it is used by both the Map and the entry Set. Having
+    // both different semantics, Map returns the previous value for the key whereas the entry Set
+    // returns whether the element was inserted successfully.
+    fun insert(
+        key: K,
+        value: V?,
+        updatePolicy: UpdatePolicy = UpdatePolicy.ALL,
+        cache: UnmanagedToManagedObjectCache = mutableMapOf()
+    ): Pair<V?, Boolean>
+
+    // Similarly to insert, Map returns the erased value whereas the entry Set returns whether the
+    // element was erased successfully.
+    fun erase(key: K): Pair<V?, Boolean>
+    fun getEntry(position: Int): Pair<K, V>
+    fun get(key: K): V?
+
+    fun put(
+        key: K,
+        value: V,
+        updatePolicy: UpdatePolicy = UpdatePolicy.ALL,
+        cache: UnmanagedToManagedObjectCache = mutableMapOf()
+    ): V? {
+        TODO("Not yet implemented")
+    }
+
+    fun putAll(
+        from: Map<out K, V>,
+        updatePolicy: UpdatePolicy = UpdatePolicy.ALL,
+        cache: UnmanagedToManagedObjectCache = mutableMapOf()
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    fun remove(key: K): V? {
+        TODO("Not yet implemented")
+    }
+
+    fun clear() {
+        TODO("Not yet implemented")
+    }
+}
+
+internal class PrimitiveMapOperator<K, V>(
+    override val mediator: Mediator,
+    override val realmReference: RealmReference,
+    override val valueConverter: RealmValueConverter<V>,
+    override val keyConverter: RealmValueConverter<K>,
+    override val nativePointer: RealmMapPointer
+) : MapOperator<K, V> {
+
+    override fun insert(
+        key: K,
+        value: V?,
+        updatePolicy: UpdatePolicy,
+        cache: UnmanagedToManagedObjectCache
+    ): Pair<V?, Boolean> {
+        // TODO call realm_dictionary_insert when ready and return a Pair with 'previousValue' and 'inserted'
+        TODO("Not yet implemented")
+    }
+
+    override fun erase(key: K): Pair<V?, Boolean> {
+        realmReference.checkClosed()
+        // TODO call realm_dictionary_erase when ready and return a Pair with 'previousValue' and 'erased'
+        TODO("Not yet implemented")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getEntry(position: Int): Pair<K, V> {
+        realmReference.checkClosed()
+        // TODO call realm_dictionary_get when ready and return a Pair with 'key' and 'value'
+        TODO("Not yet implemented")
+    }
+
+    override fun get(key: K): V? {
+        realmReference.checkClosed()
+        // TODO call realm_dictionary_find when ready and return 'value'
+        TODO("Not yet implemented")
+    }
+}
+
+@Suppress("UnusedPrivateMember") // TODO remove when parameter is used
+internal class RealmObjectMapOperator<K, V>(
+    override val mediator: Mediator,
+    override val realmReference: RealmReference,
+    override val valueConverter: RealmValueConverter<V>,
+    override val keyConverter: RealmValueConverter<K>,
+    override val nativePointer: RealmMapPointer,
+    private val clazz: KClass<V & Any>
+) : MapOperator<K, V> {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun insert(
+        key: K,
+        value: V?,
+        updatePolicy: UpdatePolicy,
+        cache: UnmanagedToManagedObjectCache
+    ): Pair<V?, Boolean> {
+        realmReference.checkClosed()
+        // TODO call realm_dictionary_insert when ready and return a Pair with 'previousValue' and 'inserted'
+        TODO("Not yet implemented")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun erase(key: K): Pair<V?, Boolean> {
+        realmReference.checkClosed()
+        // TODO call realm_dictionary_erase when ready and return a Pair with 'previousValue' and 'erased'
+        TODO("Not yet implemented")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getEntry(position: Int): Pair<K, V> {
+        realmReference.checkClosed()
+        // TODO call realm_dictionary_get when ready and return a Pair with 'key' and 'value'
+        TODO("Not yet implemented")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun get(key: K): V? {
+        realmReference.checkClosed()
+
+        // TODO call realm_dictionary_find when ready and return 'value'
+        TODO("Not yet implemented")
+    }
+}
+
+// ----------------------------------------------------------------------
+// Dictionary
+// ----------------------------------------------------------------------
+
+internal class UnmanagedRealmDictionary<E> : RealmDictionary<E>, MutableMap<String, E> by mutableMapOf()
+
+internal class ManagedRealmDictionary<E>(
+    nativePointer: RealmMapPointer,
+    operator: MapOperator<String, E>
+) : ManagedRealmMap<String, E>(nativePointer, operator), RealmDictionary<E>
+
+// ----------------------------------------------------------------------
+// EntrySet
+// ----------------------------------------------------------------------
+
+// TODO add RealmMapEntrySetImpl: represents a ManagedRealmMap in the form of an
+//  AbstractMutableSet<MutableMap.MutableEntry<K, V>>(). It is also a managed data structure.
+
+// TODO add UnmanagedRealmMapEntry: represents unmanaged entries, used to add unmanaged K-V pairs to
+//  a managed or unmanaged dictionary when working with from dictionary.entries.
+
+// TODO add ManagedRealmMapEntry: represents managed entries obtained when iterating through the
+//  values contained in a (managed) dictionary.entries.
+
+// ----------------------------------------------------------------------
+// Internal helpers for factory functions
+// ----------------------------------------------------------------------
+
+internal fun <T> Map<String, T>.asRealmDictionary(): RealmDictionary<T> =
+    UnmanagedRealmDictionary<T>().apply { putAll(this@asRealmDictionary) }
+
+internal fun <T> Array<out Pair<String, T>>.asRealmDictionary(): RealmDictionary<T> =
+    UnmanagedRealmDictionary<T>().apply { putAll(this@asRealmDictionary) }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmMapInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmMapInternal.kt
@@ -20,6 +20,7 @@ import io.realm.kotlin.UpdatePolicy
 import io.realm.kotlin.internal.interop.RealmMapPointer
 import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmMap
+import io.realm.kotlin.types.RealmMapMutableEntry
 import kotlin.reflect.KClass
 
 // ----------------------------------------------------------------------
@@ -228,6 +229,18 @@ internal class ManagedRealmDictionary<E>(
 // ----------------------------------------------------------------------
 // Internal helpers for factory functions
 // ----------------------------------------------------------------------
+
+@Suppress("UnusedPrivateMember") // TODO remove when parameter is used
+internal fun <K, V> realmMapEntryOf(pair: Pair<K, V>): RealmMapMutableEntry<K, V> =
+    TODO("Not yet implemented")
+
+@Suppress("UnusedPrivateMember") // TODO remove when parameter is used
+internal fun <K, V> realmMapEntryOf(key: K, value: V): RealmMapMutableEntry<K, V> =
+    TODO("Not yet implemented")
+
+@Suppress("UnusedPrivateMember") // TODO remove when parameter is used
+internal fun <K, V> realmMapEntryOf(entry: Map.Entry<K, V>): RealmMapMutableEntry<K, V> =
+    TODO("Not yet implemented")
 
 internal fun <T> Map<String, T>.asRealmDictionary(): RealmDictionary<T> =
     UnmanagedRealmDictionary<T>().apply { putAll(this@asRealmDictionary) }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
@@ -27,15 +27,20 @@ public interface RealmMap<K, V> : MutableMap<K, V>
  */
 public interface RealmDictionary<E> : RealmMap<String, E>
 
-/**
- * Convenience alias for `MutableSet<MutableMap.MutableEntry<K, V>>`. This is the output produced by
- * [Map.entries] and represents a [RealmDictionary] in the form of a [MutableSet] of
- * [RealmMapMutableEntry] values.
- */
-public typealias RealmMapEntrySet<K, V> = MutableSet<MutableMap.MutableEntry<K, V>>
+internal typealias RealmMapEntrySet<K, V> = MutableSet<MutableMap.MutableEntry<K, V>>
+
+internal typealias RealmMapMutableEntry<K, V> = MutableMap.MutableEntry<K, V>
 
 /**
- * Convenience alias for `MutableMap.MutableEntry<K, V>`. Represents the `K`-`V` pairs contained by
- * a [RealmMap].
+ * Convenience alias for `MutableSet<MutableMap.MutableEntry<String, V>>`. This is the output
+ * produced by [RealmDictionary.entries] and represents a [RealmDictionary] in the form of a
+ * [MutableSet] of [RealmDictionaryMutableEntry] values.
  */
-public typealias RealmMapMutableEntry<K, V> = MutableMap.MutableEntry<K, V>
+public typealias RealmDictionaryEntrySet<V> = RealmMapEntrySet<String, V>
+
+/**
+ * Convenience alias for `RealmMapMutableEntry<String, V>`. Represents the `String`-`V` pairs
+ * contained by a [RealmDictionary].
+ */
+public typealias RealmDictionaryMutableEntry<V> = RealmMapMutableEntry<String, V>
+

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
@@ -16,17 +16,26 @@
 
 package io.realm.kotlin.types
 
+/**
+ * TODO
+ */
+// TODO flow and Deleteable
 public interface RealmMap<K, V> : MutableMap<K, V>
 
+/**
+ * TODO
+ */
 public interface RealmDictionary<E> : RealmMap<String, E>
 
-internal class UnmanagedRealmDictionary<E> : RealmDictionary<E>, MutableMap<String, E> by mutableMapOf()
+/**
+ * Convenience alias for `MutableSet<MutableMap.MutableEntry<K, V>>`. This is the output produced by
+ * [Map.entries] and represents a [RealmDictionary] in the form of a [MutableSet] of
+ * [RealmMapMutableEntry] values.
+ */
+public typealias RealmMapEntrySet<K, V> = MutableSet<MutableMap.MutableEntry<K, V>>
 
-internal class ManagedRealmDictionary<E> : AbstractMutableMap<String, E>(), RealmDictionary<E> {
-    override val entries: MutableSet<MutableMap.MutableEntry<String, E>>
-        get() = TODO("Not yet implemented")
-
-    override fun put(key: String, value: E): E? {
-        TODO("Not yet implemented")
-    }
-}
+/**
+ * Convenience alias for `MutableMap.MutableEntry<K, V>`. Represents the `K`-`V` pairs contained by
+ * a [RealmMap].
+ */
+public typealias RealmMapMutableEntry<K, V> = MutableMap.MutableEntry<K, V>

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmMap.kt
@@ -43,4 +43,3 @@ public typealias RealmDictionaryEntrySet<V> = RealmMapEntrySet<String, V>
  * contained by a [RealmDictionary].
  */
 public typealias RealmDictionaryMutableEntry<V> = RealmMapMutableEntry<String, V>
-


### PR DESCRIPTION
- Added the basic infrastructure and API operations with stubs for later implementation. In principle the interfaces should (hopefully) not change in the upcoming pull requests.
- Added helper functions for creating dictionaries as stubs for now.
- Slightly modified some aspects in connection with collection operators for better alignment with lists and sets.

Pull request plan:
- [x] **THIS PR:** basic infrastructure and API: `RealmMap` and `RealmDictionary` interfaces and associated helper functions (stubs)
- [ ] setting up exhaustive testing infrastructure, add support for `copyToRealm` for objects with dictionaries and interface functions `get`, `put`, `putAll`, `remove` and `clear` for all types except `RealmAny` (it will be done once the interface implementation is complete)
- [ ] support for `entries` (i.e. `RealmMapEntrySet`, `UnmanagedRealmMapEntry` and `ManagedRealmMapEntry`) and internal entry set iterator (which enables iterating through the dictionary's k-v pairs externally)
- [ ] `containsKey`, `containsValue` - currently missing support in the C-API (https://github.com/realm/realm-core/issues/6181)
- [ ] `values` - this change entails refactoring `RealmResults` to contain primitive values
- [ ] support for `RealmAny`
- [ ] support for `Deleteable` and `asFlow`
- [ ] support for `copyFromRealm`
- [ ] support for dynamic realms
- [ ] sync testing
- [ ] documentation
- [ ] changelog entry