### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,9 +12,10 @@ body:
     attributes:
       label: How frequently does the bug occur?
       options:
-        - Seen once
+        - -- select --
+        - Once
         - Sometimes
-        - All the time
+        - Always
     validations:
       required: true
 # Description
@@ -38,9 +39,10 @@ body:
     attributes:
       label: Can you reproduce the bug?
       options:
-        - Yes, always
-        - Yes, sometimes
-        - Not yet
+        - -- select --
+        - Always
+        - Sometimes
+        - 'No'
     validations:
       required: true 
   - type: textarea
@@ -62,12 +64,15 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: sync
+    id: services
     attributes:
-      label: What SDK flavour are you using?
+      label: What Atlas App Services are you using?
       options:
+        - -- select --
         - Local Database only
-        - MongoDB Realm (i.e. Sync, auth, functions)
+        - Atlas Device Sync
+        - 'Atlas App Services: Function or GraphQL or DataAPI etc'
+        - Both Atlas Device Sync and Atlas App Services
     validations:
       required: true
   - type: dropdown
@@ -75,8 +80,9 @@ body:
     attributes:
       label: Are you using encryption?
       options:
-        - Yes, using encryption
-        - No, not using encryption
+        - -- select --
+        - 'Yes'
+        - 'No'
     validations:
       required: true
 # Environment

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -94,7 +94,7 @@ body:
     validations:
       required: true
   - type: textarea
-    id: java-build-environment
+    id: kotlin-build-environment
     attributes:
       label: "Build environment"
       description: Build environment versions

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,100 @@
+name: Bug Report
+description: Report a bug
+labels: [T-Bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide as much detail as you can so we have a better chance of fixing the bug quickly. 
+        Thanks for your contribution to improve this project!
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How frequently does the bug occur?
+      options:
+        - Seen once
+        - Sometimes
+        - All the time
+    validations:
+      required: true
+# Description
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Describe what you were expecting and what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Stacktrace & log output
+      description: Please paste any relevant log output or stacktrace if you're getting an exception/crash.
+      render: shell
+# Repro information
+  - type: dropdown
+    id: repro
+    attributes:
+      label: Can you reproduce the bug?
+      options:
+        - Yes, always
+        - Yes, sometimes
+        - Not yet
+    validations:
+      required: true 
+  - type: textarea
+    id: code-snippets
+    attributes:
+      label: Reproduction Steps
+      description: |
+        If you can reproduce the bug, please provide detailed steps for how WE can reproduce it.
+        Ideally, please provide a self contained test case or link (e.g. github repo) to a sample app that demonstrates the bug.
+        If that's not possible, please show code samples that highlight or reproduce the issue.
+        If relevant, include your model definitions.
+        Should you need to share code confidentially, you can send a link to: realm-help (the @) mongodb.com.
+# Version
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version(s) of the SDK has the bug been observed in?
+    validations:
+      required: true
+  - type: dropdown
+    id: sync
+    attributes:
+      label: What SDK flavour are you using?
+      options:
+        - Local Database only
+        - MongoDB Realm (i.e. Sync, auth, functions)
+    validations:
+      required: true
+  - type: dropdown
+    id: encryption
+    attributes:
+      label: Are you using encryption?
+      options:
+        - Yes, using encryption
+        - No, not using encryption
+    validations:
+      required: true
+# Environment
+  - type: input
+    id: platform
+    attributes:
+      label: Platform OS and version(s)
+      description: OS and version(s) are you seeing the issue on?
+    validations:
+      required: true
+  - type: textarea
+    id: java-build-environment
+    attributes:
+      label: "Build environment"
+      description: Build environment versions
+      value: |
+        Android Studio version: ...
+        Android Build Tools version: ...
+        Gradle version: ...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: General Questions and Inquiries
+    url: https://www.mongodb.com/community/forums/tags/c/atlas-app-services-realm/9/kotlin
+    about: Please ask general design/architecture questions in the community forums.
+  - name: MongoDB Atlas Device Sync Production Issues
+    url: https://support.mongodb.com/
+    about: Please report urgent production issues to the support portal directly.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,3 +1,6 @@
+# NOTE: This is a common file that is overwritten by realm/ci-actions sync service
+# and should only be modified in that repository.
+
 name: Feature Request
 description: Request a new feature or enhancement
 labels: [T-Enhancement]
@@ -5,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to suggest improvements to the SDK!
+        Thanks for taking the time to suggest improvements to Realm!
   - type: textarea
     id: problem
     attributes:
@@ -32,9 +35,21 @@ body:
     attributes:
       label: How important is this improvement for you?
       options:
+        - -- select --
         - Dealbreaker
         - Would be a major improvement
-        - I'd like to see it, but have a workaround
-        - Fairly niche, but nice to have anyway.
+        - I would like to have it but have a workaround
+        - Fairly niche but nice to have anyway
     validations:
-      required: false
+      required: true
+  - type: dropdown
+    id: sync
+    attributes:
+      label: Feature would mainly be used with
+      options:
+        - -- select --
+        - Local Database only
+        - Atlas Device Sync
+        - 'Atlas App Services: Auth or Functions etc'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Request a new feature or enhancement
+labels: [T-Enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest improvements to the SDK!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: A clear and concise description of the problem you are trying to solve.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: Describe the solution you envision, including API and usage example if possible.
+    validations:
+      required: false
+  - type: textarea
+    id: alternative-solution
+    attributes:
+      label: Alternatives
+      description: Describe the alternative solutions or features you have considered
+    validations:
+      required: false
+  - type: dropdown
+    id: importance
+    attributes:
+      label: How important is this improvement for you?
+      options:
+        - Dealbreaker
+        - Would be a major improvement
+        - I'd like to see it, but have a workaround
+        - Fairly niche, but nice to have anyway.
+    validations:
+      required: false


### PR DESCRIPTION
This adds a menu and forms for creating new issues. Just grabbed the Java templates and updated the link to the forum to show the kotlin issues instead.