### PR TITLE
Synchronize access to list of logs

### DIFF
--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
@@ -1319,9 +1319,6 @@ class SyncedRealmTests {
         assertTrue(customLogger.logs.isNotEmpty())
         assertTrue(
             customLogger.logs
-                .onEach {
-                    delay(100)
-                }
                 .filter { it.contains("Connection[1]: Negotiated protocol version:") }
                 .isNotEmpty()
         )

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
@@ -1263,12 +1263,17 @@ class SyncedRealmTests {
     ) : RealmLogger {
 
         private val _logs = mutableListOf<String>()
-        public val logs: List<String>
-            get() = _logs
+        /**
+         * Returns a snapshot of the current state of the logs.
+         */
+        val logs: List<String>
+            get() = synchronized(_logs) { _logs.toList() }
 
         override fun log(level: LogLevel, throwable: Throwable?, message: String?, vararg args: Any?) {
             val logMessage: String = message!!
-            _logs.add(logMessage)
+            synchronized(_logs) {
+                _logs.add(logMessage)
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1235 

This solution is rather slow, but locks are not generally available on Native. 

AtomicFu does have a `SynchronizationObject` that could be locked, but all primitives for that was in a package marked "very much experimental", so I opted for something more stable.  