### PR TITLE
Replace 'List' with 'RealmList' in inline code comments for Backlinks Example

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmObjectExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmObjectExt.kt
@@ -47,7 +47,7 @@ import kotlin.reflect.KProperty1
  *
  * ```
  * class Parent : RealmObject {
- *  var children: List<Child>? = null
+ *  var children: RealmList<Child>? = null
  * }
  *
  * class Child : RealmObject {


### PR DESCRIPTION
The docs in [backlinks.html](https://www.mongodb.com/docs/realm-sdks/kotlin/latest/library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin.ext/backlinks.html ) show an example of a Parent with a child of type "List" but this should actually be "RealmList"