### PR TITLE
Add support for querying on `RealmSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* None.
+* Add support for querying on RealmSets containing objects with `RealmSet.query(...)`.  (Issue [#1037](https://github.com/realm/realm-kotlin/issues/1258))
 
 ### Fixed
 * None.

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -376,7 +376,16 @@ expect object RealmInterop {
         query: String,
         args: Pair<Int, RealmQueryArgsTransport>
     ): RealmQueryPointer
-    fun realm_query_parse_for_list(list: RealmListPointer, query: String, args: Pair<Int, RealmQueryArgsTransport>): RealmQueryPointer
+    fun realm_query_parse_for_list(
+        list: RealmListPointer,
+        query: String,
+        args: Pair<Int, RealmQueryArgsTransport>
+    ): RealmQueryPointer
+    fun realm_query_parse_for_set(
+        set: RealmSetPointer,
+        query: String,
+        args: Pair<Int, RealmQueryArgsTransport>
+    ): RealmQueryPointer
     fun realm_query_find_first(query: RealmQueryPointer): Link?
     fun realm_query_find_all(query: RealmQueryPointer): RealmResultsPointer
     fun realm_query_count(query: RealmQueryPointer): Long

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -17,6 +17,7 @@
 package io.realm.kotlin.internal.interop
 
 import io.realm.kotlin.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
+import io.realm.kotlin.internal.interop.RealmInterop.cptr
 import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
 import io.realm.kotlin.internal.interop.sync.AuthProvider
 import io.realm.kotlin.internal.interop.sync.CoreConnectionState
@@ -1377,6 +1378,22 @@ actual object RealmInterop {
         return LongPointerWrapper(
             realmc.realm_query_parse_for_list(
                 list.cptr(),
+                query,
+                count.toLong(),
+                args.second.value
+            )
+        )
+    }
+
+    actual fun realm_query_parse_for_set(
+        set: RealmSetPointer,
+        query: String,
+        args: Pair<Int, RealmQueryArgsTransport>
+    ): RealmQueryPointer {
+        val count = args.first
+        return LongPointerWrapper(
+            realmc.realm_query_parse_for_set(
+                set.cptr(),
                 query,
                 count.toLong(),
                 args.second.value

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1122,6 +1122,22 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_query_parse_for_set(
+        set: RealmSetPointer,
+        query: String,
+        args: Pair<Int, RealmQueryArgsTransport>
+    ): RealmQueryPointer {
+        val count = args.first
+        return CPointerWrapper(
+            realm_wrapper.realm_query_parse_for_set(
+                set.cptr(),
+                query,
+                count.toULong(),
+                args.second.value.ptr
+            )
+        )
+    }
+
     actual fun realm_query_find_first(query: RealmQueryPointer): Link? {
         memScoped {
             val found = alloc<BooleanVar>()

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/BaseRealmObjectExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/BaseRealmObjectExt.kt
@@ -16,7 +16,9 @@
 
 package io.realm.kotlin.ext
 
+import io.realm.kotlin.Realm
 import io.realm.kotlin.VersionId
+import io.realm.kotlin.dynamic.DynamicRealmObject
 import io.realm.kotlin.internal.UnmanagedState
 import io.realm.kotlin.internal.checkNotificationsAvailable
 import io.realm.kotlin.internal.interop.RealmInterop
@@ -28,6 +30,9 @@ import io.realm.kotlin.notifications.InitialObject
 import io.realm.kotlin.notifications.ObjectChange
 import io.realm.kotlin.notifications.UpdatedObject
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmObject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 
@@ -68,19 +73,19 @@ public fun BaseRealmObject.isValid(): Boolean = runIfManaged {
 /**
  * Observe changes to a Realm object. The flow would emit an [InitialObject] once subscribed and
  * then, on every change to the object an [UpdatedObject]. If the observed object is deleted from
- * the Realm, the flow would emit a [DeletedObject] and then will complete, otherwise it will continue
- * running until canceled.
+ * the Realm, the flow would emit a [DeletedObject] and then will complete, otherwise it will
+ * continue running until canceled.
  *
- * The change calculations will execute on the thread represented by
- * [Configuration.notificationDispatcher].
+ * The change calculations will be executed on the thread represented by
+ * `Configuration.notificationDispatcher`.
  *
  * The flow has an internal buffer of [Channel.BUFFERED] but if the consumer fails to consume
  * the elements in a timely manner the coroutine scope will be cancelled with a
  * [CancellationException].
  *
  * @return a flow representing changes to the object.
- * @throws UnsupportedOperationException if called on a live [RealmObject] or [EmbeddedRealmObject] from
- * a write transaction ([Realm.write]) or on a [DynamicRealmObject] inside a migration
+ * @throws UnsupportedOperationException if called on a live [RealmObject] or [EmbeddedRealmObject]
+ * from a write transaction ([Realm.write]) or on a [DynamicRealmObject] inside a migration
  * ([AutomaticSchemaMigration.migrate]).
  */
 public fun <T : BaseRealmObject> T.asFlow(): Flow<ObjectChange<T>> = runIfManaged {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmListExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmListExt.kt
@@ -52,7 +52,7 @@ public inline fun <reified T : TypedRealmObject> RealmList<T>.copyFromRealm(dept
 // `RealmList` interface as `RealmQuery` has an `BaseRealmObject` upper bound which `RealmList` do
 // not.
 /**
- * Query the objects of a list by the `filter` and `arguments`.
+ * Query the objects in a list by the `filter` and `arguments`.
  *
  * @param filter the Realm Query Language predicate to append.
  * @param arguments Realm values for the predicate.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmSetExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmSetExt.kt
@@ -17,7 +17,6 @@
 package io.realm.kotlin.ext
 
 import io.realm.kotlin.TypedRealm
-import io.realm.kotlin.internal.ManagedRealmList
 import io.realm.kotlin.internal.ManagedRealmSet
 import io.realm.kotlin.internal.UnmanagedRealmSet
 import io.realm.kotlin.internal.asRealmSet

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmSetExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmSetExt.kt
@@ -17,9 +17,15 @@
 package io.realm.kotlin.ext
 
 import io.realm.kotlin.TypedRealm
+import io.realm.kotlin.internal.ManagedRealmList
+import io.realm.kotlin.internal.ManagedRealmSet
 import io.realm.kotlin.internal.UnmanagedRealmSet
 import io.realm.kotlin.internal.asRealmSet
 import io.realm.kotlin.internal.getRealm
+import io.realm.kotlin.internal.query
+import io.realm.kotlin.query.RealmQuery
+import io.realm.kotlin.query.TRUE_PREDICATE
+import io.realm.kotlin.types.BaseRealmObject
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.RealmSet
@@ -44,3 +50,19 @@ public inline fun <T : RealmObject> RealmSet<T>.copyFromRealm(depth: UInt = UInt
         realm.copyFromRealm(this, depth).toSet()
     } ?: throw IllegalArgumentException("This RealmSet is unmanaged. Only managed sets can be copied.")
 }
+
+/**
+ * Query the objects of a set by the `filter` and `arguments`.
+ *
+ * @param filter the Realm Query Language predicate to append.
+ * @param arguments Realm values for the predicate.
+ */
+public fun <T : BaseRealmObject> RealmSet<T>.query(
+    filter: String = TRUE_PREDICATE,
+    vararg arguments: Any?
+): RealmQuery<T> =
+    if (this is ManagedRealmSet) {
+        query(filter, arguments)
+    } else {
+        throw IllegalArgumentException("Unmanaged set cannot be queried")
+    }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmSetExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmSetExt.kt
@@ -51,7 +51,7 @@ public inline fun <T : RealmObject> RealmSet<T>.copyFromRealm(depth: UInt = UInt
 }
 
 /**
- * Query the objects of a set by the `filter` and `arguments`.
+ * Query the objects in a set by the `filter` and `arguments`.
  *
  * @param filter the Realm Query Language predicate to append.
  * @param arguments Realm values for the predicate.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectHelper.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmObjectHelper.kt
@@ -480,37 +480,39 @@ internal object RealmObjectHelper {
         } else {
             CollectionOperatorType.REALM_OBJECT
         }
-        val key = obj.propertyInfoOrThrow(propertyName).key
-        return getSetByKey(obj, key, elementType, operatorType)
+        val propertyMetadata = obj.propertyInfoOrThrow(propertyName)
+        return getSetByKey(obj, propertyMetadata, elementType, operatorType)
     }
 
     // Cannot call managedRealmList directly from an inline function
     @Suppress("LongParameterList")
     internal fun <R> getSetByKey(
         obj: RealmObjectReference<out BaseRealmObject>,
-        key: PropertyKey,
+        propertyMetadata: PropertyMetadata,
         elementType: KClass<R & Any>,
         operatorType: CollectionOperatorType,
         issueDynamicObject: Boolean = false,
         issueDynamicMutableObject: Boolean = false
     ): ManagedRealmSet<R> {
-        val setPtr = RealmInterop.realm_get_set(obj.objectPointer, key)
+        val setPtr = RealmInterop.realm_get_set(obj.objectPointer, propertyMetadata.key)
         val operator = createSetOperator<R>(
             setPtr,
             elementType,
+            propertyMetadata,
             obj.mediator,
             obj.owner,
             operatorType,
             issueDynamicObject,
             issueDynamicMutableObject,
         )
-        return ManagedRealmSet(setPtr, operator)
+        return ManagedRealmSet(obj, setPtr, operator)
     }
 
     @Suppress("LongParameterList")
     private fun <R> createSetOperator(
         setPtr: RealmSetPointer,
         clazz: KClass<R & Any>,
+        propertyMetadata: PropertyMetadata,
         mediator: Mediator,
         realm: RealmReference,
         operatorType: CollectionOperatorType,
@@ -530,13 +532,17 @@ internal object RealmObjectHelper {
                 realmAnyConverter(mediator, realm, issueDynamicObject, issueDynamicMutableObject),
                 setPtr
             ) as SetOperator<R>
-            CollectionOperatorType.REALM_OBJECT -> RealmObjectSetOperator(
-                mediator,
-                realm,
-                converter(clazz, mediator, realm),
-                clazz,
-                setPtr
-            )
+            CollectionOperatorType.REALM_OBJECT -> {
+                val classKey: ClassKey = realm.schemaMetadata.getOrThrow(propertyMetadata.linkTarget).classKey
+                RealmObjectSetOperator(
+                    mediator,
+                    realm,
+                    converter(clazz, mediator, realm),
+                    setPtr,
+                    clazz,
+                    classKey
+                )
+            }
             else ->
                 throw IllegalArgumentException("Unsupported collection type: ${operatorType.name}")
         }
@@ -867,7 +873,7 @@ internal object RealmObjectHelper {
         @Suppress("UNCHECKED_CAST")
         return getSetByKey(
             obj,
-            propertyMetadata.key,
+            propertyMetadata,
             clazz,
             operatorType,
             true,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmSetInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmSetInternal.kt
@@ -17,7 +17,9 @@
 package io.realm.kotlin.internal
 
 import io.realm.kotlin.UpdatePolicy
+import io.realm.kotlin.internal.RealmValueArgumentConverter.convertToQueryArgs
 import io.realm.kotlin.internal.interop.Callback
+import io.realm.kotlin.internal.interop.ClassKey
 import io.realm.kotlin.internal.interop.RealmChangesPointer
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.RealmInterop.realm_set_get
@@ -27,10 +29,13 @@ import io.realm.kotlin.internal.interop.RealmSetPointer
 import io.realm.kotlin.internal.interop.ValueType
 import io.realm.kotlin.internal.interop.getterScope
 import io.realm.kotlin.internal.interop.inputScope
+import io.realm.kotlin.internal.query.ObjectBoundQuery
+import io.realm.kotlin.internal.query.ObjectQuery
 import io.realm.kotlin.notifications.SetChange
 import io.realm.kotlin.notifications.internal.DeletedSetImpl
 import io.realm.kotlin.notifications.internal.InitialSetImpl
 import io.realm.kotlin.notifications.internal.UpdatedSetImpl
+import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.types.BaseRealmObject
 import io.realm.kotlin.types.RealmSet
 import kotlinx.coroutines.channels.ChannelResult
@@ -54,7 +59,8 @@ internal class UnmanagedRealmSet<E> : RealmSet<E>, InternalDeleteable, MutableSe
 /**
  * Implementation for managed sets, backed by Realm.
  */
-internal class ManagedRealmSet<E>(
+internal class ManagedRealmSet<E> constructor(
+    internal val parent: RealmObjectReference<*>,
     internal val nativePointer: RealmSetPointer,
     val operator: SetOperator<E>
 ) : AbstractMutableSet<E>(), RealmSet<E>, InternalDeleteable, Observable<ManagedRealmSet<E>, SetChange<E>>, Flowable<SetChange<E>> {
@@ -129,13 +135,13 @@ internal class ManagedRealmSet<E>(
 
     override fun freeze(frozenRealm: RealmReference): ManagedRealmSet<E>? {
         return RealmInterop.realm_set_resolve_in(nativePointer, frozenRealm.dbPointer)?.let {
-            ManagedRealmSet(it, operator.copy(frozenRealm, it))
+            ManagedRealmSet(parent, it, operator.copy(frozenRealm, it))
         }
     }
 
     override fun thaw(liveRealm: RealmReference): ManagedRealmSet<E>? {
         return RealmInterop.realm_set_resolve_in(nativePointer, liveRealm.dbPointer)?.let {
-            ManagedRealmSet(it, operator.copy(liveRealm, it))
+            ManagedRealmSet(parent, it, operator.copy(liveRealm, it))
         }
     }
 
@@ -173,6 +179,33 @@ internal class ManagedRealmSet<E>(
 
     internal fun isValid(): Boolean {
         return !nativePointer.isReleased() && RealmInterop.realm_set_is_valid(nativePointer)
+    }
+}
+
+internal fun <E : BaseRealmObject> ManagedRealmSet<E>.query(
+    query: String,
+    args: Array<out Any?>
+): RealmQuery<E> {
+    val operator: RealmObjectSetOperator<E> = operator as RealmObjectSetOperator<E>
+    return ObjectQuery.tryCatchCoreException {
+        val queryPointer = inputScope {
+            val queryArgs = convertToQueryArgs(args)
+            RealmInterop.realm_query_parse_for_set(
+                this@query.nativePointer,
+                query,
+                queryArgs
+            )
+        }
+        ObjectBoundQuery(
+            parent,
+            ObjectQuery(
+                operator.realmReference,
+                operator.classKey,
+                operator.clazz,
+                operator.mediator,
+                queryPointer,
+            )
+        )
     }
 }
 
@@ -256,12 +289,13 @@ internal class PrimitiveSetOperator<E>(
         PrimitiveSetOperator(mediator, realmReference, converter, nativePointer)
 }
 
-internal class RealmObjectSetOperator<E>(
+internal class RealmObjectSetOperator<E> constructor(
     override val mediator: Mediator,
     override val realmReference: RealmReference,
     override val converter: RealmValueConverter<E>,
-    private val clazz: KClass<E & Any>,
-    private val nativePointer: RealmSetPointer
+    private val nativePointer: RealmSetPointer,
+    val clazz: KClass<E & Any>,
+    val classKey: ClassKey
 ) : SetOperator<E> {
 
     override fun add(
@@ -317,7 +351,7 @@ internal class RealmObjectSetOperator<E>(
     ): SetOperator<E> {
         val converter =
             converter<E>(clazz, mediator, realmReference) as CompositeConverter<E, *>
-        return RealmObjectSetOperator(mediator, realmReference, converter, clazz, nativePointer)
+        return RealmObjectSetOperator(mediator, realmReference, converter, nativePointer, clazz, classKey)
     }
 }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmSet.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmSet.kt
@@ -21,6 +21,7 @@ import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.notifications.InitialSet
 import io.realm.kotlin.notifications.SetChange
 import io.realm.kotlin.notifications.UpdatedSet
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmSetTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmSetTests.kt
@@ -26,8 +26,10 @@ import io.realm.kotlin.ext.asRealmObject
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.ext.realmSetOf
 import io.realm.kotlin.ext.toRealmSet
+import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.query.find
+import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TypeDescriptor
 import io.realm.kotlin.types.ObjectId
@@ -36,9 +38,15 @@ import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.RealmSet
 import io.realm.kotlin.types.RealmUUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withTimeout
 import org.mongodb.kbson.BsonObjectId
 import org.mongodb.kbson.Decimal128
 import kotlin.reflect.KClassifier
@@ -53,6 +61,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class RealmSetTests {
 
@@ -424,6 +434,173 @@ class RealmSetTests {
                     .add(RealmSetContainer())
             }
         }
+    }
+
+    @Test
+    fun setAsFlow_completesWhenParentIsDeleted() = runBlocking {
+        val container = realm.write { copyToRealm(RealmSetContainer()) }
+        val mutex = Mutex(true)
+        val job = async {
+            container.objectSetField.asFlow().collect {
+                mutex.unlock()
+            }
+        }
+        mutex.lock()
+        realm.write { delete(findLatest(container)!!) }
+        withTimeout(10.seconds) {
+            job.await()
+        }
+    }
+
+    @Test
+    fun query_objectSet() = runBlocking {
+        val container = realm.write {
+            copyToRealm(
+                RealmSetContainer().apply {
+                    (1..5).map {
+                        objectSetField.add(RealmSetContainer().apply { stringField = "$it" })
+                    }
+                }
+            )
+        }
+        val objectSetField = container.objectSetField
+        assertEquals(5, objectSetField.size)
+
+        val all: RealmQuery<RealmSetContainer> = container.objectSetField.query()
+        val ids = (1..5).map { it.toString() }.toMutableSet()
+        all.find().forEach { assertTrue(ids.remove(it.stringField)) }
+        assertTrue { ids.isEmpty() }
+
+        container.objectSetField.query("stringField = $0", 3.toString())
+            .find()
+            .single()
+            .run {
+                assertEquals("3", stringField)
+            }
+    }
+
+    @Test
+    fun queryOnSetAsFlow_completesWhenParentIsDeleted() = runBlocking {
+        val container = realm.write { copyToRealm(RealmSetContainer()) }
+        val mutex = Mutex(true)
+        val listener = async {
+            container.objectSetField.query()
+                .asFlow()
+                .let {
+                    withTimeout(10.seconds) {
+                        it.collect {
+                            mutex.unlock()
+                        }
+                    }
+                }
+        }
+        mutex.lock()
+        realm.write { delete(findLatest(container)!!) }
+        listener.await()
+    }
+
+    @Test
+    fun queryOnSetAsFlow_throwsOnInsufficientBuffers() = runBlocking {
+        val container = realm.write { copyToRealm(RealmSetContainer()) }
+        val flow = container.objectSetField.query().asFlow()
+            .buffer(1)
+
+        val listener = async {
+            withTimeout(10.seconds) {
+                assertFailsWith<CancellationException> {
+                    flow.collect { current ->
+                        delay(1000.milliseconds)
+                    }
+                }.message!!.let { message ->
+                    assertEquals(
+                        "Cannot deliver object notifications. Increase dispatcher processing resources or buffer the flow with buffer(...)",
+                        message
+                    )
+                }
+            }
+        }
+        (1..100).forEach { i ->
+            realm.write {
+                findLatest(container)!!.objectSetField.run {
+                    clear()
+                    add(RealmSetContainer().apply { this.id = i })
+                }
+            }
+        }
+        listener.await()
+    }
+
+    // This test shows that our internal logic still works (by closing the flow on deletion events)
+    // even though the public consumer is dropping elements
+    @Test
+    fun queryOnSetAsFlow_backpressureStrategyDoesNotRuinInternalLogic() = runBlocking {
+        val container = realm.write { copyToRealm(RealmSetContainer()) }
+        val flow = container.objectSetField.query().asFlow()
+            .buffer(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+        val listener = async {
+            withTimeout(10.seconds) {
+                flow.collect { current ->
+                    delay(30.milliseconds)
+                }
+            }
+        }
+        (1..100).forEach { i ->
+            realm.write {
+                findLatest(container)!!.objectSetField.run {
+                    clear()
+                    add(RealmSetContainer().apply { this.id = i })
+                }
+            }
+        }
+        realm.write { delete(findLatest(container)!!) }
+        listener.await()
+    }
+
+    @Test
+    fun query_throwsOnSyntaxError() = runBlocking {
+        val instance = realm.write { copyToRealm(RealmSetContainer()) }
+        assertFailsWithMessage<IllegalArgumentException>("syntax error") {
+            instance.objectSetField.query("ASDF = $0 $0")
+        }
+        Unit
+    }
+
+    @Test
+    fun query_throwsOnUnmanagedSet() = runBlocking {
+        realm.write {
+            val instance = RealmSetContainer()
+            copyToRealm(instance)
+            assertFailsWithMessage<IllegalArgumentException>("Unmanaged set cannot be queried") {
+                instance.objectSetField.query()
+            }
+            Unit
+        }
+    }
+
+    @Test
+    fun query_throwsOnDeletedSet() = runBlocking {
+        realm.write {
+            val instance = copyToRealm(RealmSetContainer())
+            val objectSetField = instance.objectSetField
+            delete(instance)
+            assertFailsWithMessage<IllegalStateException>("Access to invalidated Collection") {
+                objectSetField.query()
+            }
+        }
+        Unit
+    }
+
+    @Test
+    fun query_throwsOnClosedSet() = runBlocking {
+        val container = realm.write { copyToRealm(RealmSetContainer()) }
+        val objectSetField = container.objectSetField
+        realm.close()
+
+        assertFailsWithMessage<IllegalStateException>("Access to invalidated Collection") {
+            objectSetField.query()
+        }
+        Unit
     }
 
     private fun getCloseableRealm(): Realm =

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicRealmObjectTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/dynamic/DynamicRealmObjectTests.kt
@@ -1455,6 +1455,23 @@ class DynamicRealmObjectTests {
     }
 
     @Test
+    fun set_query() {
+        realm.writeBlocking {
+            copyToRealm(
+                Sample().apply {
+                    (1..5).forEach { objectSetField.add(Sample().apply { intField = it }) }
+                }
+            )
+        }
+        val dynamicRealm = realm.asDynamicRealm()
+        val dynamicSample = dynamicRealm.query("Sample").find().first()
+
+        val results = dynamicSample.getObjectSet("objectSetField").query("intField > 2").find()
+        assertEquals(3, results.size)
+        results.forEach { assertTrue { it.getValue<Long>("intField") > 2 } }
+    }
+
+    @Test
     fun getListVariants_throwsOnWrongTypes() {
         realm.writeBlocking {
             copyToRealm(Sample())

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/set/RealmSetContainer.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/set/RealmSetContainer.kt
@@ -28,6 +28,8 @@ import org.mongodb.kbson.Decimal128
 import kotlin.reflect.KMutableProperty1
 
 class RealmSetContainer : RealmObject {
+
+    var id: Int = -1
     var stringField: String = "Realm"
 
     var stringSetField: RealmSet<String> = realmSetOf()


### PR DESCRIPTION
Closes #1258

We needed to add support for queries on `RealmSet`s. The API follows the same pattern for `RealmList` due to the `BaseRealmObject` upper bound in `RealmQuery` and exposes `query` as an extension function.

Also refined some wording in a few documentation places and added missing imports for their respective links.