### PR TITLE
Fail build if model class contain types not supported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements
 * Upgrade OpenSSL from 3.0.7 to 3.0.8.
+* Model classes with types not supported by Realm will now fail at compile time instead of logging a debug message. This error can be suppressed by using the `@Ignore` annotation. (Issue [#1226](https://github.com/realm/realm-kotlin/issues/1226))
 * Add support for querying on RealmSets containing objects with `RealmSet.query(...)`.  (Issue [#1037](https://github.com/realm/realm-kotlin/issues/1258))
 * [Sync] Add support for setting App Services connection identifiers through `AppConfiguration.appName` and `AppConfiguration.appVersion`, making it easier to identify connections in the server logs. (Issue (#407)[https://github.com/realm/realm-kotlin/issues/407])
 * [Sync] Added `RecoverUnsyncedChangesStrategy`, an alternative automatic client reset strategy that tries to automatically recover any unsynced data from the client.

--- a/examples/realm-java-compatibility/app/src/androidTest/java/io/realm/kotlin/demo/javacompatibility/InstrumentedTest.kt
+++ b/examples/realm-java-compatibility/app/src/androidTest/java/io/realm/kotlin/demo/javacompatibility/InstrumentedTest.kt
@@ -37,9 +37,8 @@ class InstrumentedTest {
 
     @Test
     fun test() {
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-
-        val repositories = setOf(JavaRepository(appContext), KotlinRepository())
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as MainApplication
+        val repositories = setOf(appContext.java, appContext.kotlin)
         for (repository in repositories) {
             assertTrue(repository.count > 0)
         }

--- a/examples/realm-java-compatibility/app/src/main/java/io/realm/kotlin/demo/javacompatibility/data/java/JavaRepository.kt
+++ b/examples/realm-java-compatibility/app/src/main/java/io/realm/kotlin/demo/javacompatibility/data/java/JavaRepository.kt
@@ -45,12 +45,12 @@ class JavaRepository(appContext: Context) : Repository {
 
     init {
         Realm.init(appContext)
-        realm = Realm.getInstance(
-            RealmConfiguration.Builder()
-                .name("java.realm")
-                .allowWritesOnUiThread(true)
-                .build()
-        )
+        val config = RealmConfiguration.Builder()
+            .name("java.realm")
+            .allowWritesOnUiThread(true)
+            .build()
+        Realm.deleteRealm(config)
+        realm = Realm.getInstance(config)
         realm.executeTransaction {
             realm.createObject(JavaEntity::class.java)
             val entities = realm.where(JavaEntity::class.java).findAll()

--- a/examples/realm-java-compatibility/app/src/main/java/io/realm/kotlin/demo/javacompatibility/data/kotlin/KotlinRepository.kt
+++ b/examples/realm-java-compatibility/app/src/main/java/io/realm/kotlin/demo/javacompatibility/data/kotlin/KotlinRepository.kt
@@ -33,9 +33,14 @@ class KotlinEntity : RealmObject {
 
 class KotlinRepository: Repository {
 
-    val realm = Realm.open(RealmConfiguration.Builder(setOf(KotlinEntity::class)).name("kotlin.realm").build())
+    val realm: Realm
 
     init {
+        val config = RealmConfiguration.Builder(setOf(KotlinEntity::class))
+            .name("kotlin.realm")
+            .build()
+        Realm.deleteRealm(config)
+        realm = Realm.open(config)
         realm.writeBlocking { copyToRealm(KotlinEntity()) }
         val entities = realm.query<KotlinEntity>().find()
         Log.w(TAG, "KOTLIN: ${entities.size}")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -97,7 +97,6 @@ import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.types.makeNotNull
 import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.dump
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
@@ -643,7 +642,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                         )
                     }
                     else -> {
-                        logDebug("Type not processed: ${declaration.dump()}")
+                        logError("Realm does not support persisting properties of this type. Mark the field with `@Ignore` to suppress this error.", declaration.locationOf())
                     }
                 }
 

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -147,4 +147,25 @@ class ModelDefinitionTests {
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, "Compilation should fail when using unsupported types")
         assertTrue(result.messages.contains("Realm does not support persisting properties of this type."), "Error was: ${result.messages}")
     }
+
+    @Test
+    fun `model_class_with_unsupported_type_is_ignored`() {
+        val result = Compiler.compileFromSource(
+            plugins = listOf(Registrar()),
+            source = SourceFile.kotlin(
+                "object_declaration.kt",
+                """
+                        import io.realm.kotlin.types.RealmObject
+                        import io.realm.kotlin.types.annotations.Ignore
+                        
+                        class Foo : RealmObject {
+                            var name: String = "HelloWorld"
+                            @Ignore
+                            var unknownType = mutableListOf<String>()
+                        }
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -129,4 +129,22 @@ class ModelDefinitionTests {
         assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using anonymous objects")
         assertTrue(result.messages.contains("Anonymous objects are not supported."))
     }
+
+    @Test
+    fun `model_class_with_unsupported_type`() {
+        val result = Compiler.compileFromSource(
+            plugins = listOf(Registrar()),
+            source = SourceFile.kotlin(
+                "object_declaration.kt",
+                """
+                        import io.realm.kotlin.types.RealmObject
+                        class Foo : RealmObject {
+                            var unknownType = mutableListOf<String>()
+                        }
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, "Compilation should fail when using unsupported types")
+        assertTrue(result.messages.contains("Realm does not support persisting properties of this type."), "Error was: ${result.messages}")
+    }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -169,7 +169,7 @@ class ModelDefinitionTests {
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
     }
 
-	@Test
+    @Test
     fun `persisted_properties_with_val_should_fail`() {
         val result = Compiler.compileFromSource(
             plugins = listOf(Registrar()),


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/1226

This mirrors the behavior in Realm Java, where we also fail at compile time for unknown types.