### PR TITLE
Add missing outputs to cinterop clean task

### DIFF
--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -671,3 +671,10 @@ realmPublish {
             "'io.realm.kotlin:gradle-plugin:${Realm.version}' instead."
     }
 }
+
+tasks.named("clean") {
+    doLast {
+        delete(buildJVMSharedLibs.get().outputs)
+        delete(project.file(".cxx"))
+    }
+}


### PR DESCRIPTION
This ensure that we clean `cinterop` files that are not placed in `cinterop/build`.