### PR TITLE
Add receiveOrFail for better testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Realm Studio 13.0.0 or above is required to open Realms created by this version.
 * This release is compatible with the following Kotlin releases:
   * Kotlin 1.7.20 and above.
-  * Ktor 2.1.2 and above.
+  * Ktor 2.2.4 and above.
   * Coroutines 1.6.4 and above.
   * AtomicFu 0.18.3 and above.
   * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Realm Studio 13.0.0 or above is required to open Realms created by this version.
 * This release is compatible with the following Kotlin releases:
   * Kotlin 1.7.20 and above.
-  * Ktor 2.2.4 and above.
+  * Ktor 2.1.2 and above.
   * Coroutines 1.6.4 and above.
   * AtomicFu 0.18.3 and above.
   * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility

--- a/benchmarks/androidApp/build.gradle.kts
+++ b/benchmarks/androidApp/build.gradle.kts
@@ -17,7 +17,9 @@ android {
     }
 
     defaultConfig {
-        minSdk = Versions.Android.minSdk
+        // Use minSdk = 32 because minSdk = 33 is throwing build time warnings saying it isn't supported,
+        // also we want to test performance against the latest release rather than the oldest.
+        minSdk = 32
         targetSdk = Versions.Android.targetSdk
         testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
         testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR,UNLOCKED"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -59,7 +59,7 @@ object Versions {
         const val buildTools = "7.2.2" // https://maven.google.com/web/index.html?q=gradle#com.android.tools.build:gradle
         const val ndkVersion = "23.2.8568313"
     }
-    const val androidxBenchmarkPlugin = "1.2.0-alpha05" // https://maven.google.com/web/index.html#androidx.benchmark:androidx.benchmark.gradle.plugin
+    const val androidxBenchmarkPlugin = "1.2.0-alpha12" // https://maven.google.com/web/index.html#androidx.benchmark:androidx.benchmark.gradle.plugin
     const val androidxStartup = "1.1.1" // https://maven.google.com/web/index.html?q=startup#androidx.startup:startup-runtime
     const val androidxJunit = "1.1.3" // https://maven.google.com/web/index.html#androidx.test.ext:junit
     const val androidxTest = "1.4.0" // https://maven.google.com/web/index.html#androidx.test:rules

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -83,7 +83,7 @@ object Versions {
     const val latestKotlin = "1.8.20-Beta" // https://kotlinlang.org/docs/eap.html#build-details
     const val kotlinCompileTesting = "1.4.9" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlint = "0.45.2" // https://github.com/pinterest/ktlint
-    const val ktor = "2.2.4" // https://github.com/ktorio/ktor
+    const val ktor = "2.1.2" // https://github.com/ktorio/ktor
     const val nexusPublishPlugin = "1.1.0" // https://github.com/gradle-nexus/publish-plugin
     const val okio = "3.2.0" // https://square.github.io/okio/#releases
     const val relinker = "1.4.5" // https://github.com/KeepSafe/ReLinker

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -83,7 +83,7 @@ object Versions {
     const val latestKotlin = "1.8.20-Beta" // https://kotlinlang.org/docs/eap.html#build-details
     const val kotlinCompileTesting = "1.4.9" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlint = "0.45.2" // https://github.com/pinterest/ktlint
-    const val ktor = "2.1.2" // https://github.com/ktorio/ktor
+    const val ktor = "2.2.4" // https://github.com/ktorio/ktor
     const val nexusPublishPlugin = "1.1.0" // https://github.com/gradle-nexus/publish-plugin
     const val okio = "3.2.0" // https://square.github.io/okio/#releases
     const val relinker = "1.4.5" // https://github.com/KeepSafe/ReLinker

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/LogObfuscator.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/LogObfuscator.kt
@@ -160,7 +160,7 @@ internal class GenericRegexPatternReplacer(
 
     override fun findAndReplace(input: String): String {
         return if (
-            input.contains("RESPONSE: 200 OK") &&
+            input.contains("RESPONSE: 200") &&
             input.contains("access_token") &&
             input.contains("refresh_token")
         ) {
@@ -186,7 +186,7 @@ internal object CustomFunctionPatternReplacer : LogReplacer {
         val (pattern, replacement) = when {
             input.contains("REQUEST: ") ->
                 """("arguments"):\[.*]""".toRegex() to """"arguments":[***]"""
-            input.contains("RESPONSE: 200 OK") ->
+            input.contains("RESPONSE: 200") ->
                 """BODY START\n.*\nBODY END""".toRegex() to "BODY START\n***\nBODY END"
             else -> return input
         }
@@ -196,21 +196,15 @@ internal object CustomFunctionPatternReplacer : LogReplacer {
 
 internal object LogObfuscatorImpl : HttpLogObfuscator {
 
-    private val urlRegex =
-        Regex("https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()!@:%_\\+.~#?&\\/\\/=]*)")
-
     private val regexReplacerMap: Map<String, LogReplacer> = defaultFeatureToReplacerMap
 
     override fun obfuscate(input: String): String {
-        return urlRegex.find(input)?.let { matchResult ->
-            val url = matchResult.value
-            regexReplacerMap
-                .filterKeys { url.contains(it) }
-                .values
-                .map {
-                    it.findAndReplace(input)
-                }
-                .firstOrNull()
-        } ?: input
+        return regexReplacerMap
+            .filterKeys { input.contains(it) }
+            .values
+            .map {
+                it.findAndReplace(input)
+            }
+            .firstOrNull() ?: input
     }
 }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/QueryTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/QueryTests.kt
@@ -46,6 +46,7 @@ import io.realm.kotlin.schema.RealmStorageType
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TypeDescriptor
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmAny
 import io.realm.kotlin.types.RealmDictionary
@@ -352,7 +353,7 @@ class QueryTests {
                     }
             }
 
-            channel.receive().let { resultsChange ->
+            channel.receiveOrFail().let { resultsChange ->
                 assertIs<InitialResults<*>>(resultsChange)
                 assertTrue(resultsChange.list.isEmpty())
             }
@@ -376,7 +377,7 @@ class QueryTests {
                     }
             }
 
-            channel.receive().let { resultsChange ->
+            channel.receiveOrFail().let { resultsChange ->
                 assertIs<InitialResults<*>>(resultsChange)
                 assertTrue(resultsChange.list.isEmpty())
             }
@@ -385,7 +386,7 @@ class QueryTests {
                 copyToRealm(QuerySample())
             }
 
-            channel.receive().let { resultsChange ->
+            channel.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
                 assertEquals(1, resultsChange.list.size)
             }
@@ -413,7 +414,7 @@ class QueryTests {
                     }
             }
 
-            channel.receive().let { resultsChange ->
+            channel.receiveOrFail().let { resultsChange ->
                 assertIs<InitialResults<*>>(resultsChange)
                 assertEquals(1, resultsChange.list.size)
             }
@@ -422,7 +423,7 @@ class QueryTests {
                 delete(query<QuerySample>())
             }
 
-            channel.receive().let { resultsChange ->
+            channel.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
                 assertTrue(resultsChange.list.isEmpty())
             }
@@ -1014,7 +1015,7 @@ class QueryTests {
                     }
             }
 
-            assertEquals(0, channel.receive())
+            assertEquals(0, channel.receiveOrFail())
 
             observer.cancel()
             channel.close()
@@ -1036,13 +1037,13 @@ class QueryTests {
                     }
             }
 
-            assertEquals(0, channel.receive())
+            assertEquals(0, channel.receiveOrFail())
 
             realm.writeBlocking {
                 copyToRealm(QuerySample())
             }
 
-            assertEquals(1, channel.receive())
+            assertEquals(1, channel.receiveOrFail())
             observer.cancel()
             channel.close()
         }
@@ -1067,13 +1068,13 @@ class QueryTests {
                     }
             }
 
-            assertEquals(1, channel.receive())
+            assertEquals(1, channel.receiveOrFail())
 
             realm.write {
                 delete(query<QuerySample>())
             }
 
-            assertEquals(0, channel.receive())
+            assertEquals(0, channel.receiveOrFail())
 
             observer.cancel()
             channel.close()
@@ -1103,8 +1104,8 @@ class QueryTests {
                     }
             }
 
-            assertEquals(0, channel1.receive())
-            assertEquals(0, channel2.receive())
+            assertEquals(0, channel1.receiveOrFail())
+            assertEquals(0, channel2.receiveOrFail())
 
             // Write one object
             realm.write {
@@ -1112,8 +1113,8 @@ class QueryTests {
             }
 
             // Assert emission and cancel first subscription
-            assertEquals(1, channel1.receive())
-            assertEquals(1, channel2.receive())
+            assertEquals(1, channel1.receiveOrFail())
+            assertEquals(1, channel2.receiveOrFail())
             observer1.cancel()
 
             // Write another object
@@ -1122,7 +1123,7 @@ class QueryTests {
             }
 
             // Assert emission and that the original channel hasn't been received
-            assertEquals(2, channel2.receive())
+            assertEquals(2, channel2.receiveOrFail())
             assertTrue(channel1.isEmpty)
 
             observer2.cancel()
@@ -1857,7 +1858,7 @@ class QueryTests {
                     }
             }
 
-            channel.receive().let { objectChange ->
+            channel.receiveOrFail().let { objectChange ->
                 assertTrue(channel.isEmpty) // Validates that this is the first event and only event
                 assertIs<PendingObject<QuerySample>>(objectChange)
             }
@@ -1870,7 +1871,7 @@ class QueryTests {
                 }
             }
 
-            channel.receive().let { objectChange ->
+            channel.receiveOrFail().let { objectChange ->
                 assertTrue(channel.isEmpty) // Validates that this is the first event and only event
 
                 assertIs<InitialObject<QuerySample>>(objectChange)
@@ -1885,7 +1886,7 @@ class QueryTests {
                 }
             }
 
-            channel.receive().let { objectChange ->
+            channel.receiveOrFail().let { objectChange ->
                 assertIs<UpdatedObject<QuerySample>>(objectChange)
                 assertEquals(6, objectChange.obj.intField)
             }
@@ -1898,7 +1899,7 @@ class QueryTests {
                 }
             }
 
-            channel.receive().let { objectChange ->
+            channel.receiveOrFail().let { objectChange ->
                 assertIs<UpdatedObject<QuerySample>>(objectChange)
                 assertEquals(7, objectChange.obj.intField)
             }
@@ -1909,9 +1910,9 @@ class QueryTests {
                 delete(query<QuerySample>("intField = $0", 7).first().find()!!)
             }
 
-            assertIs<DeletedObject<QuerySample>>(channel.receive())
+            assertIs<DeletedObject<QuerySample>>(channel.receiveOrFail())
 
-            channel.receive().let { objectChange ->
+            channel.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<QuerySample>>(objectChange)
                 assertEquals(4, objectChange.obj.intField)
             }
@@ -1924,7 +1925,7 @@ class QueryTests {
                 }
             }
 
-            channel.receive().let { objectChange ->
+            channel.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<QuerySample>>(objectChange)
                 assertEquals(7, objectChange.obj.intField)
             }
@@ -1938,9 +1939,9 @@ class QueryTests {
                 }
             }
 
-            assertIs<DeletedObject<QuerySample>>(channel.receive())
+            assertIs<DeletedObject<QuerySample>>(channel.receiveOrFail())
 
-            channel.receive().let { objectChange ->
+            channel.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<QuerySample>>(objectChange)
                 assertEquals(10, objectChange.obj.intField)
             }
@@ -1951,7 +1952,7 @@ class QueryTests {
                 delete(query<QuerySample>())
             }
 
-            assertIs<DeletedObject<QuerySample>>(channel.receive())
+            assertIs<DeletedObject<QuerySample>>(channel.receiveOrFail())
 
             observer.cancel()
             channel.close()
@@ -1981,8 +1982,8 @@ class QueryTests {
                     }
             }
 
-            assertIs<PendingObject<*>>(channel1.receive())
-            assertIs<PendingObject<*>>(channel2.receive())
+            assertIs<PendingObject<*>>(channel1.receiveOrFail())
+            assertIs<PendingObject<*>>(channel2.receiveOrFail())
 
             // Write one object
             realm.write {
@@ -1990,8 +1991,8 @@ class QueryTests {
             }
 
             // Assert emission and cancel first subscription
-            assertIs<InitialObject<*>>(channel1.receive())
-            assertIs<InitialObject<*>>(channel2.receive())
+            assertIs<InitialObject<*>>(channel1.receiveOrFail())
+            assertIs<InitialObject<*>>(channel2.receiveOrFail())
             observer1.cancel()
 
             // Update object
@@ -2002,7 +2003,7 @@ class QueryTests {
             }
 
             // Assert emission and that the original channel hasn't been received
-            assertIs<UpdatedObject<*>>(channel2.receive())
+            assertIs<UpdatedObject<*>>(channel2.receiveOrFail())
             assertTrue(channel1.isEmpty)
 
             observer2.cancel()
@@ -2237,7 +2238,7 @@ class QueryTests {
                 val results = query!!.find()
                 channel.send(results)
             }
-            val results = channel.receive()
+            val results = channel.receiveOrFail()
             assertEquals(1, results.size)
 
             query!!.find { res ->
@@ -2476,7 +2477,7 @@ class QueryTests {
                     }
             }
 
-            val aggregatedValue = channel.receive()
+            val aggregatedValue = channel.receiveOrFail()
             when (type) {
                 AggregatorQueryType.SUM -> when (aggregatedValue) {
                     is Number -> assertEquals(0, aggregatedValue.toInt())
@@ -2492,7 +2493,7 @@ class QueryTests {
                 saveData(propertyDescriptor)
             }
 
-            val receivedAggregate = channel.receive()
+            val receivedAggregate = channel.receiveOrFail()
             when (propertyDescriptor.clazz) {
                 RealmAny::class -> when (type) {
                     AggregatorQueryType.MIN -> {
@@ -2542,12 +2543,12 @@ class QueryTests {
             when (propertyDescriptor.clazz) {
                 RealmAny::class -> when (type) {
                     AggregatorQueryType.SUM -> assertFailsWith<TimeoutCancellationException> {
-                        withTimeout(100) { channel.receive() }
+                        withTimeout(100) { channel.receiveOrFail() }
                     }
                     // MAX for RealmAny is RealmObject so emitted objects will not be the same
                     // even though they may the same at a structural level
                     AggregatorQueryType.MAX -> {
-                        val receivedRepeatedAggregate = channel.receive()
+                        val receivedRepeatedAggregate = channel.receiveOrFail()
                         val actualString = (receivedRepeatedAggregate as RealmAny)
                             .asRealmObject<QuerySample>()
                             .stringField
@@ -2557,11 +2558,11 @@ class QueryTests {
                         assertEquals(expectedString, actualString)
                     }
                     AggregatorQueryType.MIN -> assertFailsWith<TimeoutCancellationException> {
-                        withTimeout(100) { channel.receive() }
+                        withTimeout(100) { channel.receiveOrFail() }
                     }
                 }
                 else -> assertFailsWith<TimeoutCancellationException> {
-                    withTimeout(100) { channel.receive() }
+                    withTimeout(100) { channel.receiveOrFail() }
                 }
             }
 
@@ -2570,7 +2571,7 @@ class QueryTests {
                 delete(query<QuerySample>())
             }
 
-            val finalAggregatedValue = channel.receive()
+            val finalAggregatedValue = channel.receiveOrFail()
             when (type) {
                 AggregatorQueryType.SUM -> when (finalAggregatedValue) {
                     is Number -> assertEquals(0, finalAggregatedValue.toInt())
@@ -2630,7 +2631,7 @@ class QueryTests {
                     }
             }
 
-            val receivedAggregate = channel.receive()
+            val receivedAggregate = channel.receiveOrFail()
             when (propertyDescriptor.clazz) {
                 RealmAny::class -> when (type) {
                     AggregatorQueryType.MIN -> {
@@ -2668,7 +2669,7 @@ class QueryTests {
                 delete(query<QuerySample>())
             }
 
-            val aggregatedValue = channel.receive()
+            val aggregatedValue = channel.receiveOrFail()
             when (type) {
                 AggregatorQueryType.SUM -> when (aggregatedValue) {
                     is Number -> assertEquals(0, aggregatedValue.toInt())
@@ -2745,8 +2746,8 @@ class QueryTests {
                     }
             }
 
-            val initialAggregate1 = channel1.receive()
-            val initialAggregate2 = channel2.receive()
+            val initialAggregate1 = channel1.receiveOrFail()
+            val initialAggregate2 = channel2.receiveOrFail()
             when (type) {
                 AggregatorQueryType.SUM -> when (initialAggregate1) {
                     is Number -> {
@@ -2777,7 +2778,7 @@ class QueryTests {
             }
 
             // Assert emission and that the original channel hasn't been received
-            val receivedAggregate = channel2.receive()
+            val receivedAggregate = channel2.receiveOrFail()
             if (propertyDescriptor.clazz == RealmAny::class) {
                 when (type) {
                     AggregatorQueryType.SUM -> {

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmAnyTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmAnyTests.kt
@@ -35,6 +35,7 @@ import io.realm.kotlin.query.find
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TypeDescriptor
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import io.realm.kotlin.types.RealmAny
 import io.realm.kotlin.types.RealmInstant
@@ -367,23 +368,23 @@ class RealmAnyTests {
                     }
             }
 
-            assertIs<PendingObject<Sample>>(sampleChannel.receive())
-            assertIs<PendingObject<RealmAnyContainer>>(containerChannel.receive())
+            assertIs<PendingObject<Sample>>(sampleChannel.receiveOrFail())
+            assertIs<PendingObject<RealmAnyContainer>>(containerChannel.receiveOrFail())
 
             val unmanagedContainer = RealmAnyContainer(RealmAny.create(Sample()))
             realm.writeBlocking {
                 copyToRealm(unmanagedContainer)
             }
 
-            assertIs<InitialObject<Sample>>(sampleChannel.receive())
-            assertIs<InitialObject<RealmAnyContainer>>(containerChannel.receive())
+            assertIs<InitialObject<Sample>>(sampleChannel.receiveOrFail())
+            assertIs<InitialObject<RealmAnyContainer>>(containerChannel.receiveOrFail())
 
             realm.writeBlocking {
                 delete(query<Sample>())
             }
 
-            val deletedObjectEvent = sampleChannel.receive()
-            val updatedContainerEvent = containerChannel.receive()
+            val deletedObjectEvent = sampleChannel.receiveOrFail()
+            val updatedContainerEvent = containerChannel.receiveOrFail()
             assertIs<DeletedObject<Sample>>(deletedObjectEvent)
             assertNull(deletedObjectEvent.obj)
             assertIs<UpdatedObject<RealmAnyContainer>>(updatedContainerEvent)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInMemoryTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmInMemoryTests.kt
@@ -11,6 +11,7 @@ import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestHelper
+import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
@@ -202,7 +203,7 @@ class RealmInMemoryTests {
 
                 try {
                     withTimeout(10000L) {
-                        realmInMainClosedChannel.receive()
+                        realmInMainClosedChannel.receiveOrFail()
                     }
                 } catch (err: Exception) {
                     threadError[0] = Exception("Worker thread was interrupted")
@@ -216,7 +217,7 @@ class RealmInMemoryTests {
 
             // Waits until the worker thread started.
             withTimeout(10000L) {
-                workerCommittedChannel.receive()
+                workerCommittedChannel.receiveOrFail()
                 if (threadError[0] != null) {
                     throw threadError[0]!!
                 }
@@ -239,7 +240,7 @@ class RealmInMemoryTests {
             // Let the worker thread continue.
             realmInMainClosedChannel.send(true)
             withTimeout(10000L) {
-                workerClosedChannel.receive()
+                workerClosedChannel.receiveOrFail()
                 if (threadError[0] != null) {
                     throw threadError[0]!!
                 }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmTests.kt
@@ -29,6 +29,7 @@ import io.realm.kotlin.query.find
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.platform.platformFileSystem
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -453,14 +454,14 @@ class RealmTests {
                 val anotherRealm = Realm.open(configuration)
                 bgThreadReadyChannel.send(Unit)
 
-                readyToCloseChannel.receive()
+                readyToCloseChannel.receiveOrFail()
 
                 anotherRealm.close()
                 closedChannel.send(Unit)
             }
 
             // Waits for background thread opening the same Realm.
-            bgThreadReadyChannel.receive()
+            bgThreadReadyChannel.receiveOrFail()
 
             // Check the realm got created correctly and signal that it can be closed.
             fileSystem.list(testDirPath)
@@ -471,7 +472,7 @@ class RealmTests {
 
             testRealm.close()
 
-            closedChannel.receive()
+            closedChannel.receiveOrFail()
 
             // Delete realm now that it's fully closed.
             Realm.deleteRealm(configuration)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/BacklinksNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/BacklinksNotificationsTests.kt
@@ -25,6 +25,7 @@ import io.realm.kotlin.notifications.UpdatedResults
 import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.test.RealmEntityNotificationTests
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -90,7 +91,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                         }
                 }
 
-                c.receive().let { resultsChange ->
+                c.receiveOrFail().let { resultsChange ->
                     assertIs<InitialResults<*>>(resultsChange)
                     assertTrue(resultsChange.list.isEmpty())
                 }
@@ -143,7 +144,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                 }
 
                 // Assertion after empty list is emitted
-                c.receive().let { resultsChange ->
+                c.receiveOrFail().let { resultsChange ->
                     assertIs<InitialResults<*>>(resultsChange)
 
                     assertNotNull(resultsChange.list)
@@ -155,7 +156,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     delete(findLatest(results.first())!!)
                 }
 
-                c.receive().let { resultsChange ->
+                c.receiveOrFail().let { resultsChange ->
                     assertIs<UpdatedResults<*>>(resultsChange)
 
                     assertNotNull(resultsChange.list)
@@ -181,7 +182,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                 }
             }
 
-            c.receive().let {
+            c.receiveOrFail().let {
                 assertIs<InitialResults<*>>(it)
                 assertEquals(0, it.list.size)
             }
@@ -190,7 +191,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                 copyToRealm(Sample().apply { nullableObject = findLatest(target) })
             }
 
-            c.receive().let {
+            c.receiveOrFail().let {
                 assertIs<UpdatedResults<*>>(it)
                 assertEquals(1, it.list.size)
                 assertEquals(0, it.deletions.size)
@@ -246,11 +247,11 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     }
                 }
 
-                c1.receive().let { resultsChange ->
+                c1.receiveOrFail().let { resultsChange ->
                     assertIs<InitialResults<*>>(resultsChange)
                     assertEquals(1, resultsChange.list.size)
                 }
-                c2.receive().let { resultsChange ->
+                c2.receiveOrFail().let { resultsChange ->
                     assertIs<InitialResults<*>>(resultsChange)
                     assertEquals(1, resultsChange.list.size)
                 }
@@ -261,7 +262,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     delete(findLatest(results.first())!!)
                 }
 
-                c2.receive().let { resultsChange ->
+                c2.receiveOrFail().let { resultsChange ->
                     assertIs<UpdatedResults<*>>(resultsChange)
                     assertEquals(0, resultsChange.list.size)
                 }
@@ -307,7 +308,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                 }
 
                 // Assertion after empty list is emitted
-                c.receive()!!.let { resultsChange ->
+                c.receiveOrFail()!!.let { resultsChange ->
                     assertIs<InitialResults<*>>(resultsChange)
 
                     assertNotNull(resultsChange.list)
@@ -315,7 +316,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                 }
 
                 // Assertion after subquery is emitted
-                sc.receive()!!.let { resultsChange ->
+                sc.receiveOrFail()!!.let { resultsChange ->
                     assertIs<InitialResults<*>>(resultsChange)
 
                     assertNotNull(resultsChange.list)
@@ -327,8 +328,8 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     delete(findLatest(target)!!)
                 }
 
-                assertNull(c.receive())
-                assertNull(sc.receive())
+                assertNull(c.receiveOrFail())
+                assertNull(sc.receiveOrFail())
 
                 observer.cancel()
                 c.close()
@@ -399,7 +400,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
 
             // Await that collect is actually collecting
             withTimeout(10.seconds) {
-                assertEquals(1, c.receive())
+                assertEquals(1, c.receiveOrFail())
             }
             realm.close()
             delay(1.seconds)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmDictionaryNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmDictionaryNotificationsTests.kt
@@ -28,6 +28,7 @@ import io.realm.kotlin.test.RealmEntityNotificationTests
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.shared.DICTIONARY_KEYS_FOR_NULLABLE
 import io.realm.kotlin.test.shared.NULLABLE_DICTIONARY_OBJECT_VALUES
+import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
@@ -100,7 +101,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Assert container got populated correctly
-            channel1.receive().let { mapChange ->
+            channel1.receiveOrFail().let { mapChange ->
                 assertIs<InitialMap<String, *>>(mapChange)
 
                 assertNotNull(mapChange.map)
@@ -112,12 +113,12 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 delete(findLatest(container)!!)
             }
 
-            channel1.receive().let { mapChange ->
+            channel1.receiveOrFail().let { mapChange ->
                 assertIs<DeletedMap<String, *>>(mapChange)
                 assertTrue(mapChange.map.isEmpty())
             }
             // Wait for flow completion
-            assertTrue(channel2.receive())
+            assertTrue(channel2.receiveOrFail())
 
             observer.cancel()
             channel1.close()
@@ -178,7 +179,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Assertion after empty dictionary is emitted
-            channel.receive().let { mapChange ->
+            channel.receiveOrFail().let { mapChange ->
                 assertIs<InitialMap<String, *>>(mapChange)
 
                 assertNotNull(mapChange.map)
@@ -220,7 +221,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 queriedDictionary[dataSet[0].first] = dataSet[0].second
             }
 
-            channel.receive().let { mapChange ->
+            channel.receiveOrFail().let { mapChange ->
                 assertIs<UpdatedMap<String, *>>(mapChange)
 
                 assertNotNull(mapChange.map)
@@ -240,7 +241,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 queriedDictionary[dataSet[0].first] = dataSet[1].second
             }
 
-            channel.receive().let { mapChange ->
+            channel.receiveOrFail().let { mapChange ->
                 assertIs<UpdatedMap<String, *>>(mapChange)
 
                 assertNotNull(mapChange.map)
@@ -260,7 +261,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 queriedDictionary.putAll(dataSet.subList(1, dataSet.size))
             }
 
-            channel.receive().let { mapChange ->
+            channel.receiveOrFail().let { mapChange ->
                 assertIs<UpdatedMap<String, *>>(mapChange)
 
                 assertNotNull(mapChange.map)
@@ -283,7 +284,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 queriedDictionary.remove(dataSet[0].first)
             }
 
-            channel.receive().let { mapChange ->
+            channel.receiveOrFail().let { mapChange ->
                 assertIs<UpdatedMap<String, *>>(mapChange)
 
                 assertNotNull(mapChange.map)
@@ -302,7 +303,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 iterator.remove()
             }
 
-            channel.receive().let { mapChange ->
+            channel.receiveOrFail().let { mapChange ->
                 assertIs<UpdatedMap<String, *>>(mapChange)
 
                 assertNotNull(mapChange.map)
@@ -321,7 +322,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 iterator.remove()
             }
 
-            channel.receive().let { mapChange ->
+            channel.receiveOrFail().let { mapChange ->
                 assertIs<UpdatedMap<String, *>>(mapChange)
 
                 assertNotNull(mapChange.map)
@@ -363,16 +364,16 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Ignore first emission with empty dictionaries
-            channel1.receive()
-            channel2.receive()
+            channel1.receiveOrFail()
+            channel2.receiveOrFail()
 
             // Trigger an update
             realm.write {
                 val queriedContainer = findLatest(container)
                 queriedContainer!!.nullableObjectDictionaryField.putAll(values)
             }
-            assertEquals(NULLABLE_DICTIONARY_OBJECT_VALUES.size, channel1.receive().map.size)
-            assertEquals(NULLABLE_DICTIONARY_OBJECT_VALUES.size, channel2.receive().map.size)
+            assertEquals(NULLABLE_DICTIONARY_OBJECT_VALUES.size, channel1.receiveOrFail().map.size)
+            assertEquals(NULLABLE_DICTIONARY_OBJECT_VALUES.size, channel2.receiveOrFail().map.size)
 
             // Cancel observer 1
             observer1.cancel()
@@ -388,7 +389,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Check channel 1 didn't receive the update
-            assertEquals(NULLABLE_DICTIONARY_OBJECT_VALUES.size + 1, channel2.receive().map.size)
+            assertEquals(NULLABLE_DICTIONARY_OBJECT_VALUES.size + 1, channel2.receiveOrFail().map.size)
             assertTrue(channel1.isEmpty)
 
             observer2.cancel()
@@ -419,7 +420,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 fail("Flow should not be canceled.")
             }
 
-            assertTrue(channel.receive().map.isEmpty())
+            assertTrue(channel.receiveOrFail().map.isEmpty())
 
             realm.close()
             observer.cancel()

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmListNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmListNotificationsTests.kt
@@ -31,6 +31,7 @@ import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.shared.OBJECT_VALUES
 import io.realm.kotlin.test.shared.OBJECT_VALUES2
 import io.realm.kotlin.test.shared.OBJECT_VALUES3
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.types.RealmList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -94,7 +95,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Assertion after empty list is emitted
-            channel.receive().let { listChange ->
+            channel.receiveOrFail().let { listChange ->
                 assertIs<InitialList<*>>(listChange)
 
                 assertNotNull(listChange.list)
@@ -139,7 +140,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 queriedList.addAll(dataset)
             }
 
-            channel.receive()
+            channel.receiveOrFail()
                 .let { listChange ->
                     assertIs<UpdatedList<*>>(listChange)
 
@@ -164,7 +165,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 queriedList.addAll(dataset3)
             }
 
-            channel.receive().let { listChange ->
+            channel.receiveOrFail().let { listChange ->
                 assertIs<UpdatedList<*>>(listChange)
 
                 assertNotNull(listChange.list)
@@ -190,7 +191,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 queriedList.removeRange(0..3)
             }
 
-            channel.receive().let { listChange ->
+            channel.receiveOrFail().let { listChange ->
                 assertIs<UpdatedList<*>>(listChange)
 
                 assertNotNull(listChange.list)
@@ -214,7 +215,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 queriedList.removeRange(0..1)
             }
 
-            channel.receive().let { listChange ->
+            channel.receiveOrFail().let { listChange ->
                 assertIs<UpdatedList<*>>(listChange)
 
                 assertNotNull(listChange.list)
@@ -236,7 +237,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 val queriedList = queriedContainer!!.objectListField
                 queriedList.addAll(dataset2)
             }
-            channel.receive().let { listChange ->
+            channel.receiveOrFail().let { listChange ->
                 assertIs<UpdatedList<*>>(listChange)
 
                 assertNotNull(listChange.list)
@@ -254,7 +255,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 queriedList[3].stringField = "D"
             }
 
-            channel.receive().let { listChange ->
+            channel.receiveOrFail().let { listChange ->
                 assertIs<UpdatedList<*>>(listChange)
 
                 assertNotNull(listChange.list)
@@ -278,7 +279,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 queriedList.reverse()
             }
 
-            channel.receive().let { listChange ->
+            channel.receiveOrFail().let { listChange ->
                 assertIs<UpdatedList<*>>(listChange)
 
                 assertNotNull(listChange.list)
@@ -322,16 +323,16 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Ignore first emission with empty lists
-            channel1.receive()
-            channel2.receive()
+            channel1.receiveOrFail()
+            channel2.receiveOrFail()
 
             // Trigger an update
             realm.write {
                 val queriedContainer = findLatest(container)
                 queriedContainer!!.objectListField.addAll(OBJECT_VALUES)
             }
-            assertEquals(OBJECT_VALUES.size, channel1.receive().list.size)
-            assertEquals(OBJECT_VALUES.size, channel2.receive().list.size)
+            assertEquals(OBJECT_VALUES.size, channel1.receiveOrFail().list.size)
+            assertEquals(OBJECT_VALUES.size, channel2.receiveOrFail().list.size)
 
             // Cancel observer 1
             observer1.cancel()
@@ -344,7 +345,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Check channel 1 didn't receive the update
-            assertEquals(OBJECT_VALUES.size + 1, channel2.receive().list.size)
+            assertEquals(OBJECT_VALUES.size + 1, channel2.receiveOrFail().list.size)
             assertTrue(channel1.isEmpty)
 
             observer2.cancel()
@@ -381,7 +382,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Assert container got populated correctly
-            channel1.receive().let { listChange ->
+            channel1.receiveOrFail().let { listChange ->
                 assertIs<InitialList<*>>(listChange)
 
                 assertNotNull(listChange.list)
@@ -393,12 +394,12 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 delete(findLatest(container)!!)
             }
 
-            channel1.receive().let { listChange ->
+            channel1.receiveOrFail().let { listChange ->
                 assertIs<DeletedList<*>>(listChange)
                 assertTrue(listChange.list.isEmpty())
             }
             // Wait for flow completion
-            assertTrue(channel2.receive())
+            assertTrue(channel2.receiveOrFail())
 
             observer.cancel()
             channel1.close()
@@ -459,7 +460,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 fail("Flow should not be canceled.")
             }
 
-            assertTrue(channel.receive().list.isEmpty())
+            assertTrue(channel.receiveOrFail().list.isEmpty())
 
             realm.close()
             observer.cancel()

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmNotificationsTests.kt
@@ -27,6 +27,7 @@ import io.realm.kotlin.notifications.RealmChange
 import io.realm.kotlin.notifications.UpdatedRealm
 import io.realm.kotlin.test.FlowableTests
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
@@ -79,7 +80,7 @@ class RealmNotificationsTests : FlowableTests {
                     c.send(it)
                 }
             }
-            c.receive().let { realmChange ->
+            c.receiveOrFail().let { realmChange ->
                 assertIs<InitialRealm<Realm>>(realmChange)
                 assertEquals(startingVersion, realmChange.realm.version())
             }
@@ -101,7 +102,7 @@ class RealmNotificationsTests : FlowableTests {
             }
 
             // We should first receive an initial Realm notification.
-            c.receive().let { realmChange ->
+            c.receiveOrFail().let { realmChange ->
                 assertIs<InitialRealm<Realm>>(realmChange)
                 assertEquals(startingVersion, realmChange.realm.version())
             }
@@ -109,7 +110,7 @@ class RealmNotificationsTests : FlowableTests {
             realm.write { /* Do nothing */ }
 
             // Now we we should receive an updated Realm change notification.
-            c.receive().let { realmChange ->
+            c.receiveOrFail().let { realmChange ->
                 assertIs<UpdatedRealm<Realm>>(realmChange)
                 assertEquals(VersionId(startingVersion.version + 1), realmChange.realm.version())
             }
@@ -143,12 +144,12 @@ class RealmNotificationsTests : FlowableTests {
             }
 
             // We should first receive an initial Realm notification.
-            c1.receive().let { realmChange ->
+            c1.receiveOrFail().let { realmChange ->
                 assertIs<InitialRealm<Realm>>(realmChange)
                 assertEquals(startingVersion, realmChange.realm.version())
             }
 
-            c2.receive().let { realmChange ->
+            c2.receiveOrFail().let { realmChange ->
                 assertIs<InitialRealm<Realm>>(realmChange)
                 assertEquals(startingVersion, realmChange.realm.version())
             }
@@ -156,12 +157,12 @@ class RealmNotificationsTests : FlowableTests {
             realm.write { /* Do nothing */ }
 
             // Now we we should receive an updated Realm change notification.
-            c1.receive().let { realmChange ->
+            c1.receiveOrFail().let { realmChange ->
                 assertIs<UpdatedRealm<Realm>>(realmChange)
                 assertEquals(VersionId(startingVersion.version + 1), realmChange.realm.version())
             }
 
-            c2.receive().let { realmChange ->
+            c2.receiveOrFail().let { realmChange ->
                 assertIs<UpdatedRealm<Realm>>(realmChange)
                 assertEquals(VersionId(startingVersion.version + 1), realmChange.realm.version())
             }
@@ -173,7 +174,7 @@ class RealmNotificationsTests : FlowableTests {
             realm.write { /* Do nothing */ }
 
             // But unclosed channels should receive notifications
-            c1.receive().let { realmChange ->
+            c1.receiveOrFail().let { realmChange ->
                 assertIs<UpdatedRealm<Realm>>(realmChange)
                 assertEquals(VersionId(startingVersion.version + 2), realmChange.realm.version())
             }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmObjectNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmObjectNotificationsTests.kt
@@ -26,6 +26,7 @@ import io.realm.kotlin.notifications.ObjectChange
 import io.realm.kotlin.notifications.UpdatedObject
 import io.realm.kotlin.test.RealmEntityNotificationTests
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.update
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -86,7 +87,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
                 }
             }
 
-            c.receive().let { objectChange ->
+            c.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<Sample>>(objectChange)
                 assertEquals("Foo", objectChange.obj.stringField)
             }
@@ -109,7 +110,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
                 }
             }
 
-            c.receive().let { objectChange ->
+            c.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<Sample>>(objectChange)
                 assertEquals("Foo", objectChange.obj.stringField)
             }
@@ -117,7 +118,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
             obj.update {
                 stringField = "Bar"
             }
-            c.receive().let { objectChange ->
+            c.receiveOrFail().let { objectChange ->
                 assertIs<UpdatedObject<Sample>>(objectChange)
 
                 assertEquals(1, objectChange.changedFields.size)
@@ -130,7 +131,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
                 stringField = "Baz"
                 booleanField = false
             }
-            c.receive().let { objectChange ->
+            c.receiveOrFail().let { objectChange ->
                 assertIs<UpdatedObject<Sample>>(objectChange)
 
                 assertEquals(2, objectChange.changedFields.size)
@@ -166,11 +167,11 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
                 }
             }
             // First event should be the initial value
-            c1.receive().let { objectChange ->
+            c1.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<Sample>>(objectChange)
                 assertEquals("Foo", objectChange.obj.stringField)
             }
-            c2.receive().let { objectChange ->
+            c2.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<Sample>>(objectChange)
                 assertEquals("Foo", objectChange.obj.stringField)
             }
@@ -178,11 +179,11 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
             obj.update {
                 stringField = "Bar"
             }
-            c1.receive().let { objectChange ->
+            c1.receiveOrFail().let { objectChange ->
                 assertIs<UpdatedObject<Sample>>(objectChange)
                 assertEquals("Bar", objectChange.obj.stringField)
             }
-            c2.receive().let { objectChange ->
+            c2.receiveOrFail().let { objectChange ->
                 assertIs<UpdatedObject<Sample>>(objectChange)
                 assertEquals("Bar", objectChange.obj.stringField)
             }
@@ -191,7 +192,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
             obj.update {
                 stringField = "Baz"
             }
-            c2.receive().let { objectChange ->
+            c2.receiveOrFail().let { objectChange ->
                 assertIs<UpdatedObject<Sample>>(objectChange)
                 assertEquals("Baz", objectChange.obj.stringField)
             }
@@ -220,19 +221,19 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
                         c1.send(it)
                     }
             }
-            c1.receive().let { objectChange ->
+            c1.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<Sample>>(objectChange)
                 assertNotNull(objectChange.obj)
             }
             realm.write {
                 delete(findLatest(obj)!!)
             }
-            c1.receive().let { objectChange ->
+            c1.receiveOrFail().let { objectChange ->
                 assertIs<DeletedObject<Sample>>(objectChange)
                 assertNull(objectChange.obj)
             }
             // Test for sentinel value
-            assertEquals(Unit, c2.receive())
+            assertEquals(Unit, c2.receiveOrFail())
             observer.cancel()
             c1.close()
             c2.close()
@@ -291,7 +292,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
                 }
                 fail("Flow should not be canceled.")
             }
-            c.receive().let { objectChange ->
+            c.receiveOrFail().let { objectChange ->
                 assertIs<InitialObject<Sample>>(objectChange)
                 assertEquals("Foo", objectChange.obj.stringField)
             }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmResultsNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmResultsNotificationsTests.kt
@@ -34,6 +34,7 @@ import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.shared.OBJECT_VALUES
 import io.realm.kotlin.test.shared.OBJECT_VALUES2
 import io.realm.kotlin.test.shared.OBJECT_VALUES3
+import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.filterNot
@@ -83,7 +84,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                     }
             }
 
-            c.receive().let { resultsChange ->
+            c.receiveOrFail().let { resultsChange ->
                 assertIs<InitialResults<*>>(resultsChange)
                 assertTrue(resultsChange.list.isEmpty())
             }
@@ -112,7 +113,7 @@ class RealmResultsNotificationsTests : FlowableTests {
             }
 
             // Assertion after empty list is emitted
-            c.receive().let { resultsChange ->
+            c.receiveOrFail().let { resultsChange ->
                 assertIs<InitialResults<*>>(resultsChange)
 
                 assertNotNull(resultsChange.list)
@@ -128,7 +129,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                 }
             }
 
-            c.receive().let { resultsChange ->
+            c.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
 
                 assertNotNull(resultsChange.list)
@@ -151,7 +152,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                 }
             }
 
-            c.receive().let { resultsChange ->
+            c.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
 
                 assertNotNull(resultsChange.list)
@@ -179,7 +180,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                 }
             }
 
-            c.receive().let { resultsChange ->
+            c.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
 
                 assertNotNull(resultsChange.list)
@@ -207,7 +208,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                 }
             }
 
-            c.receive().let { resultsChange ->
+            c.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
 
                 assertNotNull(resultsChange.list)
@@ -230,7 +231,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                 }
             }
 
-            c.receive().let { resultsChange ->
+            c.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
 
                 assertNotNull(resultsChange.list)
@@ -250,7 +251,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                     }
             }
 
-            c.receive().let { resultsChange ->
+            c.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
 
                 assertNotNull(resultsChange.list)
@@ -295,11 +296,11 @@ class RealmResultsNotificationsTests : FlowableTests {
                     }
             }
 
-            c1.receive().let { resultsChange ->
+            c1.receiveOrFail().let { resultsChange ->
                 assertIs<InitialResults<*>>(resultsChange)
                 assertEquals(1, resultsChange.list.size)
             }
-            c2.receive().let { resultsChange ->
+            c2.receiveOrFail().let { resultsChange ->
                 assertIs<InitialResults<*>>(resultsChange)
                 assertEquals(1, resultsChange.list.size)
             }
@@ -310,7 +311,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                 copyToRealm(Sample().apply { stringField = "Baz" })
             }
 
-            c2.receive().let { resultsChange ->
+            c2.receiveOrFail().let { resultsChange ->
                 assertIs<UpdatedResults<*>>(resultsChange)
                 assertEquals(2, resultsChange.list.size)
             }
@@ -352,11 +353,11 @@ class RealmResultsNotificationsTests : FlowableTests {
             realm.write {
                 copyToRealm(Sample().apply { stringField = "Foo" })
             }
-            assertEquals(1, c.receive())
+            assertEquals(1, c.receiveOrFail())
             realm.write {
                 copyToRealm(Sample().apply { stringField = "Bar" })
             }
-            assertEquals(-1, c.receive())
+            assertEquals(-1, c.receiveOrFail())
             observer1.cancel()
             observer2.cancel()
             c.close()
@@ -380,7 +381,7 @@ class RealmResultsNotificationsTests : FlowableTests {
             realm.write {
                 copyToRealm(Sample().apply { stringField = "Foo" })
             }
-            assertEquals(1, c.receive())
+            assertEquals(1, c.receiveOrFail())
             realm.close()
             observer.cancel()
             c.close()

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmSetNotificationsTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/notifications/RealmSetNotificationsTests.kt
@@ -28,6 +28,7 @@ import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.shared.SET_OBJECT_VALUES
 import io.realm.kotlin.test.shared.SET_OBJECT_VALUES2
 import io.realm.kotlin.test.shared.SET_OBJECT_VALUES3
+import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
@@ -90,7 +91,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Assertion after empty set is emitted
-            channel.receive().let { setChange ->
+            channel.receiveOrFail().let { setChange ->
                 assertIs<InitialSet<*>>(setChange)
 
                 assertNotNull(setChange.set)
@@ -133,7 +134,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
                 queriedSet.addAll(dataset)
             }
 
-            channel.receive().let { setChange ->
+            channel.receiveOrFail().let { setChange ->
                 assertIs<UpdatedSet<*>>(setChange)
 
                 assertNotNull(setChange.set)
@@ -157,7 +158,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
                 iterator.remove()
             }
 
-            channel.receive().let { setChange ->
+            channel.receiveOrFail().let { setChange ->
                 assertIs<UpdatedSet<*>>(setChange)
 
                 assertNotNull(setChange.set)
@@ -196,16 +197,16 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Ignore first emission with empty sets
-            channel1.receive()
-            channel2.receive()
+            channel1.receiveOrFail()
+            channel2.receiveOrFail()
 
             // Trigger an update
             realm.write {
                 val queriedContainer = findLatest(container)
                 queriedContainer!!.objectSetField.addAll(SET_OBJECT_VALUES)
             }
-            assertEquals(SET_OBJECT_VALUES.size, channel1.receive().set.size)
-            assertEquals(SET_OBJECT_VALUES.size, channel2.receive().set.size)
+            assertEquals(SET_OBJECT_VALUES.size, channel1.receiveOrFail().set.size)
+            assertEquals(SET_OBJECT_VALUES.size, channel2.receiveOrFail().set.size)
 
             // Cancel observer 1
             observer1.cancel()
@@ -218,7 +219,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Check channel 1 didn't receive the update
-            assertEquals(SET_OBJECT_VALUES.size + 1, channel2.receive().set.size)
+            assertEquals(SET_OBJECT_VALUES.size + 1, channel2.receiveOrFail().set.size)
             assertTrue(channel1.isEmpty)
 
             observer2.cancel()
@@ -254,7 +255,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
             }
 
             // Assert container got populated correctly
-            channel1.receive().let { setChange ->
+            channel1.receiveOrFail().let { setChange ->
                 assertIs<InitialSet<*>>(setChange)
 
                 assertNotNull(setChange.set)
@@ -266,12 +267,12 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
                 delete(findLatest(container)!!)
             }
 
-            channel1.receive().let { setChange ->
+            channel1.receiveOrFail().let { setChange ->
                 assertIs<DeletedSet<*>>(setChange)
                 assertTrue(setChange.set.isEmpty())
             }
             // Wait for flow completion
-            assertTrue(channel2.receive())
+            assertTrue(channel2.receiveOrFail())
 
             observer.cancel()
             channel1.close()
@@ -332,7 +333,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
                 fail("Flow should not be canceled.")
             }
 
-            assertTrue(channel.receive().set.isEmpty())
+            assertTrue(channel.receiveOrFail().set.isEmpty())
 
             realm.close()
             observer.cancel()

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/Utils.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/Utils.kt
@@ -21,7 +21,11 @@ import io.realm.kotlin.Realm
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmObject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.Instant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 // Platform independent helper methods
 object Utils {
@@ -84,5 +88,12 @@ fun Instant.toRealmInstant(): RealmInstant {
         val adjustedSeconds = s + 1
         val adjustedNanoSeconds = ns - 1_000_000_000
         RealmInstant.from(adjustedSeconds, adjustedNanoSeconds)
+    }
+}
+
+// Variant of `Channel.receiveOrFail()` that will will throw if a timeout is hit.
+suspend fun <T : Any?> Channel<T>.receiveOrFail(timeout: Duration = 30.seconds): T {
+    return withTimeout(timeout) {
+        receive()
     }
 }

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/jvm/RealmTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/jvm/RealmTests.kt
@@ -22,6 +22,7 @@ import io.realm.kotlin.entities.link.Child
 import io.realm.kotlin.entities.link.Parent
 import io.realm.kotlin.internal.platform.singleThreadDispatcher
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlinx.coroutines.async
@@ -86,11 +87,11 @@ class RealmTests {
             async(notificationDispatcher) {
                 channel.send(1)
             }
-            assertEquals(1, channel.receive())
+            assertEquals(1, channel.receiveOrFail())
             async(writeDispatcher) {
                 channel.send(2)
             }
-            assertEquals(2, channel.receive())
+            assertEquals(2, channel.receiveOrFail())
             channel.close()
             Unit
         }

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncClientResetIntegrationTests.kt
@@ -52,6 +52,7 @@ import io.realm.kotlin.test.mongodb.util.TestAppInitializer.addEmailProvider
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initializeFlexibleSync
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initializePartitionSync
 import io.realm.kotlin.test.util.TestHelper
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import io.realm.kotlin.types.RealmObject
 import kotlinx.coroutines.async
@@ -417,22 +418,22 @@ class SyncClientResetIntegrationTests {
                 }
 
                 // No initial data
-                assertEquals(0, objectChannel.receive().list.size)
+                assertEquals(0, objectChannel.receiveOrFail().list.size)
 
                 app.triggerClientReset(syncMode, realm.syncSession, user.id) {
                     insertElement(realm)
-                    assertEquals(1, objectChannel.receive().list.size)
+                    assertEquals(1, objectChannel.receiveOrFail().list.size)
                 }
 
                 // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receiveOrFail())
 
                 // TODO We must not need this. Force updating the instance pointer.
                 realm.write { }
 
                 // Validate Realm instance has been correctly updated
-                assertEquals(0, objectChannel.receive().list.size)
+                assertEquals(0, objectChannel.receiveOrFail().list.size)
 
                 job.cancel()
             }
@@ -510,23 +511,23 @@ class SyncClientResetIntegrationTests {
                 }
 
                 // No initial data
-                assertEquals(0, objectChannel.receive().list.size)
+                assertEquals(0, objectChannel.receiveOrFail().list.size)
 
                 app.triggerClientReset(syncMode, realm.syncSession, user.id) {
                     // Write something while the session is paused to make sure the before realm contains something
                     insertElement(realm)
-                    assertEquals(1, objectChannel.receive().list.size)
+                    assertEquals(1, objectChannel.receiveOrFail().list.size)
                 }
 
                 // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receiveOrFail())
 
                 // TODO We must not need this. Force updating the instance pointer.
                 realm.write { }
 
                 // Validate Realm instance has been correctly updated
-                assertEquals(1, objectChannel.receive().list.size)
+                assertEquals(1, objectChannel.receiveOrFail().list.size)
 
                 job.cancel()
             }
@@ -600,8 +601,8 @@ class SyncClientResetIntegrationTests {
                     )
 
                     // TODO Twice until the deprecated method is removed
-                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
-                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
                 }
             }
         }
@@ -673,8 +674,8 @@ class SyncClientResetIntegrationTests {
                     )
 
                     // TODO Twice until the deprecated method is removed
-                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
-                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
                 }
             }
         }
@@ -746,9 +747,9 @@ class SyncClientResetIntegrationTests {
                 app.triggerClientReset(syncMode, realm.syncSession, user.id)
 
                 // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
+                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
             }
         }
     }
@@ -830,12 +831,12 @@ class SyncClientResetIntegrationTests {
                 app.triggerClientReset(syncMode, realm.syncSession, user.id)
 
                 // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receiveOrFail())
 
                 // TODO Twice until the deprecated method is removed
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
+                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
             }
         }
     }
@@ -875,20 +876,20 @@ class SyncClientResetIntegrationTests {
                 // Validate we receive logs on the regular path
                 assertEquals(
                     ClientResetLogEvents.DISCARD_LOCAL_ON_BEFORE_RESET,
-                    logChannel.receive()
+                    logChannel.receiveOrFail()
                 )
                 assertEquals(
                     ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RECOVERY,
-                    logChannel.receive()
+                    logChannel.receiveOrFail()
                 )
-                // assertEquals(ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RESET, logChannel.receive())
+                // assertEquals(ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RESET, logChannel.receiveOrFail())
 
                 (realm.syncSession as SyncSessionImpl).simulateError(
                     ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
                     SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
                 )
                 // Validate that we receive logs on the error callback
-                val actual = logChannel.receive()
+                val actual = logChannel.receiveOrFail()
                 assertEquals(ClientResetLogEvents.DISCARD_LOCAL_ON_ERROR, actual)
             }
         }
@@ -938,7 +939,7 @@ class SyncClientResetIntegrationTests {
                         SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
                     )
 
-                    val exception = channel.receive()
+                    val exception = channel.receiveOrFail()
                     val originalFilePath = assertNotNull(exception.originalFilePath)
                     val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
                     assertTrue(fileExists(originalFilePath))
@@ -992,7 +993,7 @@ class SyncClientResetIntegrationTests {
                         SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
                     )
 
-                    val exception = channel.receive()
+                    val exception = channel.receiveOrFail()
 
                     val originalFilePath = assertNotNull(exception.originalFilePath)
                     val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
@@ -1061,8 +1062,8 @@ class SyncClientResetIntegrationTests {
                     assertEquals(1, countObjects(realm))
                 }
 
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receive())
+                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receiveOrFail())
             }
         }
     }
@@ -1110,7 +1111,7 @@ class SyncClientResetIntegrationTests {
                     ProtocolClientErrorCode.RLM_SYNC_ERR_CLIENT_AUTO_CLIENT_RESET_FAILURE,
                     SyncErrorCodeCategory.RLM_SYNC_ERROR_CATEGORY_CLIENT
                 )
-                val exception = channel.receive()
+                val exception = channel.receiveOrFail()
 
                 assertNotNull(exception.recoveryFilePath)
                 assertNotNull(exception.originalFilePath)
@@ -1173,8 +1174,8 @@ class SyncClientResetIntegrationTests {
                 app.triggerClientReset(syncMode, realm.syncSession, user.id)
 
                 // Validate that the client reset was triggered successfully
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
+                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
             }
         }
     }
@@ -1239,7 +1240,7 @@ class SyncClientResetIntegrationTests {
                     )
 
                     // TODO Twice until the deprecated method is removed
-                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
                 }
             }
         }
@@ -1301,8 +1302,8 @@ class SyncClientResetIntegrationTests {
                 insertElement(realm)
                 assertEquals(1, countObjects(realm))
 
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_RECOVERY, channel.receive())
+                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_AFTER_RECOVERY, channel.receiveOrFail())
             }
         }
     }
@@ -1368,8 +1369,8 @@ class SyncClientResetIntegrationTests {
                     assertEquals(1, countObjects(realm))
                 }
 
-                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receive())
-                assertEquals(ClientResetEvents.ON_AFTER_DISCARD, channel.receive())
+                assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
+                assertEquals(ClientResetEvents.ON_AFTER_DISCARD, channel.receiveOrFail())
             }
         }
     }
@@ -1440,7 +1441,7 @@ class SyncClientResetIntegrationTests {
                     )
 
                     // TODO Twice until the deprecated method is removed
-                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receive())
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
                 }
             }
         }

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncSessionTests.kt
@@ -37,6 +37,7 @@ import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestHelper
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
@@ -332,7 +333,7 @@ class SyncSessionTests {
 
         runBlocking {
             val deferred = async { Realm.open(config) }
-            val session = channel.receive()
+            val session = channel.receiveOrFail()
             try {
                 assertFailsWithMessage<IllegalStateException>("Operation is not allowed inside a `SyncSession.ErrorHandler`.") {
                     runBlocking {
@@ -412,7 +413,7 @@ class SyncSessionTests {
                     }
             }
 
-            val insertedObject = channel.receive()
+            val insertedObject = channel.receiveOrFail()
             assertEquals(oid, insertedObject._id.toHexString())
             assertEquals(partitionValue, insertedObject.name)
             realm.close()
@@ -524,7 +525,7 @@ class SyncSessionTests {
             assertNotNull(realm2)
 
             // Await the sync session sent.
-            val session = channel.receive()
+            val session = channel.receiveOrFail()
 
             // Validate that the session was captured and that the configuration cannot be accessed.
             assertIs<SyncSession>(session)

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/SyncedRealmTests.kt
@@ -58,6 +58,7 @@ import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.TestHelper.randomEmail
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import io.realm.kotlin.types.BaseRealmObject
 import kotlinx.coroutines.Dispatchers
@@ -196,13 +197,13 @@ class SyncedRealmTests {
                     }
             }
 
-            assertEquals(0, channel.receive().list.size)
+            assertEquals(0, channel.receiveOrFail().list.size)
 
             realm1.write {
                 copyToRealm(child)
             }
 
-            val childResults = channel.receive()
+            val childResults = channel.receiveOrFail()
             val childPk = childResults.list[0]
             assertEquals("CHILD_A", childPk._id)
             observer.cancel()
@@ -234,7 +235,7 @@ class SyncedRealmTests {
                 c.send(it)
             }
         }
-        val event: RealmChange<Realm> = c.receive()
+        val event: RealmChange<Realm> = c.receiveOrFail()
         assertTrue(event is InitialRealm)
 
         // Write remote change
@@ -257,7 +258,7 @@ class SyncedRealmTests {
         try {
             withTimeout(timeout = 10.seconds) {
                 while (true) {
-                    val updateEvent: RealmChange<Realm> = c.receive()
+                    val updateEvent: RealmChange<Realm> = c.receiveOrFail()
                     assertTrue(updateEvent is UpdatedRealm)
                     if (updateEvent.realm.query<SyncObjectWithAllTypes>().find().size == 1)
                         break
@@ -337,7 +338,7 @@ class SyncedRealmTests {
                 channel.trySend(AssertionError("Realm was successfully opened"))
             }
 
-            val error = channel.receive()
+            val error = channel.receiveOrFail()
             assertTrue(error is UnrecoverableSyncException, "Was $error")
             val message = error.message
             assertNotNull(message)
@@ -383,7 +384,7 @@ class SyncedRealmTests {
             assertNotNull(realm2)
 
             // Await for exception to happen
-            val exception = channel.receive()
+            val exception = channel.receiveOrFail()
 
             channel.close()
 
@@ -570,13 +571,13 @@ class SyncedRealmTests {
                 // Create another Realm to ensure the log files are generated.
                 val anotherRealm = Realm.open(configuration)
                 bgThreadReadyChannel.send(Unit)
-                readyToCloseChannel.receive()
+                readyToCloseChannel.receiveOrFail()
                 anotherRealm.close()
                 closedChannel.send(Unit)
             }
 
             // Waits for background thread opening the same Realm.
-            bgThreadReadyChannel.receive()
+            bgThreadReadyChannel.receiveOrFail()
 
             // Check the realm got created correctly and signal that it can be closed.
             fileSystem.list(syncDir)
@@ -585,7 +586,7 @@ class SyncedRealmTests {
                     readyToCloseChannel.send(Unit)
                 }
             testRealm.close()
-            closedChannel.receive()
+            closedChannel.receiveOrFail()
 
             // Delete realm now that it's fully closed.
             Realm.deleteRealm(configuration)
@@ -742,7 +743,7 @@ class SyncedRealmTests {
             realm.writeBlocking { copyToRealm(masterObject) }
             realm.syncSession.uploadAllLocalChanges()
         }
-        assertEquals(42, counterValue.receive())
+        assertEquals(42, counterValue.receiveOrFail())
 
         // Increment counter asynchronously after download initial data (1)
         val increment1 = async {
@@ -758,7 +759,7 @@ class SyncedRealmTests {
                 }
             }
         }
-        assertEquals(43, counterValue.receive())
+        assertEquals(43, counterValue.receiveOrFail())
 
         // Increment counter asynchronously after download initial data (2)
         val increment2 = async {
@@ -774,7 +775,7 @@ class SyncedRealmTests {
                 }
             }
         }
-        assertEquals(44, counterValue.receive())
+        assertEquals(44, counterValue.receiveOrFail())
 
         increment1.cancel()
         increment2.cancel()

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/internal/KtorNetworkTransportTest.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/internal/KtorNetworkTransportTest.kt
@@ -29,6 +29,7 @@ import io.realm.kotlin.test.mongodb.util.BaasApp
 import io.realm.kotlin.test.mongodb.util.KtorTestAppInitializer.initialize
 import io.realm.kotlin.test.mongodb.util.Service
 import io.realm.kotlin.test.mongodb.util.TEST_METHODS
+import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlin.test.AfterTest
@@ -87,7 +88,7 @@ internal class KtorNetworkTransportTest {
                     mapOf(),
                     body
                 ) { response -> channel.trySend(response) }
-                channel.receive()
+                channel.receiveOrFail()
             }
             assertEquals(200, response.httpResponseCode, "$method failed")
             assertEquals(0, response.customResponseCode, "$method failed")
@@ -108,7 +109,7 @@ internal class KtorNetworkTransportTest {
                     mapOf(),
                     body
                 ) { response -> channel.trySend(response) }
-                channel.receive()
+                channel.receiveOrFail()
             }
             assertEquals(500, response.httpResponseCode, "$method failed")
             assertEquals(0, response.customResponseCode, "$method failed")
@@ -132,7 +133,7 @@ internal class KtorNetworkTransportTest {
                     mapOf(),
                     body
                 ) { response -> channel.trySend(response) }
-                channel.receive()
+                channel.receiveOrFail()
             }
             assertEquals(200, response.httpResponseCode, "$method failed")
             assertEquals(0, response.customResponseCode, "$method failed")

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/nonlatin/NonLatinTests.kt
@@ -10,6 +10,7 @@ import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
+import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.serialization.json.JsonObject
@@ -80,7 +81,7 @@ class NonLatinTests {
                     }
             }
 
-            val insertedObject = channel.receive()
+            val insertedObject = channel.receiveOrFail()
             assertEquals(oid, insertedObject._id.toHexString())
             val char1 = "foo\u0000bar".toCharArray()
             val char2 = insertedObject.name.toCharArray()


### PR DESCRIPTION
This PR adds a new extension method `Channel.receiveOrFail` that mirrors the `TestHelper.awaitOrFail` in Realm Java. This prevents tests using channels from hanging forever.

I considered wrapping our `runBlocking` method, but this approach will better pinpoint the point of failure and is also easy to use.

I also sneaked in an update of Ktor + an update of the obfuscation tests since that was what prompted this improvement in the first place (those changes are constrained to the [LogObfuscator](https://github.com/realm/realm-kotlin/compare/cm/receiveOrFail?expand=1#diff-25cf77886f487923d744109883ee33b72a5265f1e9f2517cf5015882a61b8711R160) and [HttpLogObfuscatorTests](https://github.com/realm/realm-kotlin/compare/cm/receiveOrFail?expand=1#diff-3080fa7a4048c742433e12073f913ff16136b82326b833dda11afb0091b8c3daL27)