### PR TITLE
Fix SyncSession.uploadAllLocalChanges and SyncSession.downloadAllServerChanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Compatibility with Realm Java when using the `io.realm.RealmObject` abstract class. (Issue [#1278](https://github.com/realm/realm-kotlin/issues/1278))
 * Compiler error when multiple fields have `@PersistedName`-annotations that match they Kotlin name. (Issue [#1240](https://github.com/realm/realm-kotlin/issues/1240))
 * Compiler error when using Kotlin 1.8.0 and Compose for desktop 1.3.0. (Issue [#1296](https://github.com/realm/realm-kotlin/issues/1296))
+* [Sync] `SyncSession.downloadAllServerChange()` and `SyncSession.uploadAllLocalChanges()` was reversed.
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncSessionImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncSessionImpl.kt
@@ -211,13 +211,13 @@ internal open class SyncSessionImpl(
                     }.freeze()
                     when (direction) {
                         TransferDirection.UPLOAD -> {
-                            RealmInterop.realm_sync_session_wait_for_download_completion(
+                            RealmInterop.realm_sync_session_wait_for_upload_completion(
                                 nativePointer,
                                 callback
                             )
                         }
                         TransferDirection.DOWNLOAD -> {
-                            RealmInterop.realm_sync_session_wait_for_upload_completion(
+                            RealmInterop.realm_sync_session_wait_for_download_completion(
                                 nativePointer,
                                 callback
                             )


### PR DESCRIPTION
This was accidentally discovered during testing another project. We have had flaky tests in the past because of this, but I think we contributed those test failures to the async nature of the server and the translator.

I could 100% reproduce this by doing:

```
// Write to Realm 1
repeat(1000) {
  realm1.write { copyToRealm(MyObject()) }
}
realm1.syncSession.uploadAllLocalChanges()
realm1.close()

// Download objects for Realm2
// It would not see all 1000 objects
```
It would result in the client cutting off some transactions meaning other devices saw anywhere from 500 - 950-ish objects.

I haven't added a test for this in this PR since the above test takes a couple of minutes to run, and it doesn't seem worth it to add that expensive of a test.