### PR TITLE
Fix issue when compiling project containing a Realm Java model class using the RealmObject abstract class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * None.
 
 ### Fixed
+* Compatibility with Realm Java when using the `io.realm.RealmObject` abstract class. (Issue [#1278](https://github.com/realm/realm-kotlin/issues/1278))
 * Compiler error when multiple fields have `@PersistedName`-annotations that match they Kotlin name. (Issue [#1240](https://github.com/realm/realm-kotlin/issues/1240))
 
 ### Compatibility

--- a/examples/realm-java-compatibility/app/src/main/java/io/realm/kotlin/demo/javacompatibility/data/java/JavaRepository.kt
+++ b/examples/realm-java-compatibility/app/src/main/java/io/realm/kotlin/demo/javacompatibility/data/java/JavaRepository.kt
@@ -21,6 +21,8 @@ import android.util.Log
 import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.RealmModel
+import io.realm.RealmObject
+import io.realm.annotations.PrimaryKey
 import io.realm.annotations.RealmClass
 import io.realm.kotlin.demo.javacompatibility.TAG
 import io.realm.kotlin.demo.javacompatibility.data.Repository
@@ -30,6 +32,11 @@ import io.realm.kotlin.demo.javacompatibility.data.Repository
 @RealmClass
 open class JavaEntity : RealmModel {
     var name: String = "JAVA"
+}
+
+open class JavaEntityWithBaseObject : RealmObject() {
+    @PrimaryKey
+    var id: String = ""
 }
 
 class JavaRepository(appContext: Context) : Repository {

--- a/examples/realm-java-compatibility/app/src/main/java/io/realm/kotlin/demo/javacompatibility/data/kotlin/KotlinRepository.kt
+++ b/examples/realm-java-compatibility/app/src/main/java/io/realm/kotlin/demo/javacompatibility/data/kotlin/KotlinRepository.kt
@@ -23,8 +23,11 @@ import io.realm.kotlin.demo.javacompatibility.TAG
 import io.realm.kotlin.demo.javacompatibility.data.Repository
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.PrimaryKey
 
 class KotlinEntity : RealmObject {
+    @PrimaryKey
+    var id: String = ""
     var name: String = "KOTLIN"
 }
 

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/IrUtils.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/IrUtils.kt
@@ -154,14 +154,20 @@ inline fun ClassDescriptor.hasInterfacePsi(interfaces: Set<String>): Boolean {
     return hasRealmObjectAsSuperType
 }
 
+// Do to the way PSI works, it can be a bit tricky to uniquely identify when the Realm Kotlin
+// RealmObject interface is used. For that reason, once we have determined a match for RealmObject,
+// We also need to ensure we didn't accidentally matched on the Realm Java RealmObject abstract
+// type. Fortunately that is visible in the PSI as `RealmObject()` (Java, abstract class) vs.
+// `RealmObject` (Kotlin, interface).
 val realmObjectPsiNames = setOf("RealmObject", "io.realm.kotlin.types.RealmObject")
 val embeddedRealmObjectPsiNames = setOf("EmbeddedRealmObject", "io.realm.kotlin.types.EmbeddedRealmObject")
+val realmJavaObjectPsiNames = setOf("io.realm.RealmObject()", "RealmObject()")
 val ClassDescriptor.isRealmObject: Boolean
-    get() = this.hasInterfacePsi(realmObjectPsiNames)
+    get() = this.hasInterfacePsi(realmObjectPsiNames) && !this.hasInterfacePsi(realmJavaObjectPsiNames)
 val ClassDescriptor.isEmbeddedRealmObject: Boolean
     get() = this.hasInterfacePsi(embeddedRealmObjectPsiNames)
 val ClassDescriptor.isBaseRealmObject: Boolean
-    get() = this.hasInterfacePsi(realmObjectPsiNames + embeddedRealmObjectPsiNames)
+    get() = this.hasInterfacePsi(realmObjectPsiNames + embeddedRealmObjectPsiNames) && !this.hasInterfacePsi(realmJavaObjectPsiNames)
 
 fun IrMutableAnnotationContainer.hasAnnotation(annotation: FqName): Boolean {
     return annotations.hasAnnotation(annotation)

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -108,7 +108,7 @@ private class RealmModelLowering(private val pluginContext: IrPluginContext) : C
             AccessorModifierIrGeneration(pluginContext).modifyPropertiesAndCollectSchema(irClass)
 
             // Add body for synthetic companion methods
-            val companion = irClass.companionObject() ?: fatalError("RealmObject without companion")
+            val companion = irClass.companionObject() ?: fatalError("RealmObject without companion: ${irClass.kotlinFqName}")
             generator.addCompanionFields(irClass, companion, SchemaCollector.properties[irClass])
             generator.addSchemaMethodBody(irClass)
             generator.addNewInstanceMethodBody(irClass)


### PR DESCRIPTION
Closes #1278 

The logic for checking the PSI tree was a bit complex so not sure if there is an easier way to do this, but it seems to fix the problem. I added the problematic case to our Java integration sample so we can catch future regressions.