### PR TITLE
Correctly cleanup Sync Client thread when it is destroyed on the C++ side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Trying to convert to a Flexible Sync Realm with Flexible Sync disabled throws a `IllegalStateException` instead of a `IllegalArgumentException`. (Issue [#1188](https://github.com/realm/realm-kotlin/pull/1188))
 * Fix missing initial flow events when registering for events while updating the realm. (Issue [#1151](https://github.com/realm/realm-kotlin/issues/1151))
 * Emit deletion events and terminate flow when registering for notifications on outdated entities instead of throwing. (Issue [#1233](https://github.com/realm/realm-kotlin/issues/1233))
-* [Sync] The underlying C++ thread controlling the Device Sync connection would leak when closing the Realm. (Issue (https://github.com/realm/realm-kotlin/issues/1290)[#1290])
+* [Sync] Close the thread associated with the Device Sync connection when closing the Realm. (Issue (https://github.com/realm/realm-kotlin/issues/1290)[#1290])
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Accessing an invalidated `RealmResults` now throws an `IllegalStateException` instead of a `RealmException`. (Issue [#1188](https://github.com/realm/realm-kotlin/pull/1188))
 * Opening a Realm with a wrong encryption key or corrupted now throws an `IllegalStateException` instead of a `IllegalArgumentException`. (Issue [#1188](https://github.com/realm/realm-kotlin/pull/1188))
 * Trying to convert to a Flexible Sync Realm with Flexible Sync disabled throws a `IllegalStateException` instead of a `IllegalArgumentException`. (Issue [#1188](https://github.com/realm/realm-kotlin/pull/1188))
+* [Sync] The underlying C++ thread controlling the Device Sync connection would leak when closing the Realm. (Issue (https://github.com/realm/realm-kotlin/issues/1290)[#1290])
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/Callback.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/Callback.kt
@@ -92,3 +92,14 @@ fun interface ProgressCallback {
 fun interface ConnectionStateChangeCallback {
     fun onChange(oldState: Int, newState: Int)
 }
+
+interface SyncThreadObserver {
+    // Should return the name of the Java Sync thread.
+    fun threadName(): String
+    // Called when the underlying Sync thread is created
+    fun onCreated()
+    // Called when the underlying Sync thread is destroyed
+    fun onDestroyed()
+    // Called when an error occurred on the underlying Sync thread
+    fun onError(error: String)
+}

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -539,7 +539,13 @@ expect object RealmInterop {
     fun realm_user_refresh_custom_data(app: RealmAppPointer, user: RealmUserPointer, callback: AppCallback<Unit>)
 
     // Sync client config
-    fun realm_sync_client_config_new(appId: String): RealmSyncClientConfigurationPointer
+    fun realm_sync_client_config_new(): RealmSyncClientConfigurationPointer
+
+    fun realm_sync_client_config_set_default_binding_thread_observer(
+        syncClientConfig: RealmSyncClientConfigurationPointer,
+        appId: String
+    )
+
     fun realm_sync_client_config_set_base_file_path(
         syncClientConfig: RealmSyncClientConfigurationPointer,
         basePath: String

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -539,7 +539,7 @@ expect object RealmInterop {
     fun realm_user_refresh_custom_data(app: RealmAppPointer, user: RealmUserPointer, callback: AppCallback<Unit>)
 
     // Sync client config
-    fun realm_sync_client_config_new(): RealmSyncClientConfigurationPointer
+    fun realm_sync_client_config_new(appId: String): RealmSyncClientConfigurationPointer
     fun realm_sync_client_config_set_base_file_path(
         syncClientConfig: RealmSyncClientConfigurationPointer,
         basePath: String

--- a/packages/cinterop/src/jvm/jni/env_utils.cpp
+++ b/packages/cinterop/src/jvm/jni/env_utils.cpp
@@ -39,12 +39,12 @@ namespace realm {
                         void **jenv = (void **) &env;
                     #endif
                     JavaVMAttachArgs args;
+                    args.version = JNI_VERSION_1_2;
+                    args.group = nullptr;
                     if (thread_name.has_value()) {
-                        args = JavaVMAttachArgs {
-                            .version = JNI_VERSION_1_2,
-                            .name = thread_name->c_str(),
-                            .group = nullptr
-                        };
+                        args.name = thread_name->c_str();
+                    } else {
+                        args.name = nullptr;
                     }
                     jint ret;
                     if (is_daemon_thread) {

--- a/packages/cinterop/src/jvm/jni/env_utils.cpp
+++ b/packages/cinterop/src/jvm/jni/env_utils.cpp
@@ -28,7 +28,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
 
 namespace realm {
     namespace jni_util {
-        JNIEnv * get_env(bool attach_if_needed) {
+        JNIEnv * get_env(bool attach_if_needed, bool is_daemon_thread, realm::util::Optional<std::string> thread_name) {
             JNIEnv *env;
             jint rc = cached_jvm->GetEnv((void **)&env, JNI_VERSION_1_2);
             if (rc == JNI_EDETACHED) {
@@ -38,7 +38,20 @@ namespace realm {
                     #else
                         void **jenv = (void **) &env;
                     #endif
-                    jint ret = cached_jvm->AttachCurrentThread(jenv, nullptr);
+                    JavaVMAttachArgs args;
+                    if (thread_name.has_value()) {
+                        args = JavaVMAttachArgs {
+                            .version = JNI_VERSION_1_2,
+                            .name = thread_name->c_str(),
+                            .group = nullptr
+                        };
+                    }
+                    jint ret;
+                    if (is_daemon_thread) {
+                        ret = cached_jvm->AttachCurrentThreadAsDaemon(jenv, &args);
+                    } else {
+                        ret = cached_jvm->AttachCurrentThread(jenv, &args);
+                    }
                     if (ret != JNI_OK) throw std::runtime_error("Could not attach JVM on thread ");
                 } else {
                     throw std::runtime_error("current thread not attached");
@@ -48,6 +61,10 @@ namespace realm {
                 throw std::runtime_error("jni version not supported");
 
             return env;
+        }
+
+        void detach_current_thread() {
+            cached_jvm->DetachCurrentThread();
         }
 
         JNIEnv * get_env_or_null() {

--- a/packages/cinterop/src/jvm/jni/env_utils.cpp
+++ b/packages/cinterop/src/jvm/jni/env_utils.cpp
@@ -42,8 +42,7 @@ namespace realm {
                     args.version = JNI_VERSION_1_2;
                     args.group = nullptr;
                     if (thread_name.has_value()) {
-                        const char* name = thread_name->c_str();
-                        args.name = name;
+                        args.name = (char*) thread_name.value().c_str();
                     } else {
                         args.name = nullptr;
                     }

--- a/packages/cinterop/src/jvm/jni/env_utils.cpp
+++ b/packages/cinterop/src/jvm/jni/env_utils.cpp
@@ -42,7 +42,8 @@ namespace realm {
                     args.version = JNI_VERSION_1_2;
                     args.group = nullptr;
                     if (thread_name.has_value()) {
-                        args.name = thread_name->c_str();
+                        const char* name = thread_name->c_str();
+                        args.name = name;
                     } else {
                         args.name = nullptr;
                     }

--- a/packages/cinterop/src/jvm/jni/env_utils.h
+++ b/packages/cinterop/src/jvm/jni/env_utils.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include "java_global_ref_by_move.hpp"
+#include "realm/util/optional.hpp"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved);
 
@@ -29,10 +30,13 @@ namespace realm {
     namespace jni_util {
         static std::vector<JavaGlobalRefByMove> m_global_refs;
 
-        JNIEnv * get_env(bool attach_if_needed = false);
+        JNIEnv * get_env(bool attach_if_needed = false,
+                         bool is_daemon_thread = false,
+                         realm::util::Optional<std::string> thread_name = realm::util::none);
         // Returns current environment (or attaches current thread) or returns null if not possible
         // to obtain an environment, in which case we assume that the VM has shut down;
         JNIEnv * get_env_or_null();
+        void detach_current_thread();
         // TODO Migrate java_method.{hpp,cpp} realm-java or implement similar caching mechanism to
         //  hold global references to classes and look up methods
         jmethodID lookup(JNIEnv *jenv, const char *class_name, const char *method_name,

--- a/packages/cinterop/src/jvm/jni/java_class_global_def.hpp
+++ b/packages/cinterop/src/jvm/jni/java_class_global_def.hpp
@@ -64,6 +64,7 @@ private:
         , m_io_realm_kotlin_internal_interop_progress_callback(env, "io/realm/kotlin/internal/interop/ProgressCallback", false)
         , m_io_realm_kotlin_internal_interop_app_callback(env, "io/realm/kotlin/internal/interop/AppCallback", false)
         , m_io_realm_kotlin_internal_interop_connection_state_change_callback(env, "io/realm/kotlin/internal/interop/ConnectionStateChangeCallback", false)
+        , m_io_realm_kotlin_internal_interop_sync_thread_observer(env, "io/realm/kotlin/internal/interop/SyncThreadObserver", false)
     {
     }
 
@@ -88,6 +89,7 @@ private:
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_progress_callback;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_app_callback;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_connection_state_change_callback;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_thread_observer;
 
     inline static std::unique_ptr<JavaClassGlobalDef>& instance()
     {
@@ -203,6 +205,11 @@ public:
     inline static const jni_util::JavaClass& connection_state_change_callback()
     {
         return instance()->m_io_realm_kotlin_internal_interop_connection_state_change_callback;
+    }
+
+    inline static const jni_util::JavaClass& sync_thread_observer()
+    {
+        return instance()->m_io_realm_kotlin_internal_interop_sync_thread_observer;
     }
 
     inline static const jni_util::JavaMethod function0Method(JNIEnv* env) {

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -954,8 +954,33 @@ actual object RealmInterop {
         )
     }
 
-    actual fun realm_sync_client_config_new(): RealmSyncClientConfigurationPointer {
-        return LongPointerWrapper(realmc.realm_sync_client_config_new())
+    actual fun realm_sync_client_config_new(appId: String): RealmSyncClientConfigurationPointer {
+        val ptr: RealmSyncClientConfigurationPointer = LongPointerWrapper(realmc.realm_sync_client_config_new())
+        realmc.realm_sync_client_config_set_default_binding_thread_observer(ptr.cptr(), object: SyncThreadObserver {
+            override fun threadName(): String {
+                return "SyncThread-$appId"
+            }
+
+            override fun onCreated() {
+                // We cannot set the name on JNI side as it would require access to JNIEnv before
+                // we attach it, so we set the thread name after it is created.
+                Thread.currentThread().name = threadName()
+            }
+
+            override fun onDestroyed() {
+                // Do nothing
+                // Thread is destroyed in the JNI side
+            }
+
+            override fun onError(error: String) {
+                // TODO Wait for https://github.com/realm/realm-core/issues/4194 to correctly
+                //  log errors. For now just print it. Throwing an exception is also a possibility
+                //  but it will tear down the app completely as it will be thrown out of context
+                //  so there is no way to catch it.
+                println("Error on sync thread: $error")
+            }
+        })
+        return ptr
     }
 
     actual fun realm_sync_client_config_set_base_file_path(

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -954,10 +954,13 @@ actual object RealmInterop {
         )
     }
 
-    actual fun realm_sync_client_config_new(appId: String): RealmSyncClientConfigurationPointer {
-        val ptr: RealmSyncClientConfigurationPointer = LongPointerWrapper(realmc.realm_sync_client_config_new())
+    actual fun realm_sync_client_config_new(): RealmSyncClientConfigurationPointer {
+        return LongPointerWrapper(realmc.realm_sync_client_config_new())
+    }
+
+    actual fun realm_sync_client_config_set_default_binding_thread_observer(syncClientConfig: RealmSyncClientConfigurationPointer, appId: String) {
         realmc.realm_sync_client_config_set_default_binding_thread_observer(
-            ptr.cptr(),
+            syncClientConfig.cptr(),
             object : SyncThreadObserver {
                 override fun threadName(): String {
                     return "SyncThread-$appId"
@@ -977,18 +980,14 @@ actual object RealmInterop {
                 @Suppress("TooGenericExceptionThrown")
                 override fun onError(error: String) {
                     // TODO Wait for https://github.com/realm/realm-core/issues/4194 to correctly
-                    //  log errors. For now, just throw an Error. Exceptions from the Sync Client
-                    //  indicate something is fundamentally is wrong on the Sync Thread.
-                    //
-                    //  As any exception here will be thrown out of context with no way to catch it, we
-                    //  turn it into an Error. Also, in Realm Java, these exceptions have only been
-                    //  reported when we integrated features ourselves, which indicates we want to
-                    //  make it very visible when they happen.
+                    //  log errors. For now, just throw an Error as exceptions from the Sync Client
+                    //  indicate that something is fundamentally wrong on the Sync Thread.
+                    //  In Realm Java this has only been reported during development of new
+                    //  features, so throwing an Error seems appropriate to increase visibility.
                     throw Error("[${threadName()}] Error on sync thread : $error")
                 }
             }
         )
-        return ptr
     }
 
     actual fun realm_sync_client_config_set_base_file_path(

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1953,7 +1953,7 @@ actual object RealmInterop {
         )
     }
 
-    actual fun realm_sync_client_config_new(): RealmSyncClientConfigurationPointer {
+    actual fun realm_sync_client_config_new(appId: String): RealmSyncClientConfigurationPointer {
         return CPointerWrapper(realm_wrapper.realm_sync_client_config_new())
     }
 

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -245,6 +245,22 @@ std::string rlm_stdstr(realm_string_t val)
     };
 }
 
+// Thread Observer callback
+%typemap(jstype) (realm_on_object_store_thread_callback_t on_thread_create, realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error, void* user_data, realm_free_userdata_func_t free_userdata) "Object" ;
+%typemap(jtype) (realm_on_object_store_thread_callback_t on_thread_create, realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error, void* user_data, realm_free_userdata_func_t free_userdata) "Object" ;
+%typemap(javain) (realm_on_object_store_thread_callback_t on_thread_create, realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error, void* user_data, realm_free_userdata_func_t free_userdata) "$javainput";
+%typemap(jni) (realm_on_object_store_thread_callback_t on_thread_create, realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error, void* user_data, realm_free_userdata_func_t free_userdata) "jobject";
+%typemap(in) (realm_on_object_store_thread_callback_t on_thread_create, realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error, void* user_data, realm_free_userdata_func_t free_userdata) {
+    auto jenv = get_env(true);
+    $1 = reinterpret_cast<realm_on_object_store_thread_callback_t>(realm_sync_thread_created);
+    $2 = reinterpret_cast<realm_on_object_store_thread_callback_t>(realm_sync_thread_destroyed);
+    $3 = reinterpret_cast<realm_on_object_store_error_callback_t>(realm_sync_thread_error);
+    $4 = static_cast<jobject>(jenv->NewGlobalRef($input));
+    $5 = [](void *userdata) {
+        get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
+    };
+}
+
 // String handling
 typedef jstring realm_string_t;
 // Typemap used for passing realm_string_t into the C-API in situations where the string buffer

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -969,8 +969,8 @@ realm_sync_thread_destroyed(realm_userdata_t userdata) {
         env->CallVoidMethod(static_cast<jobject>(userdata), java_callback_method);
         jni_check_exception(env);
     }
-    // Cleanup Java thread associated with the Sync Client Thread, otherwise
-    // the JVM cannot cleanup shut down.
+    // Detach from the Java thread associated with the Sync Client Thread, otherwise
+    // the JVM will not be able to shutdown.
     detach_current_thread();
 }
 

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -125,4 +125,13 @@ realm_sync_session_register_progress_notifier_wrapper(
         jobject callback
 );
 
+void
+realm_sync_thread_created(realm_userdata_t userdata);
+
+void
+realm_sync_thread_destroyed(realm_userdata_t userdata);
+
+void
+realm_sync_thread_error(realm_userdata_t userdata, const char* error);
+
 #endif //TEST_REALM_API_HELPERS_H

--- a/packages/library-base/proguard-rules-consumer-common.pro
+++ b/packages/library-base/proguard-rules-consumer-common.pro
@@ -113,6 +113,10 @@
 -keep class io.realm.kotlin.internal.interop.ConnectionStateChangeCallback {
     *;
 }
+-keep class io.realm.kotlin.internal.interop.SyncThreadObserver {
+    *;
+}
+
 # Preserve Function<X> methods as they back various functional interfaces called from JNI
 -keep class kotlin.jvm.functions.Function* {
     *;

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
@@ -139,9 +139,10 @@ public class AppConfigurationImpl constructor(
     }
 
     private fun initializeSyncClientConfig(sdkInfo: String?, applicationInfo: String?): RealmSyncClientConfigurationPointer =
-        RealmInterop.realm_sync_client_config_new(appId)
+        RealmInterop.realm_sync_client_config_new()
             .also { syncClientConfig ->
                 // Initialize client configuration first
+                RealmInterop.realm_sync_client_config_set_default_binding_thread_observer(syncClientConfig, appId)
                 RealmInterop.realm_sync_client_config_set_log_level(
                     syncClientConfig,
                     CoreLogLevel.valueFromPriority(log.logLevel.priority.toShort())

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
@@ -139,7 +139,7 @@ public class AppConfigurationImpl constructor(
     }
 
     private fun initializeSyncClientConfig(sdkInfo: String?, applicationInfo: String?): RealmSyncClientConfigurationPointer =
-        RealmInterop.realm_sync_client_config_new()
+        RealmInterop.realm_sync_client_config_new(appId)
             .also { syncClientConfig ->
                 // Initialize client configuration first
                 RealmInterop.realm_sync_client_config_set_log_level(

--- a/packages/test-sync/src/jvmTest/kotlin/io/realm/kotlin/jvm/RealmTests.kt
+++ b/packages/test-sync/src/jvmTest/kotlin/io/realm/kotlin/jvm/RealmTests.kt
@@ -53,11 +53,6 @@ class RealmTests {
         val activeThreads = Thread.getAllStackTraces().keys
             .filter { !it.isDaemon }
             .filterNot {
-                // Ignore the Sync thread for now, until https://github.com/realm/realm-core/issues/5966
-                // is fixed.
-                it.name.startsWith("Thread-")
-            }
-            .filterNot {
                 // Android Studio or Gradle worker threads
                 it.name.startsWith("/127.0.0.1")
             }


### PR DESCRIPTION
Close https://github.com/realm/realm-kotlin/issues/1290

This PR makes sure we correctly clean up the Sync thread. This is currently leaking, which on the JVM prevents it from shutting down gracefully, and depending on your usage (like in #1290), it might also be a big resource drain.

There is an open question about how to handle exceptions on the Sync thread. Ideally, they should never happen and they are reported back to us as just a string. For now, I just print them (waiting for proper logging), but we could also consider throwing an exception, but it will 100% tear the app down with it. 

In Java, we throw an Exception, and I don't think we have seen 