### PR TITLE
Apply Realm Kotlin compiler plugin after other plugins

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -80,7 +80,7 @@ object Versions {
     const val jvmTarget = "1.8"
     // When updating the Kotlin version, also remember to update /examples/min-android-sample/build.gradle.kts
     const val kotlin = "1.7.20" // https://github.com/JetBrains/kotlin and https://kotlinlang.org/docs/releases.html#release-details
-    const val latestKotlin = "1.8.0-RC" // https://kotlinlang.org/docs/eap.html#build-details
+    const val latestKotlin = "1.8.0" // https://kotlinlang.org/docs/eap.html#build-details
     const val kotlinCompileTesting = "1.4.9" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlint = "0.45.2" // https://github.com/pinterest/ktlint
     const val ktor = "2.1.2" // https://github.com/ktorio/ktor

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Registrar.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Registrar.kt
@@ -16,10 +16,12 @@
 
 package io.realm.kotlin.compiler
 
+import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
+import org.jetbrains.kotlin.com.intellij.openapi.extensions.LoadingOrder
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.resolve.extensions.SyntheticResolveExtension
@@ -42,11 +44,7 @@ import org.jetbrains.kotlin.resolve.extensions.SyntheticResolveExtension
  * The [RealmObjectCompanion] holds static information about the schema (members, primary key, etc.)
  * and utility methods for constructing objects, etc.
  */
-// For some reason the plugin is not picked up when applied by adding the artifact as a
-// 'kotlinCompilerPluginClasspath'-dependency if using the auto service infrastructure, so
-// registering it through
-// resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar instead.
-// @AutoService(ComponentRegistrar::class)
+@AutoService(ComponentRegistrar::class)
 class Registrar : ComponentRegistrar {
     override fun registerProjectComponents(
         project: MockProject,
@@ -56,14 +54,22 @@ class Registrar : ComponentRegistrar {
             configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
         SchemaCollector.properties.clear()
 
-        // Trigger generation of companion objects and addition of the RealmObjectCompanion to it
-        SyntheticResolveExtension.registerExtension(
-            project,
-            RealmModelSyntheticCompanionExtension()
-        )
-
-        // Adds RealmObjectInternal properties, rewires accessors and adds static companion
-        // properties and methods
-        IrGenerationExtension.registerExtension(project, RealmModelLoweringExtension())
+        // We load our extensions LAST to avoid exposing our internal attributes to other plugins,
+        // like serialization (issue https://github.com/realm/realm-kotlin/issues/1251).
+        project.extensionArea.run {
+            // Trigger generation of companion objects and addition of the RealmObjectCompanion to it
+            getExtensionPoint(SyntheticResolveExtension.extensionPointName).registerExtension(
+                RealmModelSyntheticCompanionExtension(),
+                LoadingOrder.LAST,
+                project
+            )
+            // Adds RealmObjectInternal properties, rewires accessors and adds static companion
+            // properties and methods
+            getExtensionPoint(IrGenerationExtension.extensionPointName).registerExtension(
+                RealmModelLoweringExtension(),
+                LoadingOrder.LAST,
+                project
+            )
+        }
     }
 }

--- a/packages/plugin-compiler/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+++ b/packages/plugin-compiler/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
@@ -1,1 +1,0 @@
-io.realm.kotlin.compiler.Registrar

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/kotlin/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/kotlin/compiler/GenerationExtensionTest.kt
@@ -35,6 +35,7 @@ import io.realm.kotlin.internal.schema.SchemaMetadata
 import io.realm.kotlin.types.BaseRealmObject
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.TypedRealmObject
+import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.junit.Test
 import java.io.File
 import kotlin.reflect.KClass
@@ -105,6 +106,14 @@ class GenerationExtensionTest {
     }
 
     @Test
+    fun `Sample compilation`() {
+        val inputs = Files("/sample")
+        val result = compile(inputs)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        inputs.assertGeneratedIR()
+    }
+
+    @Test
     @Suppress("invisible_member", "invisible_reference")
     fun `implement RealmObjectInternal and generate internal properties`() {
         val inputs = Files("/sample")
@@ -132,8 +141,6 @@ class GenerationExtensionTest {
         // Accessing getters/setters
         sampleModel.`io_realm_kotlin_objectReference` = realmObjectReference
         assertEquals(realmObjectReference, sampleModel.`io_realm_kotlin_objectReference`)
-
-        inputs.assertGeneratedIR()
     }
 
     @Test
@@ -274,7 +281,6 @@ class GenerationExtensionTest {
         val newInstance = companionObject.`io_realm_kotlin_newInstance`()
         assertNotNull(newInstance)
         assertEquals(kClazz, newInstance.javaClass)
-        inputs.assertGeneratedIR()
     }
 
     @Test
@@ -315,13 +321,11 @@ class GenerationExtensionTest {
         // nameProperty.setter.call(sampleModel, "Zepp")
         // get value using the CInterop call
         // assertEquals("Hello Zepp", nameProperty.call(sampleModel))
-
-        inputs.assertGeneratedIR()
     }
 
     private fun compile(
         inputs: Files,
-        plugins: List<Registrar> = listOf(Registrar())
+        plugins: List<ComponentRegistrar> = listOf(Registrar())
     ): KotlinCompilation.Result =
         KotlinCompilation().apply {
             sources = inputs.fileMap.values.map { SourceFile.fromPath(it) }


### PR DESCRIPTION
This PR will change the order of registration of our compiler plugin, so that it is applied after other plugins. This will avoid having other plugins processing our internal `io.realm.kotlin.x`-attributes.

*Reviewing considerations*
I found it hard to put up a test that verifies this across Kotlin versions in the current integration test infrastructure. If we add it in `test-base` it is only verified for Kotlin version of the SDK and if enabling serialization in `examples/kmm-sample` it would only be verified for `Versions.latestKotlin`. I guess the right approach would be to add feature specific projects in `integration-tests/compatibility/<feature>` and trigger those for both `Versions.kotlin` and `Versions.latestKotlin` ... But didn't deem it for this PR!?

Test for current level of `kotlinx.serialization` support. We could do a test in `test-base` to verify the current level of _"out of the box"_ `kotlinx.serialization`-support to catch regressions, but as we don't have full `kotlinx.serialization`-support until #973 and/or #994 I also didn't deem it for this PR. Support at the time of this PR is limited to:
- Kotlin primitive types 
- Bson types
- Object references

Thus not supporting:
- Realm abstract/interface/container types: `RealmInstant`, `RealmUUID`, `MutableRealmInt`, `RealmSet` and `RealmList` 
 
This PR will add *NOT* full `kotlinx.serialization`-support, but will only address the regression mentioned in #1251 for Kotlin 1.8.0 of the _"out of the box"_ working supported field types. See above notes on supported types. 