### PR TITLE
Fix RealmUUID equal comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Compatibility with Realm Java when using the `io.realm.RealmObject` abstract class. (Issue [#1278](https://github.com/realm/realm-kotlin/issues/1278))
 * Compiler error when multiple fields have `@PersistedName`-annotations that match they Kotlin name. (Issue [#1240](https://github.com/realm/realm-kotlin/issues/1240))
+* RealmUUID would throw an `ClassCastException` when comparing with an object instance of a different type. (Issue [#1288](https://github.com/realm/realm-kotlin/issues/1288))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmUUIDImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmUUIDImpl.kt
@@ -54,8 +54,11 @@ public class RealmUUIDImpl : RealmUUID {
 
     override fun equals(other: Any?): Boolean {
         // Check if 'other' is null since type coercion would fail in that case
-        if (other == null) return false
-        return (other as RealmUUID).bytes.contentEquals(bytes)
+        return when (other) {
+            null -> false
+            is RealmUUID -> other.bytes.contentEquals(bytes)
+            else -> false
+        }
     }
 
     override fun hashCode(): Int {

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmUUIDTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmUUIDTests.kt
@@ -155,5 +155,7 @@ class RealmUUIDTests {
 
         @Suppress("EqualsNullCall")
         assertFalse(uuid1.equals(null)) // Do not assume type coercion in 'equals' implementation
+
+        assertFalse(uuid1.equals("hello world")) // Do not assume type coercion in 'equals' implementation
     }
 }


### PR DESCRIPTION
Fixes https://github.com/realm/realm-kotlin/issues/1288

Comparing a `RealmUUID` instance with an object instance of a different type resulted on a `ClassCastException`