### PR TITLE
Fix Client Reset on JVM builds running on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 1.7.1 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+ 
+### Fixed
+* [Sync] Client Reset on JVM on Linux would crash with `No built-in scheduler implementation for this platform. Register your own with Scheduler::set_default_factory()`
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.7.20 and above.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.6.4 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Gradle version: 6.7.1.
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.7.0 (2023-03-15)
 
 ### Breaking Changes

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -866,7 +866,10 @@ after_client_reset(void* userdata, realm_t* before_realm,
                                                    "onAfterReset",
                                                    "(Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;Z)V");
     auto before_pointer = wrap_pointer(env, reinterpret_cast<jlong>(before_realm), false);
-    realm_t* after_realm_ptr = realm_from_thread_safe_reference(after_realm, NULL);
+    // Reuse the scheduler from the beforeRealm, otherwise Core will attempt to recreate a new one,
+    // which will fail on platforms that hasn't defined a default scheduler factory.
+    realm_scheduler_t scheduler = realm_scheduler(before_realm->get()->scheduler());
+    realm_t* after_realm_ptr = realm_from_thread_safe_reference(after_realm, scheduler);
     auto after_pointer = wrap_pointer(env, reinterpret_cast<jlong>(after_realm_ptr), false);
     env->CallVoidMethod(static_cast<jobject>(userdata), java_after_callback_function, before_pointer, after_pointer, did_recover);
 


### PR DESCRIPTION
Discovered while working on Github Actions and running Sync tests across all platforms. Our current tests capture this just fine, as long as they run on Linux. This will be done more systematically once GHA support is merged.