### PR TITLE
`RealmDictionary` - 8: add support for dynamic realms and add missing support for Decimal128 in `copyFromRealm`

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicMutableRealmObject.kt
@@ -20,6 +20,7 @@ import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.internal.dynamic.DynamicUnmanagedRealmObject
 import io.realm.kotlin.schema.RealmStorageType
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.RealmSet
@@ -37,6 +38,10 @@ public interface DynamicMutableRealmObject : DynamicRealmObject {
     override fun getObjectList(propertyName: String): RealmList<DynamicMutableRealmObject>
 
     override fun getObjectSet(propertyName: String): RealmSet<DynamicMutableRealmObject>
+
+    override fun getObjectDictionary(
+        propertyName: String
+    ): RealmDictionary<DynamicMutableRealmObject>
 
     /**
      * Sets the value for the given field.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicRealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/dynamic/DynamicRealmObject.kt
@@ -21,6 +21,7 @@ import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.schema.RealmStorageType
 import io.realm.kotlin.types.BaseRealmObject
 import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.RealmSet
@@ -99,7 +100,7 @@ public interface DynamicRealmObject : BaseRealmObject {
      *
      * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
      *
-     * To retrieve values, objects or list of nullable elements or object use the `get<X>Value`,
+     * To retrieve values, objects or lists of nullable elements or objects use the `get<X>Value`,
      * [getObject] and other `get<X>List` variants.
      *
      * @param propertyName the name of the list property to retrieve the list for.
@@ -117,8 +118,8 @@ public interface DynamicRealmObject : BaseRealmObject {
      *
      * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
      *
-     * To retrieve values, objects or list of non-nullable elements or object use the `get<X>Value`,
-     * [getObject] and other `get<X>List` variants.
+     * To retrieve values, objects or lists of non-nullable elements or objects use the
+     * `get<X>Value`, [getObject] and other `get<X>List` variants.
      *
      * @param propertyName the name of the list property to retrieve the list for.
      * @param clazz the Kotlin class of the list element type.
@@ -135,7 +136,7 @@ public interface DynamicRealmObject : BaseRealmObject {
      *
      * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
      *
-     * To retrieve values, objects or list of value elements use the `get<X>Value`,
+     * To retrieve values, objects or lists of value elements use the `get<X>Value`,
      * [getObject] and other `get<X>List` variants.
      *
      * @param propertyName the name of the list property to retrieve the list for.
@@ -152,7 +153,7 @@ public interface DynamicRealmObject : BaseRealmObject {
      *
      * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
      *
-     * To retrieve values, objects or set of nullable elements or object use the `get<X>Value`,
+     * To retrieve values, objects or sets of nullable elements or objects use the `get<X>Value`,
      * [getObject] and other `get<X>Set` variants.
      *
      * @param propertyName the name of the set property to retrieve the set for.
@@ -170,8 +171,8 @@ public interface DynamicRealmObject : BaseRealmObject {
      *
      * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
      *
-     * To retrieve values, objects or set of non-nullable elements or object use the `get<X>Value`,
-     * [getObject] and other `get<X>Set` variants.
+     * To retrieve values, objects or sets of non-nullable elements or objects use the
+     * `get<X>Value`, [getObject] and other `get<X>Set` variants.
      *
      * @param propertyName the name of the set property to retrieve the set for.
      * @param clazz the Kotlin class of the set element type.
@@ -188,7 +189,7 @@ public interface DynamicRealmObject : BaseRealmObject {
      *
      * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
      *
-     * To retrieve values, objects or set of value elements use the `get<X>Value`,
+     * To retrieve values, objects or sets of value elements use the `get<X>Value`,
      * [getObject] and other `get<X>Set` variants.
      *
      * @param propertyName the name of the set property to retrieve the set for.
@@ -198,6 +199,66 @@ public interface DynamicRealmObject : BaseRealmObject {
      * property's [RealmStorageType.kClass].
      */
     public fun getObjectSet(propertyName: String): RealmSet<out DynamicRealmObject>
+
+    /**
+     * Returns the dictionary of non-nullable value elements referenced by the property name as a
+     * [RealmDictionary].
+     *
+     * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
+     *
+     * To retrieve values, objects or dictionaries of nullable elements or objects use the
+     * `get<X>Value`, [getObject] and other `get<X>Dictionary` variants.
+     *
+     * @param propertyName the name of the dictionary property to retrieve the dictionary for.
+     * @param clazz the Kotlin class of the dictionary element type.
+     * @param T the type of the dictionary element type.
+     * @return the referenced [RealmDictionary]
+     * @throws IllegalArgumentException if the class doesn't contain a field with the specific
+     * name, if trying to retrieve values for non-dictionary properties or if `clazz` doesn't match
+     * the property's [RealmStorageType.kClass].
+     */
+    public fun <T : Any> getValueDictionary(
+        propertyName: String,
+        clazz: KClass<T>
+    ): RealmDictionary<T>
+
+    /**
+     * Returns the dictionary of nullable elements referenced by the property name as a
+     * [RealmDictionary].
+     *
+     * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
+     *
+     * To retrieve values, objects or dictionaries of non-nullable elements or objects use the
+     * `get<X>Value`, [getObject] and other `get<X>Dictionary` variants.
+     *
+     * @param propertyName the name of the dictionary property to retrieve the dictionary for.
+     * @param clazz the Kotlin class of the dictionary element type.
+     * @param T the type of the dictionary element type.
+     * @return the referenced [RealmDictionary]
+     * @throws IllegalArgumentException if the class doesn't contain a field with the specific
+     * name, if trying to retrieve values for non-dictionary properties or if `clazz` doesn't match
+     * the property's [RealmStorageType.kClass].
+     */
+    public fun <T : Any> getNullableValueDictionary(
+        propertyName: String,
+        clazz: KClass<T>
+    ): RealmDictionary<T?>
+
+    /**
+     * Returns the dictionary of objects referenced by the property name as a [RealmDictionary].
+     *
+     * The `class` argument must be the [KClass] of the [RealmStorageType] for the property.
+     *
+     * To retrieve values, objects or dictionaries of value elements use the `get<X>Value`,
+     * [getObject] and other `get<X>Dictionary` variants.
+     *
+     * @param propertyName the name of the dictionary property to retrieve the dictionary for.
+     * @return the referenced [RealmDictionary]
+     * @throws IllegalArgumentException if the class doesn't contain a field with the specific
+     * name, if trying to retrieve values for non-dictionary properties or if `clazz` doesn't match
+     * the property's [RealmStorageType.kClass].
+     */
+    public fun getObjectDictionary(propertyName: String): RealmDictionary<out DynamicRealmObject>
 
     /**
      * Returns a backlinks collection referenced by the property name as a [RealmResults].
@@ -257,3 +318,19 @@ public inline fun <reified T : Any> DynamicRealmObject.getValueSet(fieldName: St
  */
 public inline fun <reified T : Any> DynamicRealmObject.getNullableValueSet(fieldName: String): RealmSet<T?> =
     this.getNullableValueSet(fieldName, T::class)
+
+/**
+ * Returns the set referenced by the property name as a [RealmDictionary].
+ *
+ * Reified convenience wrapper of [DynamicRealmObject.getValueSet].
+ */
+public inline fun <reified T : Any> DynamicRealmObject.getValueDictionary(fieldName: String): RealmDictionary<T> =
+    this.getValueDictionary(fieldName, T::class)
+
+/**
+ * Returns the set of nullable elements referenced by the property name as a [RealmDictionary].
+ *
+ * Reified convenience wrapper of [DynamicRealmObject.getNullableValueSet].
+ */
+public inline fun <reified T : Any> DynamicRealmObject.getNullableValueDictionary(fieldName: String): RealmDictionary<T?> =
+    this.getNullableValueDictionary(fieldName, T::class)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicMutableRealmObjectImpl.kt
@@ -18,6 +18,7 @@ package io.realm.kotlin.internal.dynamic
 
 import io.realm.kotlin.dynamic.DynamicMutableRealmObject
 import io.realm.kotlin.internal.RealmObjectHelper
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmSet
 import kotlin.reflect.KClass
@@ -95,6 +96,36 @@ internal class DynamicMutableRealmObjectImpl : DynamicMutableRealmObject, Dynami
 
     override fun getObjectSet(propertyName: String): RealmSet<DynamicMutableRealmObject> {
         return getValueSet(propertyName, DynamicMutableRealmObject::class)
+    }
+
+    override fun <T : Any> getValueDictionary(
+        propertyName: String,
+        clazz: KClass<T>
+    ): RealmDictionary<T> {
+        return RealmObjectHelper.dynamicGetDictionary(
+            `io_realm_kotlin_objectReference`!!,
+            propertyName,
+            clazz,
+            nullable = false,
+            issueDynamicMutableObject = true
+        ).let { it as RealmDictionary<T> }
+    }
+
+    override fun <T : Any> getNullableValueDictionary(
+        propertyName: String,
+        clazz: KClass<T>
+    ): RealmDictionary<T?> {
+        return RealmObjectHelper.dynamicGetDictionary(
+            `io_realm_kotlin_objectReference`!!,
+            propertyName,
+            clazz,
+            nullable = true,
+            issueDynamicMutableObject = true
+        )
+    }
+
+    override fun getObjectDictionary(propertyName: String): RealmDictionary<DynamicMutableRealmObject> {
+        return getValueDictionary(propertyName, DynamicMutableRealmObject::class)
     }
 
     override fun <T> set(propertyName: String, value: T): DynamicMutableRealmObject {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicRealmObjectImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicRealmObjectImpl.kt
@@ -22,6 +22,7 @@ import io.realm.kotlin.internal.RealmObjectInternal
 import io.realm.kotlin.internal.RealmObjectReference
 import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmSet
 import kotlin.reflect.KClass
@@ -72,6 +73,25 @@ public open class DynamicRealmObjectImpl : DynamicRealmObject, RealmObjectIntern
 
     override fun getObjectSet(propertyName: String): RealmSet<out DynamicRealmObject> {
         return getValueSet(propertyName, DynamicRealmObject::class)
+    }
+
+    override fun <T : Any> getValueDictionary(
+        propertyName: String,
+        clazz: KClass<T>
+    ): RealmDictionary<T> {
+        return RealmObjectHelper.dynamicGetDictionary(`io_realm_kotlin_objectReference`!!, propertyName, clazz, false)
+            .let { it as RealmDictionary<T> }
+    }
+
+    override fun <T : Any> getNullableValueDictionary(
+        propertyName: String,
+        clazz: KClass<T>
+    ): RealmDictionary<T?> {
+        return RealmObjectHelper.dynamicGetDictionary(`io_realm_kotlin_objectReference`!!, propertyName, clazz, true)
+    }
+
+    override fun getObjectDictionary(propertyName: String): RealmDictionary<out DynamicRealmObject> {
+        return getValueDictionary(propertyName, DynamicRealmObject::class)
     }
 
     override fun getBacklinks(propertyName: String): RealmResults<out DynamicRealmObject> {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicUnmanagedRealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/dynamic/DynamicUnmanagedRealmObject.kt
@@ -2,12 +2,14 @@ package io.realm.kotlin.internal.dynamic
 
 import io.realm.kotlin.dynamic.DynamicMutableRealmObject
 import io.realm.kotlin.dynamic.DynamicRealmObject
+import io.realm.kotlin.ext.realmDictionaryOf
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.realmSetOf
 import io.realm.kotlin.internal.RealmObjectInternal
 import io.realm.kotlin.internal.RealmObjectReference
 import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmSet
 import kotlin.reflect.KClass
@@ -54,12 +56,28 @@ internal class DynamicUnmanagedRealmObject(
         clazz: KClass<T>
     ): RealmSet<T?> = properties.getOrPut(propertyName) { realmSetOf<T?>() } as RealmSet<T?>
 
+    override fun <T : Any> getValueDictionary(
+        propertyName: String,
+        clazz: KClass<T>
+    ): RealmDictionary<T> =
+        properties.getOrPut(propertyName) { realmDictionaryOf<T?>() } as RealmDictionary<T>
+
+    override fun <T : Any> getNullableValueDictionary(
+        propertyName: String,
+        clazz: KClass<T>
+    ): RealmDictionary<T?> =
+        properties.getOrPut(propertyName) { realmDictionaryOf<T?>() } as RealmDictionary<T?>
+
     override fun getBacklinks(propertyName: String): RealmResults<out DynamicRealmObject> =
         throw IllegalStateException("Unmanaged dynamic realm objects do not support backlinks.")
 
     override fun getObjectSet(propertyName: String): RealmSet<DynamicMutableRealmObject> =
         properties.getOrPut(propertyName) { realmSetOf<DynamicMutableRealmObject>() }
             as RealmSet<DynamicMutableRealmObject>
+
+    override fun getObjectDictionary(propertyName: String): RealmDictionary<DynamicMutableRealmObject> =
+        properties.getOrPut(propertyName) { realmDictionaryOf<DynamicMutableRealmObject>() }
+            as RealmDictionary<DynamicMutableRealmObject>
 
     override fun <T> set(propertyName: String, value: T): DynamicMutableRealmObject {
         properties[propertyName] = value as Any

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CopyFromRealmTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CopyFromRealmTests.kt
@@ -549,7 +549,7 @@ class CopyFromRealmTests {
     @Test
     fun objectDictionary() {
         val sample = Sample().apply {
-            nullableObjectDictionaryField = (1..5).map { i ->
+            nullableObjectDictionaryFieldNotNull = (1..5).map { i ->
                 val key = i.toString()
                 val value = Sample().apply { stringField = i.toString() }
                 key to value
@@ -565,11 +565,11 @@ class CopyFromRealmTests {
         realm.close()
 
         assertNotSame(insertedObj, unmanagedObj)
-        assertNotNull(unmanagedObj.nullableObjectDictionaryField)
-        val copiedDictionary: RealmDictionary<Sample?> = unmanagedObj.nullableObjectDictionaryField
+        assertNotNull(unmanagedObj.nullableObjectDictionaryFieldNotNull)
+        val copiedDictionary: RealmDictionary<Sample?> = unmanagedObj.nullableObjectDictionaryFieldNotNull
         assertEquals(5, copiedDictionary.size)
         copiedDictionary.forEach { copiedEntry ->
-            val actual = sample.nullableObjectDictionaryField.filter { expectedEntry ->
+            val actual = sample.nullableObjectDictionaryFieldNotNull.filter { expectedEntry ->
                 assertNotNull(copiedEntry.value).stringField == expectedEntry.value?.stringField
             }.size
 
@@ -608,7 +608,7 @@ class CopyFromRealmTests {
         // Copying collections from a closed Realm should fail
         val managedList: RealmList<Sample> = managedObj.objectListField
         val managedSet: RealmSet<Sample> = managedObj.objectSetField
-        val managedDictionary: RealmDictionary<Sample?> = managedObj.nullableObjectDictionaryField
+        val managedDictionary: RealmDictionary<Sample?> = managedObj.nullableObjectDictionaryFieldNotNull
         val results: RealmResults<Sample> = realm.query<Sample>().find()
 
         realm.close()
@@ -650,13 +650,13 @@ class CopyFromRealmTests {
         val sample = Sample().apply {
             objectListField.add(Sample().apply { stringField = "listObject" })
             objectSetField.add(Sample().apply { stringField = "listObject" })
-            nullableObjectDictionaryField["A"] = Sample().apply { stringField = "listObject" }
+            nullableObjectDictionaryFieldNotNull["A"] = Sample().apply { stringField = "listObject" }
         }
         realm.writeBlocking {
             val liveObj = copyToRealm(sample)
             val liveList = liveObj.objectListField
             val liveSet = liveObj.objectSetField
-            val liveDictionary = liveObj.nullableObjectDictionaryField
+            val liveDictionary = liveObj.nullableObjectDictionaryFieldNotNull
             delete(liveObj)
 
             // Copying deleted objects should fail
@@ -740,7 +740,7 @@ class CopyFromRealmTests {
             nullableObject = topLevelObject
             objectListField = realmListOf(topLevelObject)
             objectSetField = realmSetOf(topLevelObject)
-            nullableObjectDictionaryField = realmDictionaryOf("A" to topLevelObject)
+            nullableObjectDictionaryFieldNotNull = realmDictionaryOf("A" to topLevelObject)
         }
 
         val unmanagedCopy = realm.writeBlocking {
@@ -750,7 +750,7 @@ class CopyFromRealmTests {
         assertSame(unmanagedCopy, unmanagedCopy.nullableObject)
         assertSame(unmanagedCopy, unmanagedCopy.objectListField.first())
         assertSame(unmanagedCopy, unmanagedCopy.objectSetField.first())
-        assertSame(unmanagedCopy, unmanagedCopy.nullableObjectDictionaryField["A"])
+        assertSame(unmanagedCopy, unmanagedCopy.nullableObjectDictionaryFieldNotNull["A"])
     }
 
     @Test
@@ -814,10 +814,10 @@ class CopyFromRealmTests {
                     )
                 }
             )
-            nullableObjectDictionaryField = realmDictionaryOf(
+            nullableObjectDictionaryFieldNotNull = realmDictionaryOf(
                 "A" to Sample().apply {
                     stringField = "dictionary-depth-1"
-                    nullableObjectDictionaryField = realmDictionaryOf(
+                    nullableObjectDictionaryFieldNotNull = realmDictionaryOf(
                         "B" to Sample().apply {
                             stringField = "dictionary-depth-2"
                         }
@@ -834,8 +834,8 @@ class CopyFromRealmTests {
         assertEquals("set-depth-2", managedObj.objectSetField.first().objectSetField.first().stringField)
         assertEquals(
             "dictionary-depth-2",
-            assertNotNull(managedObj.nullableObjectDictionaryField["A"]).let { objLevel1 ->
-                assertNotNull(objLevel1.nullableObjectDictionaryField["B"]).stringField
+            assertNotNull(managedObj.nullableObjectDictionaryFieldNotNull["A"]).let { objLevel1 ->
+                assertNotNull(objLevel1.nullableObjectDictionaryFieldNotNull["B"]).stringField
             }
         )
 
@@ -845,14 +845,14 @@ class CopyFromRealmTests {
         assertEquals("set-depth-1", unmanagedCopy.objectSetField.first().stringField)
         assertEquals(
             "dictionary-depth-1",
-            assertNotNull(unmanagedCopy.nullableObjectDictionaryField["A"]).stringField
+            assertNotNull(unmanagedCopy.nullableObjectDictionaryFieldNotNull["A"]).stringField
         )
         assertNull(unmanagedCopy.nullableObject!!.nullableObject)
         assertEquals(0, unmanagedCopy.objectListField.first().objectListField.size)
         assertEquals(0, unmanagedCopy.objectSetField.first().objectSetField.size)
         assertEquals(
             0,
-            assertNotNull(unmanagedCopy.nullableObjectDictionaryField["A"]).objectSetField.size
+            assertNotNull(unmanagedCopy.nullableObjectDictionaryFieldNotNull["A"]).objectSetField.size
         )
     }
 
@@ -873,7 +873,7 @@ class CopyFromRealmTests {
                 }
             )
             stringDictionaryField = realmDictionaryOf("A" to "foo", "B" to "bar")
-            nullableObjectDictionaryField = realmDictionaryOf(
+            nullableObjectDictionaryFieldNotNull = realmDictionaryOf(
                 "A" to Sample().apply {
                     stringField = "set-depth-1"
                 }
@@ -887,7 +887,7 @@ class CopyFromRealmTests {
         assertNull(unmanagedCopy.nullableObject)
         assertEquals(0, unmanagedCopy.objectListField.size)
         assertEquals(0, unmanagedCopy.objectSetField.size)
-        assertEquals(0, unmanagedCopy.nullableObjectDictionaryField.size)
+        assertEquals(0, unmanagedCopy.nullableObjectDictionaryFieldNotNull.size)
         assertEquals(2, unmanagedCopy.stringListField.size)
         assertEquals(2, unmanagedCopy.stringSetField.size)
         assertEquals(2, unmanagedCopy.stringDictionaryField.size)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicMutableRealmObjectTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicMutableRealmObjectTests.kt
@@ -23,9 +23,11 @@ import io.realm.kotlin.dynamic.DynamicMutableRealm
 import io.realm.kotlin.dynamic.DynamicMutableRealmObject
 import io.realm.kotlin.dynamic.DynamicRealmObject
 import io.realm.kotlin.dynamic.getNullableValue
+import io.realm.kotlin.dynamic.getNullableValueDictionary
 import io.realm.kotlin.dynamic.getNullableValueList
 import io.realm.kotlin.dynamic.getNullableValueSet
 import io.realm.kotlin.dynamic.getValue
+import io.realm.kotlin.dynamic.getValueDictionary
 import io.realm.kotlin.dynamic.getValueList
 import io.realm.kotlin.dynamic.getValueSet
 import io.realm.kotlin.entities.Sample
@@ -34,6 +36,8 @@ import io.realm.kotlin.entities.embedded.embeddedSchemaWithPrimaryKey
 import io.realm.kotlin.entities.primarykey.PrimaryKeyString
 import io.realm.kotlin.ext.asRealmObject
 import io.realm.kotlin.ext.isManaged
+import io.realm.kotlin.ext.realmDictionaryEntryOf
+import io.realm.kotlin.ext.realmDictionaryOf
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.realmSetOf
 import io.realm.kotlin.internal.InternalConfiguration
@@ -51,18 +55,25 @@ import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmAny
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmSet
 import io.realm.kotlin.types.RealmUUID
 import kotlinx.coroutines.test.runTest
+import org.mongodb.kbson.BsonDecimal128
 import org.mongodb.kbson.BsonObjectId
 import org.mongodb.kbson.Decimal128
+import kotlin.reflect.KClass
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Suppress("LargeClass")
@@ -404,19 +415,30 @@ class DynamicMutableRealmObjectTests {
                             linkingObjects.first().getValue(Sample::stringField.name)
                         )
                     } else if (type.isNullable) {
+                        fun <T> assertionsForNullable(
+                            listFromSample: RealmList<T?>,
+                            property: RealmProperty,
+                            value: T,
+                            clazz: KClass<*>
+                        ) {
+                            listFromSample.add(value)
+                            listFromSample.add(null)
+                            val listOfNullable = dynamicSample.getNullableValueList(
+                                property.name,
+                                clazz
+                            )
+                            assertEquals(2, listOfNullable.size)
+                            assertEquals(value, listOfNullable[0])
+                            assertNull(listOfNullable[1])
+                        }
+
                         when (type.storageType) {
-                            RealmStorageType.BOOL -> {
-                                val value = true
-                                dynamicSample.getNullableValueList<Boolean>(property.name)
-                                    .add(value)
-                                dynamicSample.getNullableValueList<Boolean>(property.name).add(null)
-                                val listOfNullable = dynamicSample.getNullableValueList(
-                                    property.name,
-                                    Boolean::class
-                                )
-                                assertEquals(value, listOfNullable[0])
-                                assertEquals(null, listOfNullable[1])
-                            }
+                            RealmStorageType.BOOL -> assertionsForNullable(
+                                dynamicSample.getNullableValueList(property.name),
+                                property,
+                                true,
+                                Boolean::class
+                            )
                             RealmStorageType.INT -> {
                                 val value: Long = when (property.name) {
                                     "nullableByteListField" -> defaultSample.byteField.toLong()
@@ -426,106 +448,65 @@ class DynamicMutableRealmObjectTests {
                                     "nullableLongListField" -> defaultSample.longField
                                     else -> error("Unexpected integral field ${property.name}")
                                 }
-                                dynamicSample.getNullableValueList<Long>(property.name).add(value)
-                                dynamicSample.getNullableValueList<Long>(property.name).add(null)
-                                val listOfNullable =
-                                    dynamicSample.getNullableValueList(property.name, Long::class)
-                                assertEquals(value, listOfNullable[0])
-                                assertEquals(null, listOfNullable[1])
-                            }
-                            RealmStorageType.STRING -> {
-                                val value = "NEW_ELEMENT"
-                                dynamicSample.getNullableValueList<String>(property.name).add(value)
-                                dynamicSample.getNullableValueList<String>(property.name).add(null)
-                                val listOfNullable =
-                                    dynamicSample.getNullableValueList(property.name, String::class)
-                                assertEquals(value, listOfNullable[0])
-                                assertEquals(null, listOfNullable[1])
-                            }
-                            RealmStorageType.FLOAT -> {
-                                val value = 1.234f
-                                dynamicSample.getNullableValueList<Float>(property.name).add(value)
-                                dynamicSample.getNullableValueList<Float>(property.name).add(null)
-                                val listOfNullable =
-                                    dynamicSample.getNullableValueList(property.name, Float::class)
-                                assertEquals(value, listOfNullable[0])
-                                assertEquals(null, listOfNullable[1])
-                            }
-                            RealmStorageType.DOUBLE -> {
-                                val value = 1.234
-                                dynamicSample.getNullableValueList<Double>(property.name).add(value)
-                                dynamicSample.getNullableValueList<Double>(property.name).add(null)
-                                val listOfNullable =
-                                    dynamicSample.getNullableValueList(property.name, Double::class)
-                                assertEquals(value, listOfNullable[0])
-                                assertEquals(null, listOfNullable[1])
-                            }
-                            RealmStorageType.DECIMAL128 -> {
-                                val value = Decimal128("1.84467440731231618E-615")
-                                dynamicSample.getNullableValueList<Decimal128>(property.name).add(value)
-                                dynamicSample.getNullableValueList<Decimal128>(property.name).add(null)
-                                val listOfNullable =
-                                    dynamicSample.getNullableValueList(property.name, Decimal128::class)
-                                assertEquals(value, listOfNullable[0])
-                                assertEquals(null, listOfNullable[1])
-                            }
-                            RealmStorageType.TIMESTAMP -> {
-                                val value = RealmInstant.from(100, 100)
-                                dynamicSample.getNullableValueList<RealmInstant>(property.name)
-                                    .add(value)
-                                dynamicSample.getNullableValueList<RealmInstant>(property.name)
-                                    .add(null)
-                                val listOfNullable = dynamicSample.getNullableValueList(
-                                    property.name,
-                                    RealmInstant::class
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList(property.name),
+                                    property,
+                                    value,
+                                    Long::class
                                 )
-                                assertEquals(value, listOfNullable[0])
-                                assertEquals(null, listOfNullable[1])
                             }
-                            RealmStorageType.OBJECT_ID -> {
-                                when (name) {
-                                    Sample::nullableObjectIdListField.name -> {
-                                        val value = ObjectId.create()
-                                        dynamicSample.getNullableValueList<ObjectId>(property.name)
-                                            .add(value)
-                                        dynamicSample.getNullableValueList<ObjectId>(property.name)
-                                            .add(null)
-                                        val listOfNullable = dynamicSample.getNullableValueList(
-                                            property.name,
-                                            ObjectId::class
-                                        )
-                                        assertEquals(value, listOfNullable[0])
-                                        assertEquals(null, listOfNullable[1])
-                                    }
-                                    Sample::nullableBsonObjectIdListField.name -> {
-                                        val value = BsonObjectId()
-                                        dynamicSample.getNullableValueList<BsonObjectId>(property.name)
-                                            .add(value)
-                                        dynamicSample.getNullableValueList<BsonObjectId>(property.name)
-                                            .add(null)
-                                        val listOfNullable = dynamicSample.getNullableValueList(
-                                            property.name,
-                                            BsonObjectId::class
-                                        )
-                                        assertEquals(value, listOfNullable[0])
-                                        assertEquals(null, listOfNullable[1])
-                                    }
-                                }
-                            }
-                            RealmStorageType.UUID -> {
-                                val value = RealmUUID.random()
-                                dynamicSample.getNullableValueList<RealmUUID>(property.name)
-                                    .add(value)
-                                dynamicSample.getNullableValueList<RealmUUID>(property.name)
-                                    .add(null)
-                                val listOfNullable = dynamicSample.getNullableValueList(
-                                    property.name,
-                                    RealmUUID::class
+                            RealmStorageType.STRING -> assertionsForNullable(
+                                dynamicSample.getNullableValueList(property.name),
+                                property,
+                                "NEW_ELEMENT",
+                                String::class
+                            )
+                            RealmStorageType.FLOAT -> assertionsForNullable(
+                                dynamicSample.getNullableValueList(property.name),
+                                property,
+                                1.234f,
+                                Float::class
+                            )
+                            RealmStorageType.DOUBLE -> assertionsForNullable(
+                                dynamicSample.getNullableValueList(property.name),
+                                property,
+                                1.234,
+                                Double::class
+                            )
+                            RealmStorageType.DECIMAL128 -> assertionsForNullable(
+                                dynamicSample.getNullableValueList(property.name),
+                                property,
+                                Decimal128("1.84467440731231618E-615"),
+                                BsonDecimal128::class
+                            )
+                            RealmStorageType.TIMESTAMP -> assertionsForNullable(
+                                dynamicSample.getNullableValueList(property.name),
+                                property,
+                                RealmInstant.from(100, 100),
+                                RealmInstant::class
+                            )
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::nullableObjectIdListField.name -> assertionsForNullable(
+                                    dynamicSample.getNullableValueList(property.name),
+                                    property,
+                                    ObjectId.create(),
+                                    ObjectId::class
                                 )
-                                assertEquals(value, listOfNullable[0])
-                                assertEquals(null, listOfNullable[1])
+                                Sample::nullableBsonObjectIdListField.name -> assertionsForNullable(
+                                    dynamicSample.getNullableValueList(property.name),
+                                    property,
+                                    BsonObjectId(),
+                                    BsonObjectId::class
+                                )
                             }
+                            RealmStorageType.UUID -> assertionsForNullable(
+                                dynamicSample.getNullableValueList(property.name),
+                                property,
+                                RealmUUID.random(),
+                                RealmUUID::class
+                            )
                             RealmStorageType.BINARY -> {
+                                // TODO use assertionsForNullable when we add support for structural equality for RealmList<ByteArray>
                                 val value = byteArrayOf(42)
                                 dynamicSample.getNullableValueList<ByteArray>(property.name)
                                     .add(value)
@@ -612,15 +593,28 @@ class DynamicMutableRealmObjectTests {
                             else -> error("Model contains untested properties: $property")
                         }
                     } else {
+                        fun <T> assertionsForValue(
+                            listFromSample: RealmList<T>,
+                            property: RealmProperty,
+                            value: T,
+                            clazz: KClass<*>
+                        ) {
+                            listFromSample.add(value)
+                            val valueList = dynamicSample.getValueList(
+                                property.name,
+                                clazz
+                            )
+                            assertEquals(1, valueList.size)
+                            assertEquals(value, valueList[0] as T)
+                        }
+
                         when (type.storageType) {
-                            RealmStorageType.BOOL -> {
-                                val value = true
-                                dynamicSample.getValueList<Boolean>(property.name).add(value)
-                                assertEquals(
-                                    value,
-                                    dynamicSample.getValueList(property.name, Boolean::class)[0]
-                                )
-                            }
+                            RealmStorageType.BOOL -> assertionsForValue(
+                                dynamicSample.getValueList(property.name),
+                                property,
+                                true,
+                                Boolean::class
+                            )
                             RealmStorageType.INT -> {
                                 val value: Long = when (property.name) {
                                     "byteListField" -> defaultSample.byteField.toLong()
@@ -630,91 +624,65 @@ class DynamicMutableRealmObjectTests {
                                     "longListField" -> defaultSample.longField
                                     else -> error("Unexpected integral field ${property.name}")
                                 }
-                                dynamicSample.getValueList<Long>(property.name).add(value)
-                                assertEquals(
+                                assertionsForValue(
+                                    dynamicSample.getValueList(property.name),
+                                    property,
                                     value,
-                                    dynamicSample.getValueList(property.name, Long::class)[0]
+                                    Long::class
                                 )
                             }
-                            RealmStorageType.STRING -> {
-                                val value = "NEW_ELEMENT"
-                                dynamicSample.getValueList<String>(property.name).add(value)
-                                assertEquals(
-                                    value,
-                                    dynamicSample.getValueList(property.name, String::class)[0]
+                            RealmStorageType.STRING -> assertionsForValue(
+                                dynamicSample.getValueList(property.name),
+                                property,
+                                "NEW_ELEMENT",
+                                String::class
+                            )
+                            RealmStorageType.FLOAT -> assertionsForValue(
+                                dynamicSample.getValueList(property.name),
+                                property,
+                                1.234f,
+                                Float::class
+                            )
+                            RealmStorageType.DOUBLE -> assertionsForValue(
+                                dynamicSample.getValueList(property.name),
+                                property,
+                                1.234,
+                                Double::class
+                            )
+                            RealmStorageType.DECIMAL128 -> assertionsForValue(
+                                dynamicSample.getValueList(property.name),
+                                property,
+                                Decimal128("1.84467440731231618E-615"),
+                                BsonDecimal128::class
+                            )
+                            RealmStorageType.TIMESTAMP -> assertionsForValue(
+                                dynamicSample.getValueList(property.name),
+                                property,
+                                RealmInstant.from(100, 100),
+                                RealmInstant::class
+                            )
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::objectIdListField.name -> assertionsForValue(
+                                    dynamicSample.getValueList(property.name),
+                                    property,
+                                    ObjectId.create(),
+                                    ObjectId::class
+                                )
+                                Sample::bsonObjectIdListField.name -> assertionsForValue(
+                                    dynamicSample.getValueList(property.name),
+                                    property,
+                                    BsonObjectId(),
+                                    BsonObjectId::class
                                 )
                             }
-                            RealmStorageType.FLOAT -> {
-                                val value = 1.234f
-                                dynamicSample.getValueList<Float>(property.name).add(value)
-                                assertEquals(
-                                    value,
-                                    dynamicSample.getValueList(property.name, Float::class)[0]
-                                )
-                            }
-                            RealmStorageType.DOUBLE -> {
-                                val value = 1.234
-                                dynamicSample.getValueList<Double>(property.name).add(value)
-                                assertEquals(
-                                    value,
-                                    dynamicSample.getValueList(property.name, Double::class)[0]
-                                )
-                            }
-                            RealmStorageType.DECIMAL128 -> {
-                                val value = Decimal128("1.84467440731231618E-615")
-                                dynamicSample.getValueList<Decimal128>(property.name).add(value)
-                                val listOfNullable =
-                                    dynamicSample.getValueList(property.name, Decimal128::class)
-                                assertEquals(value, listOfNullable[0])
-                            }
-                            RealmStorageType.TIMESTAMP -> {
-                                val value = RealmInstant.from(100, 100)
-                                dynamicSample.getValueList<RealmInstant>(property.name).add(value)
-                                assertEquals(
-                                    value,
-                                    dynamicSample.getValueList(
-                                        property.name,
-                                        RealmInstant::class
-                                    )[0]
-                                )
-                            }
-                            RealmStorageType.OBJECT_ID -> {
-                                when (name) {
-                                    Sample::objectIdListField.name -> {
-                                        val value = ObjectId.create()
-                                        dynamicSample.getValueList<ObjectId>(property.name)
-                                            .add(value)
-                                        assertEquals(
-                                            value,
-                                            dynamicSample.getValueList(
-                                                property.name,
-                                                ObjectId::class
-                                            )[0]
-                                        )
-                                    }
-                                    Sample::bsonObjectIdListField.name -> {
-                                        val value = BsonObjectId()
-                                        dynamicSample.getValueList<BsonObjectId>(property.name)
-                                            .add(value)
-                                        assertEquals(
-                                            value,
-                                            dynamicSample.getValueList(
-                                                property.name,
-                                                BsonObjectId::class
-                                            )[0]
-                                        )
-                                    }
-                                }
-                            }
-                            RealmStorageType.UUID -> {
-                                val value = RealmUUID.random()
-                                dynamicSample.getValueList<RealmUUID>(property.name).add(value)
-                                assertEquals(
-                                    value,
-                                    dynamicSample.getValueList(property.name, RealmUUID::class)[0]
-                                )
-                            }
+                            RealmStorageType.UUID -> assertionsForValue(
+                                dynamicSample.getValueList(property.name),
+                                property,
+                                RealmUUID.random(),
+                                RealmUUID::class
+                            )
                             RealmStorageType.BINARY -> {
+                                // TODO use assertionsForValue when we add support for structural equality for RealmList<ByteArray>
                                 val value = byteArrayOf(42)
                                 dynamicSample.getValueList<ByteArray>(property.name).add(value)
                                 assertContentEquals(
@@ -742,16 +710,30 @@ class DynamicMutableRealmObjectTests {
                 }
                 is SetPropertyType -> {
                     if (type.isNullable) {
+                        fun <T> assertionsForNullable(
+                            setFromSample: RealmSet<T?>,
+                            property: RealmProperty,
+                            value: T,
+                            clazz: KClass<*>
+                        ) {
+                            setFromSample.add(value)
+                            setFromSample.add(null)
+                            val setOfNullable = dynamicSample.getNullableValueSet(
+                                property.name,
+                                clazz
+                            )
+                            assertEquals(2, setOfNullable.size)
+                            assertTrue(setOfNullable.contains(value as Any?))
+                            assertTrue(setOfNullable.contains(null))
+                        }
+
                         when (type.storageType) {
-                            RealmStorageType.BOOL -> {
-                                val value = true
-                                dynamicSample.getNullableValueSet<Boolean>(property.name).add(value)
-                                dynamicSample.getNullableValueSet<Boolean>(property.name).add(null)
-                                val setOfNullable =
-                                    dynamicSample.getNullableValueSet(property.name, Boolean::class)
-                                assertTrue(setOfNullable.contains(value))
-                                assertTrue(setOfNullable.contains(null))
-                            }
+                            RealmStorageType.BOOL -> assertionsForNullable(
+                                dynamicSample.getNullableValueSet(property.name),
+                                property,
+                                true,
+                                Boolean::class
+                            )
                             RealmStorageType.INT -> {
                                 val value: Long = when (property.name) {
                                     "nullableByteSetField" -> defaultSample.byteField.toLong()
@@ -761,109 +743,69 @@ class DynamicMutableRealmObjectTests {
                                     "nullableLongSetField" -> defaultSample.longField
                                     else -> error("Unexpected integral field ${property.name}")
                                 }
-                                dynamicSample.getNullableValueSet<Long>(property.name).add(value)
-                                dynamicSample.getNullableValueSet<Long>(property.name).add(null)
-                                val setOfNullable =
-                                    dynamicSample.getNullableValueSet(property.name, Long::class)
-                                assertTrue(setOfNullable.contains(value))
-                                assertTrue(setOfNullable.contains(null))
-                            }
-                            RealmStorageType.STRING -> {
-                                val value = "NEW_ELEMENT"
-                                dynamicSample.getNullableValueSet<String>(property.name).add(value)
-                                dynamicSample.getNullableValueSet<String>(property.name).add(null)
-                                val setOfNullable =
-                                    dynamicSample.getNullableValueSet(property.name, String::class)
-                                assertTrue(setOfNullable.contains(value))
-                                assertTrue(setOfNullable.contains(null))
-                            }
-                            RealmStorageType.FLOAT -> {
-                                val value = 1.234f
-                                dynamicSample.getNullableValueSet<Float>(property.name).add(value)
-                                dynamicSample.getNullableValueSet<Float>(property.name).add(null)
-                                val setOfNullable =
-                                    dynamicSample.getNullableValueSet(property.name, Float::class)
-                                assertTrue(setOfNullable.contains(value))
-                                assertTrue(setOfNullable.contains(null))
-                            }
-                            RealmStorageType.DOUBLE -> {
-                                val value = 1.234
-                                dynamicSample.getNullableValueSet<Double>(property.name).add(value)
-                                dynamicSample.getNullableValueSet<Double>(property.name).add(null)
-                                val setOfNullable =
-                                    dynamicSample.getNullableValueSet(property.name, Double::class)
-                                assertTrue(setOfNullable.contains(value))
-                                assertTrue(setOfNullable.contains(null))
-                            }
-                            RealmStorageType.TIMESTAMP -> {
-                                val value = RealmInstant.from(100, 100)
-                                dynamicSample.getNullableValueSet<RealmInstant>(property.name)
-                                    .add(value)
-                                dynamicSample.getNullableValueSet<RealmInstant>(property.name)
-                                    .add(null)
-                                val setOfNullable = dynamicSample.getNullableValueSet(
-                                    property.name,
-                                    RealmInstant::class
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name),
+                                    property,
+                                    value,
+                                    Long::class
                                 )
-                                assertTrue(setOfNullable.contains(value))
-                                assertTrue(setOfNullable.contains(null))
                             }
-                            RealmStorageType.OBJECT_ID -> {
-                                when (name) {
-                                    Sample::nullableObjectIdSetField.name -> {
-                                        val value = ObjectId.create()
-                                        dynamicSample.getNullableValueSet<ObjectId>(property.name)
-                                            .add(value)
-                                        dynamicSample.getNullableValueSet<ObjectId>(property.name)
-                                            .add(null)
-                                        val setOfNullable = dynamicSample.getNullableValueSet(
-                                            property.name,
-                                            ObjectId::class
-                                        )
-                                        assertTrue(setOfNullable.contains(value))
-                                        assertTrue(setOfNullable.contains(null))
-                                    }
-                                    Sample::nullableBsonObjectIdSetField.name -> {
-                                        val value = BsonObjectId()
-                                        dynamicSample.getNullableValueSet<BsonObjectId>(property.name)
-                                            .add(value)
-                                        dynamicSample.getNullableValueSet<BsonObjectId>(property.name)
-                                            .add(null)
-                                        val setOfNullable = dynamicSample.getNullableValueSet(
-                                            property.name,
-                                            BsonObjectId::class
-                                        )
-                                        assertTrue(setOfNullable.contains(value))
-                                        assertTrue(setOfNullable.contains(null))
-                                    }
-                                }
-                            }
-                            RealmStorageType.UUID -> {
-                                val value = RealmUUID.random()
-                                dynamicSample.getNullableValueSet<RealmUUID>(property.name)
-                                    .add(value)
-                                dynamicSample.getNullableValueSet<RealmUUID>(property.name)
-                                    .add(null)
-                                val setOfNullable = dynamicSample.getNullableValueSet(
-                                    property.name,
-                                    RealmUUID::class
+                            RealmStorageType.STRING -> assertionsForNullable(
+                                dynamicSample.getNullableValueSet(property.name),
+                                property,
+                                "NEW_ELEMENT",
+                                String::class
+                            )
+                            RealmStorageType.FLOAT -> assertionsForNullable(
+                                dynamicSample.getNullableValueSet(property.name),
+                                property,
+                                1.234f,
+                                Float::class
+                            )
+                            RealmStorageType.DOUBLE -> assertionsForNullable(
+                                dynamicSample.getNullableValueSet(property.name),
+                                property,
+                                1.234,
+                                Double::class
+                            )
+                            RealmStorageType.TIMESTAMP -> assertionsForNullable(
+                                dynamicSample.getNullableValueSet(property.name),
+                                property,
+                                RealmInstant.from(100, 100),
+                                RealmInstant::class
+                            )
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::nullableObjectIdSetField.name -> assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name),
+                                    property,
+                                    ObjectId.create(),
+                                    ObjectId::class
                                 )
-                                assertTrue(setOfNullable.contains(value))
-                                assertTrue(setOfNullable.contains(null))
-                            }
-                            RealmStorageType.BINARY -> {
-                                val value = byteArrayOf(42)
-                                dynamicSample.getNullableValueSet<ByteArray>(property.name)
-                                    .add(value)
-                                dynamicSample.getNullableValueSet<ByteArray>(property.name)
-                                    .add(null)
-                                val setOfNullable = dynamicSample.getNullableValueSet(
-                                    property.name,
-                                    ByteArray::class
+                                Sample::nullableBsonObjectIdSetField.name -> assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name),
+                                    property,
+                                    BsonObjectId(),
+                                    BsonObjectId::class
                                 )
-                                assertTrue(setOfNullable.contains(value))
-                                assertTrue(setOfNullable.contains(null))
                             }
+                            RealmStorageType.UUID -> assertionsForNullable(
+                                dynamicSample.getNullableValueSet(property.name),
+                                property,
+                                RealmUUID.random(),
+                                RealmUUID::class
+                            )
+                            RealmStorageType.BINARY -> assertionsForNullable(
+                                dynamicSample.getNullableValueSet(property.name),
+                                property,
+                                byteArrayOf(42),
+                                ByteArray::class
+                            )
+                            RealmStorageType.DECIMAL128 -> assertionsForNullable(
+                                dynamicSample.getNullableValueSet(property.name),
+                                property,
+                                Decimal128("1.84467440731231618E-615"),
+                                Decimal128::class
+                            )
                             RealmStorageType.ANY -> {
                                 // Check writing a regular object using the Dynamic API throws
                                 val objectValue = RealmAny.create(
@@ -938,15 +880,25 @@ class DynamicMutableRealmObjectTests {
                             else -> error("Model contains untested properties: $property")
                         }
                     } else {
+                        fun <T> assertionsForValue(
+                            setFromSample: RealmSet<T>,
+                            property: RealmProperty,
+                            value: T,
+                            clazz: KClass<*>
+                        ) {
+                            setFromSample.add(value)
+                            val setOfValue = dynamicSample.getValueSet(property.name, clazz)
+                            assertEquals(1, setOfValue.size)
+                            assertTrue(setOfValue.contains(value as Any))
+                        }
+
                         when (type.storageType) {
-                            RealmStorageType.BOOL -> {
-                                val value = true
-                                dynamicSample.getValueSet<Boolean>(property.name).add(value)
-                                assertTrue(
-                                    dynamicSample.getValueSet(property.name, Boolean::class)
-                                        .contains(value)
-                                )
-                            }
+                            RealmStorageType.BOOL -> assertionsForValue(
+                                dynamicSample.getValueSet(property.name),
+                                property,
+                                true,
+                                Boolean::class
+                            )
                             RealmStorageType.INT -> {
                                 val value: Long = when (property.name) {
                                     "byteSetField" -> defaultSample.byteField.toLong()
@@ -956,92 +908,69 @@ class DynamicMutableRealmObjectTests {
                                     "longSetField" -> defaultSample.longField
                                     else -> error("Unexpected integral field ${property.name}")
                                 }
-                                dynamicSample.getValueSet<Long>(property.name).add(value)
-                                assertTrue(
-                                    dynamicSample.getValueSet(property.name, Long::class)
-                                        .contains(value)
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    property,
+                                    value,
+                                    Long::class
                                 )
                             }
-                            RealmStorageType.STRING -> {
-                                val value = "NEW_ELEMENT"
-                                dynamicSample.getValueSet<String>(property.name).add(value)
-                                assertTrue(
-                                    dynamicSample.getValueSet(property.name, String::class)
-                                        .contains(value)
+                            RealmStorageType.STRING -> assertionsForValue(
+                                dynamicSample.getValueSet(property.name),
+                                property,
+                                "NEW_ELEMENT",
+                                String::class
+                            )
+                            RealmStorageType.FLOAT -> assertionsForValue(
+                                dynamicSample.getValueSet(property.name),
+                                property,
+                                1.234f,
+                                Float::class
+                            )
+                            RealmStorageType.DOUBLE -> assertionsForValue(
+                                dynamicSample.getValueSet(property.name),
+                                property,
+                                1.234,
+                                Double::class
+                            )
+                            RealmStorageType.TIMESTAMP -> assertionsForValue(
+                                dynamicSample.getValueSet(property.name),
+                                property,
+                                RealmInstant.from(100, 100),
+                                RealmInstant::class
+                            )
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::objectIdSetField.name -> assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    property,
+                                    ObjectId.create(),
+                                    ObjectId::class
+                                )
+                                Sample::bsonObjectIdSetField.name -> assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    property,
+                                    BsonObjectId(),
+                                    BsonObjectId::class
                                 )
                             }
-                            RealmStorageType.FLOAT -> {
-                                val value = 1.234f
-                                dynamicSample.getValueSet<Float>(property.name).add(value)
-                                assertTrue(
-                                    dynamicSample.getValueSet(property.name, Float::class)
-                                        .contains(value)
-                                )
-                            }
-                            RealmStorageType.DOUBLE -> {
-                                val value = 1.234
-                                dynamicSample.getValueSet<Double>(property.name).add(value)
-                                assertTrue(
-                                    dynamicSample.getValueSet(property.name, Double::class)
-                                        .contains(value)
-                                )
-                            }
-                            RealmStorageType.TIMESTAMP -> {
-                                val value = RealmInstant.from(100, 100)
-                                dynamicSample.getValueSet<RealmInstant>(property.name).add(value)
-                                assertTrue(
-                                    dynamicSample.getValueSet(
-                                        property.name,
-                                        RealmInstant::class
-                                    ).contains(value)
-                                )
-                            }
-                            RealmStorageType.OBJECT_ID -> {
-                                when (name) {
-                                    Sample::objectIdSetField.name -> {
-                                        val value = ObjectId.create()
-                                        dynamicSample.getValueSet<ObjectId>(property.name)
-                                            .add(value)
-                                        assertTrue(
-                                            dynamicSample.getValueSet(
-                                                property.name,
-                                                ObjectId::class
-                                            ).contains(value)
-                                        )
-                                    }
-                                    Sample::bsonObjectIdSetField.name -> {
-                                        val value = BsonObjectId()
-                                        dynamicSample.getValueSet<BsonObjectId>(property.name)
-                                            .add(value)
-                                        assertTrue(
-                                            dynamicSample.getValueSet(
-                                                property.name,
-                                                BsonObjectId::class
-                                            ).contains(value)
-                                        )
-                                    }
-                                }
-                            }
-                            RealmStorageType.UUID -> {
-                                val value = RealmUUID.random()
-                                dynamicSample.getValueSet<RealmUUID>(property.name).add(value)
-                                assertTrue(
-                                    dynamicSample.getValueSet(
-                                        property.name,
-                                        RealmUUID::class
-                                    ).contains(value)
-                                )
-                            }
-                            RealmStorageType.BINARY -> {
-                                val value = byteArrayOf(42)
-                                dynamicSample.getValueSet<ByteArray>(property.name).add(value)
-                                assertTrue(
-                                    dynamicSample.getValueSet(
-                                        property.name,
-                                        ByteArray::class
-                                    ).contains(value)
-                                )
-                            }
+                            RealmStorageType.UUID -> assertionsForValue(
+                                dynamicSample.getValueSet(property.name),
+                                property,
+                                RealmUUID.random(),
+                                RealmUUID::class
+                            )
+                            RealmStorageType.BINARY -> assertionsForValue(
+                                dynamicSample.getValueSet(property.name),
+                                property,
+                                byteArrayOf(42),
+                                ByteArray::class
+                            )
+                            RealmStorageType.DECIMAL128 -> assertionsForValue(
+                                dynamicSample.getValueSet(property.name),
+                                property,
+                                Decimal128("1.84467440731231618E-615"),
+                                BsonDecimal128::class
+                            )
                             RealmStorageType.OBJECT -> {
                                 val value = dynamicMutableRealm.copyToRealm(
                                     DynamicMutableRealmObject.create("Sample")
@@ -1065,7 +994,339 @@ class DynamicMutableRealmObjectTests {
                     }
                 }
                 is DictionaryPropertyType -> {
-                    // TODO add support for dictionaries in dynamic realms
+                    if (type.isNullable) {
+                        fun <T> assertionsForNullable(
+                            dictionaryFromSample: RealmDictionary<T?>,
+                            property: RealmProperty,
+                            value: T,
+                            clazz: KClass<*>
+                        ) {
+                            dictionaryFromSample["A"] = value
+                            dictionaryFromSample["B"] = null
+                            val dictionaryOfNullable = dynamicSample.getNullableValueDictionary(
+                                property.name,
+                                clazz
+                            )
+                            assertEquals(2, dictionaryOfNullable.size)
+                            assertTrue(dictionaryOfNullable.containsKey("A"))
+                            assertTrue(dictionaryOfNullable.containsKey("B"))
+                            assertFalse(dictionaryOfNullable.containsKey("C"))
+                            assertTrue(dictionaryOfNullable.containsValue(value as Any?))
+                            assertTrue(dictionaryOfNullable.containsValue(null))
+                            dictionaryOfNullable.entries.also { entries ->
+                                assertTrue(
+                                    entries.contains(realmDictionaryEntryOf("A" to value as Any?))
+                                )
+                                assertTrue(
+                                    entries.contains(realmDictionaryEntryOf("B" to null))
+                                )
+                            }
+                        }
+
+                        when (type.storageType) {
+                            RealmStorageType.BOOL -> assertionsForNullable(
+                                dynamicSample.getNullableValueDictionary(property.name),
+                                property,
+                                true,
+                                Boolean::class
+                            )
+                            RealmStorageType.INT -> {
+                                val value: Long = when (property.name) {
+                                    "nullableByteDictionaryField" -> defaultSample.byteField.toLong()
+                                    "nullableCharDictionaryField" -> defaultSample.charField.code.toLong()
+                                    "nullableShortDictionaryField" -> defaultSample.shortField.toLong()
+                                    "nullableIntDictionaryField" -> defaultSample.intField.toLong()
+                                    "nullableLongDictionaryField" -> defaultSample.longField
+                                    else -> error("Unexpected integral field ${property.name}")
+                                }
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(property.name),
+                                    property,
+                                    value,
+                                    Long::class
+                                )
+                            }
+                            RealmStorageType.STRING -> assertionsForNullable(
+                                dynamicSample.getNullableValueDictionary(property.name),
+                                property,
+                                "NEW_ELEMENT",
+                                String::class
+                            )
+                            RealmStorageType.BINARY -> assertionsForNullable(
+                                dynamicSample.getNullableValueDictionary(property.name),
+                                property,
+                                byteArrayOf(42),
+                                ByteArray::class
+                            )
+                            RealmStorageType.OBJECT -> {
+                                val value = dynamicMutableRealm.copyToRealm(
+                                    DynamicMutableRealmObject.create("Sample")
+                                ).set("stringField", "NEW_OBJECT")
+                                dynamicSample.getNullableValueDictionary<DynamicRealmObject>(property.name)["A"] =
+                                    value
+                                dynamicSample.getNullableValueDictionary<DynamicRealmObject>(property.name)["B"] =
+                                    null
+
+                                val nullableObjDictionary =
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        DynamicRealmObject::class
+                                    )
+                                assertEquals(2, nullableObjDictionary.size)
+                                assertTrue(nullableObjDictionary.containsKey("A"))
+                                assertTrue(nullableObjDictionary.containsKey("B"))
+                                assertFalse(nullableObjDictionary.containsKey("C"))
+                                nullableObjDictionary["A"].also { obj ->
+                                    assertNotNull(obj)
+                                    assertEquals(
+                                        "NEW_OBJECT",
+                                        obj.getValue("stringField")
+                                    )
+                                }
+                            }
+                            RealmStorageType.FLOAT -> assertionsForNullable(
+                                dynamicSample.getNullableValueDictionary(property.name),
+                                property,
+                                1.234f,
+                                Float::class
+                            )
+                            RealmStorageType.DOUBLE -> assertionsForNullable(
+                                dynamicSample.getNullableValueDictionary(property.name),
+                                property,
+                                1.234,
+                                Double::class
+                            )
+                            RealmStorageType.DECIMAL128 -> assertionsForNullable(
+                                dynamicSample.getNullableValueDictionary(property.name),
+                                property,
+                                Decimal128("1.84467440731231618E-615"),
+                                Decimal128::class
+                            )
+                            RealmStorageType.TIMESTAMP -> assertionsForNullable(
+                                dynamicSample.getNullableValueDictionary(property.name),
+                                property,
+                                RealmInstant.from(100, 100),
+                                RealmInstant::class
+                            )
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::objectIdSetField.name -> assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(property.name),
+                                    property,
+                                    ObjectId.create(),
+                                    ObjectId::class
+                                )
+                                Sample::bsonObjectIdSetField.name -> assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(property.name),
+                                    property,
+                                    BsonObjectId(),
+                                    BsonObjectId::class
+                                )
+                            }
+                            RealmStorageType.UUID -> assertionsForNullable(
+                                dynamicSample.getNullableValueDictionary(property.name),
+                                property,
+                                RealmUUID.random(),
+                                RealmUUID::class
+                            )
+                            RealmStorageType.ANY -> {
+                                // Check writing a regular object using the Dynamic API throws
+                                val objectValue = RealmAny.create(
+                                    PrimaryKeyString(),
+                                    PrimaryKeyString::class
+                                )
+                                assertFailsWith<ClassCastException> {
+                                    dynamicSample.set(
+                                        name,
+                                        realmDictionaryOf<RealmAny?>("A" to objectValue)
+                                    )
+                                }
+
+                                // Test we can set null ...
+                                dynamicSample.set(name, realmDictionaryOf<RealmAny?>("A" to null))
+                                dynamicSample.getNullableValueDictionary<RealmAny>(name)
+                                    .also { dictionary ->
+                                        assertEquals(1, dictionary.size)
+                                        assertNull(dictionary["A"])
+                                    }
+
+                                // ... and primitives...
+                                val value = RealmAny.create(42)
+                                dynamicSample.set(name, realmDictionaryOf<RealmAny?>("A" to value))
+                                dynamicSample.getNullableValueDictionary<RealmAny>(name)
+                                    .also { dictionary ->
+                                        assertEquals(1, dictionary.size)
+                                        assertEquals(value, dictionary["A"])
+                                    }
+
+                                // ... and dynamic mutable unmanaged objects ...
+                                DynamicMutableRealmObject.create(
+                                    "Sample",
+                                    mapOf("stringField" to "Custom1")
+                                ).also { dynamicMutableUnmanagedObject ->
+                                    val dynamicRealmAny =
+                                        RealmAny.create(dynamicMutableUnmanagedObject)
+                                    dynamicSample.set(name, realmDictionaryOf("A" to dynamicRealmAny))
+                                    val expectedValue =
+                                        dynamicMutableUnmanagedObject.getValue<String>("stringField")
+                                    val actualDictionary =
+                                        dynamicSample.getNullableValueDictionary<RealmAny>(name)
+                                    assertEquals(1, actualDictionary.size)
+                                    val actualValue = actualDictionary["A"]
+                                        ?.asRealmObject<DynamicRealmObject>()
+                                        ?.getValue<String>("stringField")
+                                    assertEquals(expectedValue, actualValue)
+                                }
+
+                                // ... and dynamic mutable managed objects
+                                dynamicMutableRealm.copyToRealm(
+                                    DynamicMutableRealmObject.create(
+                                        "Sample",
+                                        mapOf("stringField" to "Custom2")
+                                    )
+                                ).also { dynamicMutableManagedObject ->
+                                    val dynamicRealmAny =
+                                        RealmAny.create(dynamicMutableManagedObject)
+                                    dynamicSample.set(name, realmDictionaryOf("A" to dynamicRealmAny))
+                                    val expectedValue =
+                                        dynamicMutableManagedObject.getValue<String>("stringField")
+                                    val actualDictionary =
+                                        dynamicSample.getNullableValueDictionary<RealmAny>(name)
+                                    assertEquals(1, actualDictionary.size)
+                                    val managedDynamicMutableObject = actualDictionary["A"]
+                                        ?.asRealmObject<DynamicMutableRealmObject>()
+                                    val actualValue = managedDynamicMutableObject?.getValue<String>("stringField")
+                                    assertEquals(expectedValue, actualValue)
+
+                                    // Check we did indeed get a dynamic mutable object
+                                    managedDynamicMutableObject?.set("stringField", "NEW")
+                                    assertEquals("NEW", managedDynamicMutableObject?.getValue("stringField"))
+                                }
+                            }
+                            else -> error("Model contains untested properties: $property")
+                        }
+                    } else {
+                        fun <T> assertionsForValue(
+                            dictionaryFromSample: RealmDictionary<T>,
+                            property: RealmProperty,
+                            value: T,
+                            clazz: KClass<*>
+                        ) {
+                            dictionaryFromSample["A"] = value
+                            val dictionaryOfValue = dynamicSample.getValueDictionary(
+                                property.name,
+                                clazz
+                            )
+                            assertEquals(1, dictionaryOfValue.size)
+                            assertTrue(dictionaryOfValue.containsKey("A"))
+                            assertFalse(dictionaryOfValue.containsKey("B"))
+                            assertTrue(dictionaryOfValue.containsValue(value as Any))
+                            assertTrue(
+                                dictionaryOfValue.entries
+                                    .contains(realmDictionaryEntryOf("A" to value as Any))
+                            )
+                        }
+                        when (type.storageType) {
+                            RealmStorageType.BOOL -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                property,
+                                true,
+                                Boolean::class
+                            )
+                            RealmStorageType.INT -> {
+                                val value: Long = when (property.name) {
+                                    "byteDictionaryField" -> defaultSample.byteField.toLong()
+                                    "charDictionaryField" -> defaultSample.charField.code.toLong()
+                                    "shortDictionaryField" -> defaultSample.shortField.toLong()
+                                    "intDictionaryField" -> defaultSample.intField.toLong()
+                                    "longDictionaryField" -> defaultSample.longField
+                                    else -> error("Unexpected integral field ${property.name}")
+                                }
+                                assertionsForValue(
+                                    dynamicSample.getValueDictionary(property.name),
+                                    property,
+                                    value,
+                                    Long::class
+                                )
+                            }
+                            RealmStorageType.STRING -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                property,
+                                "NEW_ELEMENT",
+                                String::class
+                            )
+                            RealmStorageType.BINARY -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                property,
+                                byteArrayOf(42),
+                                ByteArray::class
+                            )
+                            RealmStorageType.OBJECT -> {
+                                val value = dynamicMutableRealm.copyToRealm(
+                                    DynamicMutableRealmObject.create("Sample")
+                                ).set("stringField", "NEW_OBJECT")
+                                dynamicSample.getValueDictionary<DynamicRealmObject>(property.name)["A"] =
+                                    value
+
+                                val objDictionary = dynamicSample.getValueDictionary(
+                                    property.name,
+                                    DynamicRealmObject::class
+                                )
+                                assertEquals(1, objDictionary.size)
+                                assertTrue(objDictionary.containsKey("A"))
+                                assertFalse(objDictionary.containsKey("B"))
+                                val objFromDictionary = assertNotNull(objDictionary["A"])
+                                assertEquals(
+                                    "NEW_OBJECT",
+                                    objFromDictionary.getValue<String>("stringField")
+                                )
+                            }
+                            RealmStorageType.FLOAT -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                property,
+                                1.234F,
+                                Float::class
+                            )
+                            RealmStorageType.DOUBLE -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                property,
+                                1.234,
+                                Double::class
+                            )
+                            RealmStorageType.DECIMAL128 -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                property,
+                                Decimal128("1.84467440731231618E-615"),
+                                Decimal128::class
+                            )
+                            RealmStorageType.TIMESTAMP -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                property,
+                                RealmInstant.from(100, 100),
+                                RealmInstant::class
+                            )
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::objectIdSetField.name -> assertionsForValue(
+                                    dynamicSample.getValueDictionary(property.name),
+                                    property,
+                                    ObjectId.create(),
+                                    ObjectId::class
+                                )
+                                Sample::bsonObjectIdSetField.name -> assertionsForValue(
+                                    dynamicSample.getValueDictionary(property.name),
+                                    property,
+                                    BsonObjectId(),
+                                    BsonObjectId::class
+                                )
+                            }
+                            RealmStorageType.UUID -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                property,
+                                RealmUUID.random(),
+                                RealmUUID::class
+                            )
+                            else -> error("Model contains untested properties: $property")
+                        }
+                    }
                 }
             }
             // TODO There is currently nothing that assert that we have tested all type

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicRealmObjectTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicRealmObjectTests.kt
@@ -22,15 +22,18 @@ import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.dynamic.DynamicRealmObject
 import io.realm.kotlin.dynamic.getNullableValue
+import io.realm.kotlin.dynamic.getNullableValueDictionary
 import io.realm.kotlin.dynamic.getNullableValueList
 import io.realm.kotlin.dynamic.getNullableValueSet
 import io.realm.kotlin.dynamic.getValue
+import io.realm.kotlin.dynamic.getValueDictionary
 import io.realm.kotlin.dynamic.getValueList
 import io.realm.kotlin.dynamic.getValueSet
 import io.realm.kotlin.entities.Sample
 import io.realm.kotlin.ext.asFlow
 import io.realm.kotlin.ext.asRealmObject
 import io.realm.kotlin.ext.query
+import io.realm.kotlin.ext.realmDictionaryOf
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.toRealmSet
 import io.realm.kotlin.internal.asDynamicRealm
@@ -45,7 +48,10 @@ import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmAny
+import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmSet
 import io.realm.kotlin.types.RealmUUID
 import org.mongodb.kbson.BsonObjectId
 import org.mongodb.kbson.Decimal128
@@ -486,154 +492,132 @@ class DynamicRealmObjectTests {
                             else -> error("Model contains untested properties: $property")
                         }
                     } else if (type.isNullable) {
+                        fun <T> assertionsForNullable(listFromSample: RealmList<T?>) {
+                            assertNull(listFromSample[0])
+                        }
+
                         when (type.storageType) {
                             RealmStorageType.BOOL -> {
-                                assertEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<Boolean>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<Boolean>(property.name)
                                 )
-                                assertEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         Boolean::class
-                                    )[0]
+                                    )
                                 )
                             }
                             RealmStorageType.INT -> {
-                                assertEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<Long>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<Long>(property.name)
                                 )
-                                assertEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         Long::class
-                                    )[0]
+                                    )
                                 )
                             }
                             RealmStorageType.STRING -> {
-                                assertEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<String>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<String>(property.name)
                                 )
-                                assertEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         String::class
-                                    )[0]
+                                    )
                                 )
                             }
                             RealmStorageType.FLOAT -> {
-                                assertEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<Float>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<Float>(property.name)
                                 )
-                                assertEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         Float::class
-                                    )[0]
+                                    )
                                 )
                             }
                             RealmStorageType.DOUBLE -> {
-                                assertEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<Double>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<Double>(property.name)
                                 )
-                                assertEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         Double::class
-                                    )[0]
+                                    )
                                 )
                             }
                             RealmStorageType.DECIMAL128 -> {
-                                assertEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<Decimal128>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<Decimal128>(property.name)
                                 )
-                                assertEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         Decimal128::class
-                                    )[0]
+                                    )
                                 )
                             }
                             RealmStorageType.TIMESTAMP -> {
-                                assertEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<RealmInstant>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<RealmInstant>(property.name)
                                 )
-                                assertEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         RealmInstant::class
-                                    )[0]
+                                    )
                                 )
                             }
-                            RealmStorageType.OBJECT_ID -> {
-                                when (name) {
-                                    Sample::nullableObjectIdField.name -> {
-                                        assertEquals(
-                                            null,
-                                            dynamicSample.getNullableValueList<ObjectId>(
-                                                property.name
-                                            )[0]
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::nullableObjectIdField.name -> {
+                                    assertionsForNullable(
+                                        dynamicSample.getNullableValueList<ObjectId>(property.name)
+                                    )
+                                    assertionsForNullable(
+                                        dynamicSample.getNullableValueList(
+                                            property.name,
+                                            ObjectId::class
                                         )
-                                        assertEquals(
-                                            null,
-                                            dynamicSample.getNullableValueList(
-                                                property.name,
-                                                ObjectId::class
-                                            )[0]
+                                    )
+                                }
+                                Sample::nullableBsonObjectIdField.name -> {
+                                    assertionsForNullable(
+                                        dynamicSample.getNullableValueList<BsonObjectId>(property.name)
+                                    )
+                                    assertionsForNullable(
+                                        dynamicSample.getNullableValueList(
+                                            property.name,
+                                            BsonObjectId::class
                                         )
-                                    }
-                                    Sample::nullableBsonObjectIdField.name -> {
-                                        assertEquals(
-                                            null,
-                                            dynamicSample.getNullableValueList<ObjectId>(property.name)[0]
-                                        )
-                                        assertEquals(
-                                            null,
-                                            dynamicSample.getNullableValueList(
-                                                property.name,
-                                                ObjectId::class
-                                            )[0]
-                                        )
-                                    }
+                                    )
                                 }
                             }
                             RealmStorageType.UUID -> {
-                                assertEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<RealmUUID>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<RealmUUID>(property.name)
                                 )
-                                assertEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         RealmUUID::class
-                                    )[0]
+                                    )
                                 )
                             }
                             RealmStorageType.BINARY -> {
-                                assertContentEquals(
-                                    null,
-                                    dynamicSample.getNullableValueList<ByteArray>(property.name)[0]
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueList<ByteArray>(property.name)
                                 )
-                                assertContentEquals(
-                                    null,
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueList(
                                         property.name,
                                         ByteArray::class
-                                    )[0]
+                                    )
                                 )
                             }
                             RealmStorageType.OBJECT -> {
@@ -824,115 +808,98 @@ class DynamicRealmObjectTests {
                 }
                 is SetPropertyType -> {
                     if (type.isNullable) {
+                        fun <T> assertionsForNullable(setFromSample: RealmSet<T?>) {
+                            assertNull(setFromSample.first())
+                        }
+
                         when (type.storageType) {
                             RealmStorageType.BOOL -> {
-                                assertNull(
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueSet<Boolean>(property.name)
-                                        .first()
                                 )
-                                assertNull(
-                                    dynamicSample.getNullableValueSet(
-                                        property.name,
-                                        Boolean::class
-                                    ).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name, Boolean::class)
                                 )
                             }
                             RealmStorageType.INT -> {
-                                assertNull(
-                                    dynamicSample.getNullableValueSet<Long>(property.name).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet<Long>(property.name)
                                 )
-                                assertNull(
-                                    dynamicSample.getNullableValueSet(
-                                        property.name,
-                                        Long::class
-                                    ).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name, Long::class)
                                 )
                             }
                             RealmStorageType.STRING -> {
-                                assertNull(
-                                    dynamicSample.getNullableValueSet<String>(property.name).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet<String>(property.name)
                                 )
-                                assertNull(
-                                    dynamicSample.getNullableValueSet(
-                                        property.name,
-                                        String::class
-                                    ).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name, String::class)
                                 )
                             }
                             RealmStorageType.FLOAT -> {
-                                assertNull(
-                                    dynamicSample.getNullableValueSet<Float>(property.name).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet<Float>(property.name)
                                 )
-                                assertNull(
-                                    dynamicSample.getNullableValueSet(
-                                        property.name,
-                                        Float::class
-                                    ).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name, Float::class)
                                 )
                             }
                             RealmStorageType.DOUBLE -> {
-                                assertNull(
-                                    dynamicSample.getNullableValueSet<Double>(property.name).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet<Double>(property.name)
                                 )
-                                assertNull(
-                                    dynamicSample.getNullableValueSet(
-                                        property.name,
-                                        Double::class
-                                    ).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name, Double::class)
                                 )
                             }
                             RealmStorageType.TIMESTAMP -> {
-                                assertNull(
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueSet<RealmInstant>(property.name)
-                                        .first()
                                 )
-                                assertNull(
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueSet(
                                         property.name,
                                         RealmInstant::class
-                                    ).first()
+                                    )
                                 )
                             }
                             RealmStorageType.OBJECT_ID -> {
                                 when (name) {
                                     Sample::nullableObjectIdSetField.name -> {
-                                        assertNull(
+                                        assertionsForNullable(
                                             dynamicSample.getNullableValueSet<ObjectId>(
                                                 property.name
-                                            ).first()
+                                            )
                                         )
-                                        assertNull(
+                                        assertionsForNullable(
                                             dynamicSample.getNullableValueSet(
                                                 property.name,
                                                 ObjectId::class
-                                            ).first()
+                                            )
                                         )
                                     }
                                     Sample::nullableBsonObjectIdSetField.name -> {
-                                        assertNull(
-                                            dynamicSample.getNullableValueSet<ObjectId>(
+                                        assertionsForNullable(
+                                            dynamicSample.getNullableValueSet<BsonObjectId>(
                                                 property.name
-                                            ).first()
+                                            )
                                         )
-                                        assertNull(
+                                        assertionsForNullable(
                                             dynamicSample.getNullableValueSet(
                                                 property.name,
-                                                ObjectId::class
-                                            ).first()
+                                                BsonObjectId::class
+                                            )
                                         )
                                     }
                                 }
                             }
                             RealmStorageType.UUID -> {
-                                assertNull(
+                                assertionsForNullable(
                                     dynamicSample.getNullableValueSet<RealmUUID>(property.name)
-                                        .first()
                                 )
-                                assertNull(
-                                    dynamicSample.getNullableValueSet(
-                                        property.name,
-                                        RealmUUID::class
-                                    ).first()
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueSet(property.name, RealmUUID::class)
                                 )
                             }
                             RealmStorageType.BINARY -> {
@@ -946,6 +913,18 @@ class DynamicRealmObjectTests {
                                     dynamicSample.getNullableValueSet(
                                         property.name,
                                         ByteArray::class
+                                    ).first()
+                                )
+                            }
+                            RealmStorageType.DECIMAL128 -> {
+                                assertNull(
+                                    dynamicSample.getNullableValueSet<Decimal128>(property.name)
+                                        .first()
+                                )
+                                assertNull(
+                                    dynamicSample.getNullableValueSet(
+                                        property.name,
+                                        Decimal128::class
                                     ).first()
                                 )
                             }
@@ -973,137 +952,140 @@ class DynamicRealmObjectTests {
                             else -> error("Model contains untested properties: $property")
                         }
                     } else {
+                        fun <T> assertionsForValue(setFromSample: RealmSet<T>, expectedValue: T) {
+                            if (expectedValue is ByteArray) {
+                                assertContentEquals(
+                                    expectedValue,
+                                    setFromSample.first() as ByteArray
+                                )
+                            } else {
+                                assertEquals(expectedValue, setFromSample.first())
+                            }
+                        }
+
                         when (type.storageType) {
                             RealmStorageType.BOOL -> {
-                                val expectedValue = defaultSample.booleanField
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet<Boolean>(property.name).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    defaultSample.booleanField
                                 )
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet(property.name, Boolean::class).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, Boolean::class),
+                                    defaultSample.booleanField
                                 )
                             }
                             RealmStorageType.INT -> {
-                                val expectedValue: Long? = when (property.name) {
-                                    "byteSetField" -> defaultSample.byteField.toLong()
-                                    "charSetField" -> defaultSample.charField.code.toLong()
-                                    "shortSetField" -> defaultSample.shortField.toLong()
-                                    "intSetField" -> defaultSample.intField.toLong()
-                                    "longSetField" -> defaultSample.longField
+                                val expectedValue: Long = when (property.name) {
+                                    Sample::byteSetField.name ->
+                                        defaultSample.byteField.toLong()
+                                    Sample::charSetField.name ->
+                                        defaultSample.charField.code.toLong()
+                                    Sample::shortSetField.name -> defaultSample.shortField.toLong()
+                                    Sample::intSetField.name ->
+                                        defaultSample.intField.toLong()
+                                    Sample::longSetField.name ->
+                                        defaultSample.longField
                                     else -> error("Unexpected integral field ${property.name}")
                                 }
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet<Long>(property.name).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    expectedValue
                                 )
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet(property.name, Long::class).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, Long::class),
+                                    expectedValue
                                 )
                             }
                             RealmStorageType.STRING -> {
-                                val expectedValue = defaultSample.stringField
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet<String>(property.name).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    defaultSample.stringField
                                 )
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet(property.name, String::class).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, String::class),
+                                    defaultSample.stringField
                                 )
                             }
                             RealmStorageType.FLOAT -> {
-                                val expectedValue = defaultSample.floatField
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet<Float>(property.name).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    defaultSample.floatField
                                 )
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet(property.name, Float::class).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, Float::class),
+                                    defaultSample.floatField
                                 )
                             }
                             RealmStorageType.DOUBLE -> {
-                                val expectedValue = defaultSample.doubleField
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet<Double>(property.name).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    defaultSample.doubleField
                                 )
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet(property.name, Double::class).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, Double::class),
+                                    defaultSample.doubleField
                                 )
                             }
                             RealmStorageType.TIMESTAMP -> {
-                                val expectedValue = defaultSample.timestampField
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet<RealmInstant>(property.name).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    defaultSample.timestampField
                                 )
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet(property.name, RealmInstant::class)
-                                        .first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, RealmInstant::class),
+                                    defaultSample.timestampField
                                 )
                             }
-                            RealmStorageType.OBJECT_ID -> {
-                                when (name) {
-                                    Sample::objectIdSetField.name -> {
-                                        val expectedValue = defaultSample.objectIdField
-                                        assertEquals(
-                                            expectedValue,
-                                            dynamicSample.getValueSet<ObjectId>(property.name)
-                                                .first()
-                                        )
-                                        assertEquals(
-                                            expectedValue,
-                                            dynamicSample.getValueSet(
-                                                property.name,
-                                                ObjectId::class
-                                            ).first()
-                                        )
-                                    }
-                                    Sample::bsonObjectIdSetField.name -> {
-                                        val expectedValue = defaultSample.bsonObjectIdField
-                                        assertEquals(
-                                            expectedValue,
-                                            dynamicSample.getValueSet<BsonObjectId>(property.name)
-                                                .first()
-                                        )
-                                        assertEquals(
-                                            expectedValue,
-                                            dynamicSample.getValueSet(
-                                                property.name,
-                                                BsonObjectId::class
-                                            ).first()
-                                        )
-                                    }
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::objectIdSetField.name -> {
+                                    assertionsForValue(
+                                        dynamicSample.getValueSet(property.name),
+                                        defaultSample.objectIdField
+                                    )
+                                    assertionsForValue(
+                                        dynamicSample.getValueSet(property.name, ObjectId::class),
+                                        defaultSample.objectIdField
+                                    )
+                                }
+                                Sample::bsonObjectIdSetField.name -> {
+                                    assertionsForValue(
+                                        dynamicSample.getValueSet(property.name),
+                                        defaultSample.bsonObjectIdField
+                                    )
+                                    assertionsForValue(
+                                        dynamicSample.getValueSet(property.name, BsonObjectId::class),
+                                        defaultSample.bsonObjectIdField
+                                    )
                                 }
                             }
                             RealmStorageType.UUID -> {
-                                val expectedValue = defaultSample.uuidField
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet<RealmUUID>(property.name).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    defaultSample.uuidField
                                 )
-                                assertEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet(property.name, RealmUUID::class)
-                                        .first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, RealmUUID::class),
+                                    defaultSample.uuidField
                                 )
                             }
                             RealmStorageType.BINARY -> {
-                                val expectedValue = defaultSample.binaryField
-                                assertContentEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet<ByteArray>(property.name).first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    defaultSample.binaryField
                                 )
-                                assertContentEquals(
-                                    expectedValue,
-                                    dynamicSample.getValueSet(property.name, ByteArray::class)
-                                        .first()
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, ByteArray::class),
+                                    defaultSample.binaryField
+                                )
+                            }
+                            RealmStorageType.DECIMAL128 -> {
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name),
+                                    defaultSample.decimal128Field
+                                )
+                                assertionsForValue(
+                                    dynamicSample.getValueSet(property.name, Decimal128::class),
+                                    defaultSample.decimal128Field
                                 )
                             }
                             RealmStorageType.OBJECT -> {
@@ -1126,7 +1108,270 @@ class DynamicRealmObjectTests {
                     }
                 }
                 is DictionaryPropertyType -> {
-                    // TODO add support for dictionaries in dynamic realms
+                    if (type.isNullable) {
+                        fun <T> assertionsForNullable(dictionaryFromSample: RealmDictionary<T?>) {
+                            assertNull(dictionaryFromSample["A"])
+                        }
+
+                        when (type.storageType) {
+                            RealmStorageType.BOOL -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<Boolean>(property.name)
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        Boolean::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.INT -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<Long>(property.name)
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        Long::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.STRING -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<String>(property.name)
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        String::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.BINARY -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<ByteArray>(
+                                        property.name
+                                    )
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        ByteArray::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.OBJECT -> when (property.name) {
+                                "nullableObjectDictionaryFieldNull" -> {
+                                    assertionsForNullable(
+                                        dynamicSample.getNullableValueDictionary<DynamicRealmObject>(
+                                            property.name
+                                        )
+                                    )
+                                    assertionsForNullable(
+                                        dynamicSample.getNullableValueDictionary(
+                                            property.name,
+                                            DynamicRealmObject::class
+                                        )
+                                    )
+                                }
+                                "nullableObjectDictionaryFieldNotNull" -> {
+                                    dynamicSample.getNullableValueDictionary<DynamicRealmObject>(
+                                        property.name
+                                    ).also { dictionaryFromSample ->
+                                        val inner = assertNotNull(dictionaryFromSample["A"])
+                                        assertEquals("INNER", inner.getValue("stringField"))
+                                    }
+                                }
+                            }
+                            RealmStorageType.FLOAT -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<Float>(
+                                        property.name
+                                    )
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        Float::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.DOUBLE -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<Double>(
+                                        property.name
+                                    )
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        Double::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.DECIMAL128 -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<Decimal128>(
+                                        property.name
+                                    )
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        Decimal128::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.TIMESTAMP -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<RealmInstant>(
+                                        property.name
+                                    )
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        RealmInstant::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.OBJECT_ID -> when (name) {
+                                Sample::objectIdSetField.name -> {
+                                    assertionsForNullable(
+                                        dynamicSample.getNullableValueDictionary<ObjectId>(
+                                            property.name
+                                        )
+                                    )
+                                    assertionsForNullable(
+                                        dynamicSample.getNullableValueDictionary(
+                                            property.name,
+                                            ObjectId::class
+                                        )
+                                    )
+                                }
+                                Sample::bsonObjectIdSetField.name -> {
+                                    val expectedValue = defaultSample.bsonObjectIdField
+                                    assertEquals(
+                                        expectedValue,
+                                        dynamicSample.getValueSet<BsonObjectId>(property.name)
+                                            .first()
+                                    )
+                                    assertEquals(
+                                        expectedValue,
+                                        dynamicSample.getValueSet(
+                                            property.name,
+                                            BsonObjectId::class
+                                        ).first()
+                                    )
+                                }
+                            }
+                            RealmStorageType.UUID -> {
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary<RealmUUID>(
+                                        property.name
+                                    )
+                                )
+                                assertionsForNullable(
+                                    dynamicSample.getNullableValueDictionary(
+                                        property.name,
+                                        RealmUUID::class
+                                    )
+                                )
+                            }
+                            RealmStorageType.ANY -> {
+                                // The testing pattern doesn't work for RealmAny since we only land
+                                // here in case the type is nullable and the expected value only
+                                // takes into consideration the default value, which is an empty
+                                // set.
+                                // However, we need to test it with different values.
+                                // See 'get_realmAnySet()'
+                            }
+                            else -> error("Model contains untested properties: $property")
+                        }
+                    } else {
+                        fun <T> assertionsForValue(
+                            dictionaryFromSample: RealmDictionary<T>,
+                            expectedValue: T
+                        ) {
+                            if (expectedValue is ByteArray) {
+                                assertContentEquals(expectedValue, dictionaryFromSample["A"] as ByteArray)
+                            } else {
+                                assertEquals(expectedValue, dictionaryFromSample["A"])
+                            }
+                        }
+
+                        when (type.storageType) {
+                            RealmStorageType.BOOL -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                defaultSample.booleanField
+                            )
+                            RealmStorageType.INT -> {
+                                val expectedValue: Long = when (property.name) {
+                                    Sample::byteDictionaryField.name ->
+                                        defaultSample.byteField.toLong()
+                                    Sample::charDictionaryField.name ->
+                                        defaultSample.charField.code.toLong()
+                                    Sample::shortDictionaryField.name ->
+                                        defaultSample.shortField.toLong()
+                                    Sample::intDictionaryField.name ->
+                                        defaultSample.intField.toLong()
+                                    Sample::longDictionaryField.name ->
+                                        defaultSample.longField
+                                    else -> error("Unexpected integral field ${property.name}")
+                                }
+                                assertionsForValue(
+                                    dynamicSample.getValueDictionary(property.name),
+                                    expectedValue
+                                )
+                            }
+                            RealmStorageType.STRING -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                defaultSample.stringField
+                            )
+                            RealmStorageType.BINARY -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                defaultSample.binaryField
+                            )
+                            RealmStorageType.OBJECT -> {
+                                // No testing needed since dictionaries of objects can only be
+                                // nullable and that has been tested above
+                            }
+                            RealmStorageType.FLOAT -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                defaultSample.floatField
+                            )
+                            RealmStorageType.DOUBLE -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                defaultSample.doubleField
+                            )
+                            RealmStorageType.DECIMAL128 -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                defaultSample.decimal128Field
+                            )
+                            RealmStorageType.TIMESTAMP -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                defaultSample.timestampField
+                            )
+                            RealmStorageType.OBJECT_ID -> when (property.name) {
+                                Sample::objectIdDictionaryField.name -> assertionsForValue(
+                                    dynamicSample.getValueDictionary(property.name),
+                                    defaultSample.objectIdField
+                                )
+                                Sample::bsonObjectIdDictionaryField.name -> assertionsForValue(
+                                    dynamicSample.getValueDictionary(property.name),
+                                    defaultSample.bsonObjectIdField
+                                )
+                            }
+                            RealmStorageType.UUID -> assertionsForValue(
+                                dynamicSample.getValueDictionary(property.name),
+                                defaultSample.uuidField
+                            )
+                            RealmStorageType.ANY -> {
+                                // Tested outside similarly to lists
+                            }
+                            else -> Unit
+                        }
+                    }
                 }
                 else -> {
                     // Required `else` branch due to https://youtrack.jetbrains.com/issue/KTIJ-18702
@@ -1358,7 +1603,76 @@ class DynamicRealmObjectTests {
     }
 
     @Test
-    fun get_throwsOnUnkownName() {
+    fun get_realmAnyDictionary() {
+        val realmAnyValues = realmDictionaryOf(
+            "A" to null,
+            "B" to RealmAny.create("Hello"),
+            "C" to RealmAny.create(Sample().apply { stringField = "INNER" }),
+        )
+
+        val unmanagedSample = Sample().apply {
+            nullableRealmAnyDictionaryField = realmAnyValues
+        }
+        realm.writeBlocking { copyToRealm(unmanagedSample) }
+        realm.asDynamicRealm()
+            .also { dynamicRealm ->
+                val dynamicSample = dynamicRealm.query("Sample")
+                    .find()
+                    .first()
+
+                val actualReifiedDictionary = dynamicSample.getNullableValueDictionary<RealmAny>(
+                    Sample::nullableRealmAnyDictionaryField.name
+                )
+                val actualDictionary = dynamicSample.getNullableValueDictionary(
+                    Sample::nullableRealmAnyDictionaryField.name,
+                    RealmAny::class
+                )
+                for (entry in realmAnyValues.entries) {
+                    val expected = realmAnyValues[entry.key]
+                    val actualReified = actualReifiedDictionary[entry.key]
+                    val actual = actualDictionary[entry.key]
+                    if (actual?.type == RealmAny.Type.OBJECT) {
+                        // Test we throw if trying to retrieve the object using its actual class instead of
+                        // DynamicRealmObject
+                        assertFailsWith<ClassCastException> {
+                            actualReified?.asRealmObject<Sample>()
+                        }
+                        assertFailsWith<ClassCastException> {
+                            actualReified?.asRealmObject(Sample::class)
+                        }
+                        assertFailsWith<ClassCastException> {
+                            actual.asRealmObject<Sample>()
+                        }
+                        assertFailsWith<ClassCastException> {
+                            actual.asRealmObject(Sample::class)
+                        }
+
+                        // Retrieve values now
+                        assertEquals(
+                            expected?.asRealmObject<Sample>()?.stringField,
+                            actualReified?.asRealmObject<DynamicRealmObject>()?.getValue("stringField")
+                        )
+                        assertEquals(
+                            expected?.asRealmObject<Sample>()?.stringField,
+                            actual.asRealmObject<DynamicRealmObject>()?.getValue("stringField")
+                        )
+                    } else {
+                        assertEquals(expected, actualReified)
+                        assertEquals(expected, actual)
+                    }
+                }
+            }
+
+        // In case of testing dictionaries we have to skip dynamic managed objects inside a
+        // RealmDictionary<RealmAny> since the semantics prevent us from writing a DynamicRealmObject
+        // in this way, rightfully so. The reason for this is that we use the regular realm's
+        // accessors which go through the non-dynamic path so objects inside the list are expected
+        // to be non-dynamic - the 'issueDynamicObject' flag is always false following this path.
+        // This should be tested for DynamicMutableRealm instead.
+    }
+
+    @Test
+    fun get_throwsOnUnknownName() {
         realm.writeBlocking {
             copyToRealm(Sample())
         }
@@ -1567,6 +1881,7 @@ class DynamicRealmObjectTests {
             bsonObjectIdListField.add(defaultSample.bsonObjectIdField)
             uuidListField.add(defaultSample.uuidField)
             binaryListField.add(defaultSample.binaryField)
+            decimal128ListField.add(defaultSample.decimal128Field)
 
             booleanSetField.add(defaultSample.booleanField)
             byteSetField.add(defaultSample.byteField)
@@ -1583,6 +1898,23 @@ class DynamicRealmObjectTests {
             objectIdSetField.add(defaultSample.objectIdField)
             uuidSetField.add(defaultSample.uuidField)
             binarySetField.add(defaultSample.binaryField)
+            decimal128SetField.add(defaultSample.decimal128Field)
+
+            booleanDictionaryField["A"] = defaultSample.booleanField
+            byteDictionaryField["A"] = defaultSample.byteField
+            charDictionaryField["A"] = defaultSample.charField
+            shortDictionaryField["A"] = defaultSample.shortField
+            intDictionaryField["A"] = defaultSample.intField
+            longDictionaryField["A"] = defaultSample.longField
+            floatDictionaryField["A"] = defaultSample.floatField
+            doubleDictionaryField["A"] = defaultSample.doubleField
+            stringDictionaryField["A"] = defaultSample.stringField
+            timestampDictionaryField["A"] = defaultSample.timestampField
+            bsonObjectIdDictionaryField["A"] = defaultSample.bsonObjectIdField
+            objectIdDictionaryField["A"] = defaultSample.objectIdField
+            uuidDictionaryField["A"] = defaultSample.uuidField
+            binaryDictionaryField["A"] = defaultSample.binaryField
+            decimal128DictionaryField["A"] = defaultSample.decimal128Field
 
             nullableStringListField.add(null)
             nullableByteListField.add(null)
@@ -1598,6 +1930,7 @@ class DynamicRealmObjectTests {
             nullableObjectIdListField.add(null)
             nullableUUIDListField.add(null)
             nullableBinaryListField.add(null)
+            nullableDecimal128ListField.add(null)
 
             nullableStringSetField.add(null)
             nullableByteSetField.add(null)
@@ -1613,6 +1946,25 @@ class DynamicRealmObjectTests {
             nullableObjectIdSetField.add(null)
             nullableUUIDSetField.add(null)
             nullableBinarySetField.add(null)
+            nullableDecimal128SetField.add(null)
+
+            nullableStringDictionaryField["A"] = null
+            nullableByteDictionaryField["A"] = null
+            nullableCharDictionaryField["A"] = null
+            nullableShortDictionaryField["A"] = null
+            nullableIntDictionaryField["A"] = null
+            nullableLongDictionaryField["A"] = null
+            nullableBooleanDictionaryField["A"] = null
+            nullableFloatDictionaryField["A"] = null
+            nullableDoubleDictionaryField["A"] = null
+            nullableTimestampDictionaryField["A"] = null
+            nullableBsonObjectIdDictionaryField["A"] = null
+            nullableObjectIdDictionaryField["A"] = null
+            nullableUUIDDictionaryField["A"] = null
+            nullableBinaryDictionaryField["A"] = null
+            nullableDecimal128DictionaryField["A"] = null
+            nullableObjectDictionaryFieldNull["A"] = null
+            nullableObjectDictionaryFieldNotNull["A"] = Sample().apply { stringField = "INNER" }
         }
     }
 }

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/Sample.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/Sample.kt
@@ -85,7 +85,7 @@ class Sample : RealmObject {
     var bsonObjectIdListField: RealmList<BsonObjectId> = realmListOf()
     var uuidListField: RealmList<RealmUUID> = realmListOf()
     var binaryListField: RealmList<ByteArray> = realmListOf()
-//    var decimal128ListField: RealmList<Decimal128> = realmListOf() // TODO add missing tests for dynamic realms
+    var decimal128ListField: RealmList<Decimal128> = realmListOf()
     var objectListField: RealmList<Sample> = realmListOf()
 
     var nullableStringListField: RealmList<String?> = realmListOf()
@@ -102,7 +102,7 @@ class Sample : RealmObject {
     var nullableBsonObjectIdListField: RealmList<BsonObjectId?> = realmListOf()
     var nullableUUIDListField: RealmList<RealmUUID?> = realmListOf()
     var nullableBinaryListField: RealmList<ByteArray?> = realmListOf()
-//    var nullableDecimal128ListField: RealmList<Decimal128?> = realmListOf() // TODO add missing tests for dynamic realms
+    var nullableDecimal128ListField: RealmList<Decimal128?> = realmListOf()
     var nullableRealmAnyListField: RealmList<RealmAny?> = realmListOf()
 
     var stringSetField: RealmSet<String> = realmSetOf()
@@ -119,7 +119,7 @@ class Sample : RealmObject {
     var bsonObjectIdSetField: RealmSet<BsonObjectId> = realmSetOf()
     var uuidSetField: RealmSet<RealmUUID> = realmSetOf()
     var binarySetField: RealmSet<ByteArray> = realmSetOf()
-//    var decimal128SetField: RealmSet<Decimal128> = realmSetOf() // TODO add missing tests for dynamic realms
+    var decimal128SetField: RealmSet<Decimal128> = realmSetOf()
     var objectSetField: RealmSet<Sample> = realmSetOf()
 
     var nullableStringSetField: RealmSet<String?> = realmSetOf()
@@ -136,7 +136,7 @@ class Sample : RealmObject {
     var nullableBsonObjectIdSetField: RealmSet<BsonObjectId?> = realmSetOf()
     var nullableUUIDSetField: RealmSet<RealmUUID?> = realmSetOf()
     var nullableBinarySetField: RealmSet<ByteArray?> = realmSetOf()
-//    var nullableDecimal128SetField: RealmSet<Decimal128?> = realmSetOf() // TODO add missing tests for dynamic realms
+    var nullableDecimal128SetField: RealmSet<Decimal128?> = realmSetOf()
     var nullableRealmAnySetField: RealmSet<RealmAny?> = realmSetOf()
 
     var stringDictionaryField: RealmDictionary<String> = realmDictionaryOf()
@@ -153,7 +153,7 @@ class Sample : RealmObject {
     var bsonObjectIdDictionaryField: RealmDictionary<BsonObjectId> = realmDictionaryOf()
     var uuidDictionaryField: RealmDictionary<RealmUUID> = realmDictionaryOf()
     var binaryDictionaryField: RealmDictionary<ByteArray> = realmDictionaryOf()
-//    var decimal128DictionaryField: RealmDictionary<Decimal128> = realmDictionaryOf() // TODO add missing tests for dynamic realms
+    var decimal128DictionaryField: RealmDictionary<Decimal128> = realmDictionaryOf()
 
     var nullableStringDictionaryField: RealmDictionary<String?> = realmDictionaryOf()
     var nullableByteDictionaryField: RealmDictionary<Byte?> = realmDictionaryOf()
@@ -167,11 +167,12 @@ class Sample : RealmObject {
     var nullableTimestampDictionaryField: RealmDictionary<RealmInstant?> = realmDictionaryOf()
     var nullableObjectIdDictionaryField: RealmDictionary<ObjectId?> = realmDictionaryOf()
     var nullableBsonObjectIdDictionaryField: RealmDictionary<BsonObjectId?> = realmDictionaryOf()
-    var nullableUuidDictionaryField: RealmDictionary<RealmUUID?> = realmDictionaryOf()
+    var nullableUUIDDictionaryField: RealmDictionary<RealmUUID?> = realmDictionaryOf()
     var nullableBinaryDictionaryField: RealmDictionary<ByteArray?> = realmDictionaryOf()
-//    var nullableDecimal128DictionaryField: RealmDictionary<Decimal128?> = realmDictionaryOf() // TODO add missing tests for dynamic realms
+    var nullableDecimal128DictionaryField: RealmDictionary<Decimal128?> = realmDictionaryOf()
     var nullableRealmAnyDictionaryField: RealmDictionary<RealmAny?> = realmDictionaryOf()
-    var nullableObjectDictionaryField: RealmDictionary<Sample?> = realmDictionaryOf()
+    var nullableObjectDictionaryFieldNotNull: RealmDictionary<Sample?> = realmDictionaryOf()
+    var nullableObjectDictionaryFieldNull: RealmDictionary<Sample?> = realmDictionaryOf()
 
     val objectBacklinks by backlinks(Sample::nullableObject)
     val listBacklinks by backlinks(Sample::objectListField)


### PR DESCRIPTION
Added support for dictionaries in dynamic realms - refactored most of the collection code for existing assertions.
Added missing support for `Decimal128` in `copyFromRealm` for sets, dictionaries and dynamic realms.

Pull request plan:
- [x] basic infrastructure and API: `RealmMap` and `RealmDictionary` interfaces and associated helper functions (stubs)
- [x] setting up exhaustive testing infrastructure, add support for `copyToRealm` for objects with dictionaries and interface functions `get`, `put`, `putAll`, `remove` and `clear` for all types except `RealmAny` (it will be done once the interface implementation is complete)
- [x] support for `entries` (i.e. `RealmMapEntrySet`, `UnmanagedRealmMapEntry` and `ManagedRealmMapEntry`) and internal entry set iterator (which enables iterating through the dictionary's k-v pairs externally)
- [x] `containsKey`, `containsValue` - currently missing support in the C-API (https://github.com/realm/realm-core/issues/6181)
- [x] `values` - this change entails refactoring `RealmResults` to contain primitive values
- [x] support for `RealmAny`
- [ ] support for ~~`Deleteable` and~~ (dictionaries don't own objects like sets and lists do so removing them from the dictionary won't remove them from the realm) `asFlow` - currently blocked by https://github.com/realm/realm-core/issues/6228
- [x] allow `ByteArray`s to be compared structurally to allow `remove` operations on entry set and values
- [x] support for `copyFromRealm`
- [x] **THIS PR:** support for dynamic realms
- [ ] sync testing
- [ ] documentation
- [ ] changelog entry