### PR TITLE
Remove all uses of freeze

### DIFF
--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -130,11 +130,6 @@ import realm_wrapper.realm_version_id_t
 import kotlin.collections.set
 import kotlin.native.internal.createCleaner
 
-private inline fun <T> T.freeze(): T {
-    // Disable freeze in 1.7.20
-    return this
-}
-
 @SharedImmutable
 actual val INVALID_CLASS_KEY: ClassKey by lazy { ClassKey(realm_wrapper.RLM_INVALID_CLASS_KEY.toLong()) }
 @SharedImmutable
@@ -182,7 +177,7 @@ class CPointerWrapper<T : CapiT>(ptr: CPointer<out CPointed>?, managed: Boolean 
 
     @OptIn(ExperimentalStdlibApi::class)
     val cleaner = if (managed) {
-        createCleaner(_ptr.freeze()) {
+        createCleaner(_ptr) {
             if (released.compareAndSet(expect = false, update = true)) {
                 realm_release(ptr)
             }
@@ -479,7 +474,7 @@ actual object RealmInterop {
         val callback = DataInitializationCallback {
             fileCreated.value = true
             true
-        }.freeze()
+        }
         realm_wrapper.realm_config_set_data_initialization_function(
             config.cptr(),
             staticCFunction { userdata, _ ->
@@ -1979,7 +1974,7 @@ actual object RealmInterop {
                 val threadId = safeUserData<String>(userdata)
                 throw Error("[SyncThread-$threadId] Error on sync thread: ${error?.toKString()}")
             },
-            user_data = StableRef.create(appId.freeze()).asCPointer(),
+            user_data = StableRef.create(appId).asCPointer(),
             free_userdata = staticCFunction { userdata ->
                 disposeUserData<String>(userdata)
             }
@@ -2003,7 +1998,7 @@ actual object RealmInterop {
                 val userDataLogCallback = safeUserData<SyncLogCallback>(userData)
                 userDataLogCallback.log(logLevel.toShort(), message?.toKString())
             },
-            StableRef.create(callback.freeze()).asCPointer(),
+            StableRef.create(callback).asCPointer(),
             staticCFunction { userData -> disposeUserData<() -> SyncLogCallback>(userData) }
         )
     }
@@ -2136,7 +2131,7 @@ actual object RealmInterop {
                     false
                 }
             },
-            StableRef.create(beforeHandler.freeze()).asCPointer(),
+            StableRef.create(beforeHandler).asCPointer(),
             staticCFunction { userdata ->
                 disposeUserData<SyncBeforeClientResetHandler>(userdata)
             }
@@ -2166,7 +2161,7 @@ actual object RealmInterop {
                     false
                 }
             },
-            StableRef.create(afterHandler.freeze()).asCPointer(),
+            StableRef.create(afterHandler).asCPointer(),
             staticCFunction { userdata ->
                 disposeUserData<SyncAfterClientResetHandler>(userdata)
             }
@@ -2967,7 +2962,7 @@ actual object RealmInterop {
             )
         ) ?: error("Couldn't create scheduler")
         scheduler.set_scheduler(capi_scheduler)
-        scheduler.freeze()
+        scheduler
         return capi_scheduler
     }
 
@@ -3089,7 +3084,7 @@ actual object RealmInterop {
             scope.launch(
                 scope.coroutineContext,
                 CoroutineStart.DEFAULT,
-                function.freeze()
+                function
             )
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -36,7 +36,6 @@ import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.RealmSchemaPointer
 import io.realm.kotlin.internal.interop.SchemaMode
 import io.realm.kotlin.internal.platform.appFilesDirectory
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.platform.prepareRealmFilePath
 import io.realm.kotlin.internal.platform.realmObjectCompanionOrThrow
 import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
@@ -139,7 +138,7 @@ public open class ConfigurationImpl constructor(
                 override fun invoke(totalBytes: Long, usedBytes: Long): Boolean {
                     return callback.shouldCompact(totalBytes, usedBytes)
                 }
-            }.freeze()
+            }
         }
 
         // We need to prepare the the migration callback so it can be frozen for Kotlin Native, but
@@ -208,7 +207,7 @@ public open class ConfigurationImpl constructor(
             )
 
             migrationCallback?.let {
-                RealmInterop.realm_config_set_migration_function(nativeConfig, it.freeze())
+                RealmInterop.realm_config_set_migration_function(nativeConfig, it)
             }
 
             userEncryptionKey?.let { key: ByteArray ->

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -107,30 +107,6 @@ public expect fun prepareRealmFilePath(directoryPath: String, filename: String):
 public expect fun createDefaultSystemLogger(tag: String, logLevel: LogLevel = LogLevel.NONE): RealmLogger
 
 /**
- * Method to freeze state.
- * Calls the platform implementation of 'freeze' on native, and is a noop on other platforms.
- *
- * Note, this method refers to Kotlin Natives notion of frozen objects, and not Realms variant
- * of frozen objects.
- *
- * From Kotlin 1.7.20 freeze is deprecated, so this is a no-op on all platforms.
- */
-public expect fun <T> T.freeze(): T
-
-/**
- * Determine if object is frozen.
- * Will return false on non-native platforms.
- */
-public expect val <T> T.isFrozen: Boolean
-
-/**
- * Call on an object which should never be frozen.
- * Will help debug when something inadvertently is.
- * This is a noop on non-native platforms.
- */
-public expect fun Any.ensureNeverFrozen()
-
-/**
  * Return the current thread id.
  */
 public expect fun threadId(): ULong

--- a/packages/library-base/src/jvm/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/jvm/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -27,13 +27,6 @@ internal actual fun currentTime(): RealmInstant {
     return RealmInstantImpl(jtInstant.epochSecond, jtInstant.nano)
 }
 
-public actual fun <T> T.freeze(): T = this
-
-public actual val <T> T.isFrozen: Boolean
-    get() = false
-
-public actual fun Any.ensureNeverFrozen() { /* Do nothing */ }
-
 public actual fun fileExists(path: String): Boolean =
     File(path).let { it.exists() && it.isFile }
 

--- a/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -72,15 +72,6 @@ internal actual fun currentTime(): RealmInstant {
     }
 }
 
-public actual fun <T> T.freeze(): T = this
-
-public actual val <T> T.isFrozen: Boolean
-    get() = false
-
-public actual fun Any.ensureNeverFrozen() {
-    /* Do nothing */
-}
-
 public actual fun fileExists(path: String): Boolean {
     val fm = platform.Foundation.NSFileManager.defaultManager
     memScoped {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -28,7 +28,6 @@ import io.realm.kotlin.internal.platform.canWrite
 import io.realm.kotlin.internal.platform.createDefaultSystemLogger
 import io.realm.kotlin.internal.platform.directoryExists
 import io.realm.kotlin.internal.platform.fileExists
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.platform.prepareRealmDirectoryPath
 import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
 import io.realm.kotlin.internal.util.Validation
@@ -284,7 +283,7 @@ public interface AppConfiguration {
                             appLogger.debug(message)
                         }
                     }
-                ).freeze() // Kotlin network client needs to be frozen before passed to the C-API
+                )
             }
 
             return AppConfigurationImpl(

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/ApiKeyAuthImpl.kt
@@ -19,7 +19,6 @@ import io.realm.kotlin.ext.asBsonObjectId
 import io.realm.kotlin.internal.interop.ErrorCode
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.util.use
 import io.realm.kotlin.mongodb.auth.ApiKey
 import io.realm.kotlin.mongodb.auth.ApiKeyAuth
@@ -48,7 +47,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     name,
                     channelResultCallback<ApiKeyWrapper, ApiKey>(channel) { apiKeyData ->
                         unwrap(apiKeyData)
-                    }.freeze()
+                    }
                 )
                 return channel.receive()
                     .getOrThrow()
@@ -76,7 +75,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     id,
                     channelResultCallback<Unit, Unit>(channel) {
                         // No-op
-                    }.freeze()
+                    }
                 )
                 return channel.receive().getOrThrow()
             }
@@ -100,7 +99,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     id,
                     channelResultCallback<Unit, Unit>(channel) {
                         // No-op
-                    }.freeze()
+                    }
                 )
                 return channel.receive()
                     .getOrThrow()
@@ -125,7 +124,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     id,
                     channelResultCallback<Unit, Unit>(channel) {
                         // No-op
-                    }.freeze()
+                    }
                 )
                 return channel.receive()
                     .getOrThrow()
@@ -150,7 +149,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                     id,
                     channelResultCallback<ApiKeyWrapper, ApiKey?>(channel) { apiKeyData: ApiKeyWrapper ->
                         unwrap(apiKeyData)
-                    }.freeze()
+                    }
                 )
                 return channel.receive()
                     .getOrThrow()
@@ -177,7 +176,7 @@ internal class ApiKeyAuthImpl(override val app: AppImpl, override val user: User
                         )
                     }
                     result
-                }.freeze()
+                }
             )
             return channel.receive()
                 .getOrThrow()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
@@ -35,7 +35,6 @@ import io.realm.kotlin.internal.platform.OS_VERSION
 import io.realm.kotlin.internal.platform.RUNTIME
 import io.realm.kotlin.internal.platform.RUNTIME_VERSION
 import io.realm.kotlin.internal.platform.appFilesDirectory
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.mongodb.AppConfiguration
 import io.realm.kotlin.mongodb.AppConfiguration.Companion.DEFAULT_BASE_URL
 
@@ -135,7 +134,7 @@ public class AppConfigurationImpl constructor(
                 framework = RUNTIME,
                 frameworkVersion = RUNTIME_VERSION
             )
-        ).freeze()
+        )
     }
 
     private fun initializeSyncClientConfig(sdkInfo: String?, applicationInfo: String?): RealmSyncClientConfigurationPointer =

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppImpl.kt
@@ -22,7 +22,6 @@ import io.realm.kotlin.internal.interop.RealmAppT
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.RealmUserPointer
 import io.realm.kotlin.internal.interop.sync.NetworkTransport
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.util.Validation
 import io.realm.kotlin.internal.util.use
 import io.realm.kotlin.mongodb.App
@@ -71,7 +70,7 @@ public class AppImpl(
                 Validation.checkType<CredentialsImpl>(credentials, "credentials").nativePointer,
                 channelResultCallback<RealmUserPointer, User>(channel) { userPointer ->
                     UserImpl(userPointer, this)
-                }.freeze()
+                }
             )
             return channel.receive()
                 .getOrThrow()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/EmailPasswordAuthImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/EmailPasswordAuthImpl.kt
@@ -2,7 +2,6 @@ package io.realm.kotlin.mongodb.internal
 
 import io.realm.kotlin.internal.interop.RealmAppPointer
 import io.realm.kotlin.internal.interop.RealmInterop
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.util.Validation
 import io.realm.kotlin.internal.util.use
 import io.realm.kotlin.mongodb.auth.EmailPasswordAuth
@@ -20,7 +19,7 @@ internal class EmailPasswordAuthImpl(private val app: RealmAppPointer) : EmailPa
                 Validation.checkEmpty(password, "password"),
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return channel.receive()
                 .getOrThrow()
@@ -35,7 +34,7 @@ internal class EmailPasswordAuthImpl(private val app: RealmAppPointer) : EmailPa
                 Validation.checkEmpty(tokenId, "tokenId"),
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return channel.receive()
                 .getOrThrow()
@@ -49,7 +48,7 @@ internal class EmailPasswordAuthImpl(private val app: RealmAppPointer) : EmailPa
                 Validation.checkEmpty(email, "email"),
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return channel.receive()
                 .getOrThrow()
@@ -63,7 +62,7 @@ internal class EmailPasswordAuthImpl(private val app: RealmAppPointer) : EmailPa
                 Validation.checkEmpty(email, "email"),
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return channel.receive()
                 .getOrThrow()
@@ -77,7 +76,7 @@ internal class EmailPasswordAuthImpl(private val app: RealmAppPointer) : EmailPa
                 Validation.checkEmpty(email, "email"),
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return channel.receive()
                 .getOrThrow()
@@ -94,7 +93,7 @@ internal class EmailPasswordAuthImpl(private val app: RealmAppPointer) : EmailPa
                     Bson.toJson(bsonValue),
                     channelResultCallback<Unit, Unit>(channel) {
                         // No-op
-                    }.freeze()
+                    }
                 )
             }
             return channel.receive()
@@ -111,7 +110,7 @@ internal class EmailPasswordAuthImpl(private val app: RealmAppPointer) : EmailPa
                 Validation.checkEmpty(tokenId, "tokenId"),
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return channel.receive()
                 .getOrThrow()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/HttpClientCache.kt
@@ -6,7 +6,6 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
-import io.realm.kotlin.internal.platform.freeze
 
 /**
  * Work-around for https://github.com/realm/realm-kotlin/issues/480
@@ -18,7 +17,7 @@ internal fun createClient(timeoutMs: Long, customLogger: Logger?): HttpClient {
     // Need to freeze value as it is used inside the client's init lambda block, which also
     // freezes captured objects too, see:
     // https://youtrack.jetbrains.com/issue/KTOR-1223#focus=Comments-27-4618681.0-0
-    val frozenTimeout = timeoutMs.freeze()
+    val frozenTimeout = timeoutMs
     return createPlatformClient {
         // Charset defaults to UTF-8 (https://ktor.io/docs/http-plain-text.html#configuration)
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SubscriptionSetImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SubscriptionSetImpl.kt
@@ -24,7 +24,6 @@ import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.RealmSubscriptionSetPointer
 import io.realm.kotlin.internal.interop.SubscriptionSetCallback
 import io.realm.kotlin.internal.interop.sync.CoreSubscriptionSetState
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.util.Validation
 import io.realm.kotlin.mongodb.exceptions.BadFlexibleSyncQueryException
 import io.realm.kotlin.mongodb.sync.MutableSubscriptionSet
@@ -100,7 +99,7 @@ internal class SubscriptionSetImpl<T : BaseRealm>(
                                 }
                             }
                         }
-                    }.freeze()
+                    }
                     RealmInterop.realm_sync_on_subscriptionset_state_change_async(
                         nativePointer,
                         CoreSubscriptionSetState.RLM_SYNC_SUBSCRIPTION_COMPLETE,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -34,7 +34,6 @@ import io.realm.kotlin.internal.interop.SyncBeforeClientResetHandler
 import io.realm.kotlin.internal.interop.SyncErrorCallback
 import io.realm.kotlin.internal.interop.sync.SyncError
 import io.realm.kotlin.internal.interop.sync.SyncSessionResyncMode
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.mongodb.exceptions.ClientResetRequiredException
 import io.realm.kotlin.mongodb.exceptions.DownloadingRealmTimeOutException
 import io.realm.kotlin.mongodb.subscriptions
@@ -86,7 +85,7 @@ internal class SyncConfigurationImpl(
                             } else {
                                 channel.trySend(true)
                             }
-                        }.freeze()
+                        }
 
                         val configPtr = createNativeConfiguration()
                         taskPointer.value = RealmInterop.realm_open_synchronized(configPtr)
@@ -154,8 +153,8 @@ internal class SyncConfigurationImpl(
     init {
         // We need to freeze `errorHandler` reference on initial thread
         val userErrorHandler = errorHandler
-        val resetStrategy = syncClientResetStrategy.freeze()
-        val frozenAppPointer = user.app.nativePointer.freeze()
+        val resetStrategy = syncClientResetStrategy
+        val frozenAppPointer = user.app.nativePointer
 
         val initializerHelper = when (resetStrategy) {
             is DiscardUnsyncedChangesStrategy ->
@@ -180,7 +179,7 @@ internal class SyncConfigurationImpl(
                 } else {
                     userErrorHandler.onError(session, syncError)
                 }
-            }.freeze()
+            }
 
         syncInitializer = { nativeConfig: RealmConfigurationPointer ->
             val nativeSyncConfig: RealmSyncConfigurationPointer = when (partitionValue) {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncSessionImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncSessionImpl.kt
@@ -28,7 +28,6 @@ import io.realm.kotlin.internal.interop.sync.ProgressDirection
 import io.realm.kotlin.internal.interop.sync.ProtocolClientErrorCode
 import io.realm.kotlin.internal.interop.sync.SyncErrorCode
 import io.realm.kotlin.internal.interop.sync.SyncErrorCodeCategory
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.util.Validation
 import io.realm.kotlin.internal.util.trySendWithBufferOverflowCheck
 import io.realm.kotlin.mongodb.User
@@ -208,7 +207,7 @@ internal open class SyncSessionImpl(
                                 channel.trySend(true)
                             }
                         }
-                    }.freeze()
+                    }
                     when (direction) {
                         TransferDirection.UPLOAD -> {
                             RealmInterop.realm_sync_session_wait_for_download_completion(

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
@@ -20,7 +20,6 @@ import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.RealmUserPointer
 import io.realm.kotlin.internal.interop.sync.AuthProvider
 import io.realm.kotlin.internal.interop.sync.CoreUserState
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.util.use
 import io.realm.kotlin.mongodb.AuthenticationProvider
 import io.realm.kotlin.mongodb.Credentials
@@ -101,7 +100,7 @@ public class UserImpl(
                 nativePointer,
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return@use channel.receive()
                 .getOrThrow()
@@ -115,7 +114,7 @@ public class UserImpl(
                 nativePointer,
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return@use channel.receive()
                 .getOrThrow()
@@ -133,7 +132,7 @@ public class UserImpl(
                 nativePointer,
                 channelResultCallback<Unit, Unit>(channel) {
                     // No-op
-                }.freeze()
+                }
             )
             return@use channel.receive()
                 .getOrThrow()
@@ -152,7 +151,7 @@ public class UserImpl(
                     (credentials as CredentialsImpl).nativePointer,
                     channelResultCallback<RealmUserPointer, User>(channel) { userPointer ->
                         UserImpl(userPointer, app)
-                    }.freeze()
+                    }
                 )
                 channel.receive().getOrThrow()
                 return this

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmDictionaryNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmDictionaryNotificationsTests.kt
@@ -20,7 +20,6 @@ import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.entities.dictionary.DictionaryEmbeddedLevel1
 import io.realm.kotlin.entities.dictionary.RealmDictionaryContainer
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.notifications.DeletedMap
 import io.realm.kotlin.notifications.InitialMap
 import io.realm.kotlin.notifications.MapChange
@@ -79,7 +78,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
             // inside a write block
             val values = NULLABLE_DICTIONARY_OBJECT_VALUES.mapIndexed { i, value ->
                 Pair(keys[i], value)
-            }.freeze()
+            }
             val channel1 = Channel<MapChange<String, *>>(capacity = 1)
             val channel2 = Channel<Boolean>(capacity = 1)
             val container = realm.write {

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmListNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmListNotificationsTests.kt
@@ -20,7 +20,6 @@ import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.entities.list.RealmListContainer
 import io.realm.kotlin.entities.list.listTestSchema
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.notifications.DeletedList
 import io.realm.kotlin.notifications.InitialList
 import io.realm.kotlin.notifications.ListChange
@@ -303,7 +302,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
         runBlocking {
             // Freeze values since native complains if we reference a package-level defined variable
             // inside a write block
-            val values = OBJECT_VALUES.freeze()
+            val values = OBJECT_VALUES
             val container = realm.write {
                 copyToRealm(RealmListContainer())
             }
@@ -361,7 +360,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
         runBlocking {
             // Freeze values since native complains if we reference a package-level defined variable
             // inside a write block
-            val values = OBJECT_VALUES.freeze()
+            val values = OBJECT_VALUES
             val channel1 = Channel<ListChange<*>>(capacity = 1)
             val channel2 = Channel<Boolean>(capacity = 1)
             val container = realm.write {

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmSetNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmSetNotificationsTests.kt
@@ -19,7 +19,6 @@ package io.realm.kotlin.test.shared.notifications
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.entities.set.RealmSetContainer
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.notifications.DeletedSet
 import io.realm.kotlin.notifications.InitialSet
 import io.realm.kotlin.notifications.SetChange
@@ -177,7 +176,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
         runBlocking {
             // Freeze values since native complains if we reference a package-level defined variable
             // inside a write block
-            val values = SET_OBJECT_VALUES.freeze()
+            val values = SET_OBJECT_VALUES
             val container = realm.write {
                 copyToRealm(RealmSetContainer())
             }
@@ -235,7 +234,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
         runBlocking {
             // Freeze values since native complains if we reference a package-level defined variable
             // inside a write block
-            val values = SET_OBJECT_VALUES.freeze()
+            val values = SET_OBJECT_VALUES
             val channel1 = Channel<SetChange<*>>(capacity = 1)
             val channel2 = Channel<Boolean>(capacity = 1)
             val container = realm.write {

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
@@ -24,7 +24,6 @@ import io.realm.kotlin.entities.sync.ObjectIdPk
 import io.realm.kotlin.entities.sync.ParentPk
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.internal.interop.RealmInterop
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.exceptions.SyncException
@@ -322,7 +321,7 @@ class SyncSessionTests {
         val user = runBlocking {
             app.createUserAndLogIn(email, password)
         }
-        val channel = Channel<SyncSession>(1).freeze()
+        val channel = Channel<SyncSession>(1)
         val config = SyncConfiguration.Builder(
             schema = setOf(ParentPk::class, ChildPk::class),
             user = user,
@@ -487,7 +486,7 @@ class SyncSessionTests {
     @Test
     fun getConfiguration_inErrorHandlerThrows() {
         // Open and close a realm with a schema.
-        val channel = Channel<SyncSession>(1).freeze()
+        val channel = Channel<SyncSession>(1)
         val (email, password) = TestHelper.randomEmail() to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
@@ -29,7 +29,6 @@ import io.realm.kotlin.entities.sync.flx.FlexEmbeddedObject
 import io.realm.kotlin.entities.sync.flx.FlexParentObject
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.internal.platform.fileExists
-import io.realm.kotlin.internal.platform.freeze
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.log.RealmLogger
@@ -315,7 +314,7 @@ class SyncedRealmTests {
 
     @Test
     fun errorHandlerReceivesPermissionDeniedSyncError() {
-        val channel = Channel<Throwable>(1).freeze()
+        val channel = Channel<Throwable>(1)
         // Remove permissions to generate a sync error containing ONLY the original path
         // This way we assert we don't read wrong data from the user_info field
         val (email, password) = "test_nowrite_noread_${randomEmail()}" to "password1234"
@@ -355,7 +354,7 @@ class SyncedRealmTests {
     @Test
     fun testErrorHandler() {
         // Open a realm with a schema. Close it without doing anything else
-        val channel = Channel<SyncException>(1).freeze()
+        val channel = Channel<SyncException>(1)
         val (email, password) = randomEmail() to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)


### PR DESCRIPTION
Closes #1294 

This PR removes all uses of `freeze`. It was already a no-op when moving to the new memory model and we just kept it to be able to shift back easily. But there has been no pushback against moving to the new memory model, so might as well cleanup the code.