### PR TITLE
Fail at compile time on wrong use of `val` and `lateinit`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements
 * Upgrade OpenSSL from 3.0.7 to 3.0.8.
+* Wrong use of `val` for persisted properties will now throw a compiler time error, instead of crashing at runtime. (Issue [#1306](https://github.com/realm/realm-kotlin/issues/1306))
 * Add support for querying on RealmSets containing objects with `RealmSet.query(...)`.  (Issue [#1037](https://github.com/realm/realm-kotlin/issues/1258))
 * [Sync] Add support for setting App Services connection identifiers through `AppConfiguration.appName` and `AppConfiguration.appVersion`, making it easier to identify connections in the server logs. (Issue (#407)[https://github.com/realm/realm-kotlin/issues/407])
 * [Sync] Added `RecoverUnsyncedChangesStrategy`, an alternative automatic client reset strategy that tries to automatically recover any unsynced data from the client.

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/ModelDefinitionTests.kt
@@ -129,4 +129,38 @@ class ModelDefinitionTests {
         assertEquals(KotlinCompilation.ExitCode.INTERNAL_ERROR, result.exitCode, "Compilation should fail when using anonymous objects")
         assertTrue(result.messages.contains("Anonymous objects are not supported."))
     }
+
+    @Test
+    fun `persisted_properties_with_val_should_fail`() {
+        val result = Compiler.compileFromSource(
+            plugins = listOf(Registrar()),
+            source = SourceFile.kotlin(
+                "persisted_properties_val.kt",
+                """
+                        import io.realm.kotlin.types.RealmObject
+                        class Person(val name: String) : RealmObject
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, "Persisted properties does not allow val")
+        assertTrue(result.messages.contains("Persisted properties must be marked with `var`"))
+    }
+
+    @Test
+    fun `persisted_properties_with_lateinit_should_fail`() {
+        val result = Compiler.compileFromSource(
+            plugins = listOf(Registrar()),
+            source = SourceFile.kotlin(
+                "persisted_properties_lateinit.kt",
+                """
+                        import io.realm.kotlin.types.RealmObject
+                        class Person : RealmObject {
+                            lateinit var name: String
+                        }
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, "Persisted properties does not allow lateinit")
+        assertTrue(result.messages.contains("Persisted properties must not be marked with `lateinit`."))
+    }
 }


### PR DESCRIPTION
Closes #1306 

It turned out that the Kotlin compiler automatically catches several wrong uses:

- `const` is not supported, but not allowed inside classes either, so we get this check for free.
- delegated properties must be marked `val`, so we get `by backlinks()` checks for free.
- We now detect wrong use of `val`
- We now detect wrong use of `lateinit`.