### PR TITLE
Fix issues related to using a Windows filesystem in tests

### DIFF
--- a/buildSrc/src/main/kotlin/io/realm/RealmPublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/realm/RealmPublishPlugin.kt
@@ -32,6 +32,7 @@ import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
+import java.io.File
 import java.net.URI
 import java.time.Duration
 
@@ -72,14 +73,14 @@ class RealmPublishPlugin : Plugin<Project> {
     }
 
     private fun configureTestRepository(project: Project) {
-        val testRepository = getPropertyValue(project, "testRepository")
-        if (!testRepository.isEmpty()) {
+        val relativePathToTestRepository: String = getPropertyValue(project, "testRepository")
+        val testRepository = File(project.rootProject.rootDir.absolutePath + File.separator + relativePathToTestRepository.replace("/", File.separator))
+        if (relativePathToTestRepository.isNotEmpty()) {
             project.extensions.getByType<PublishingExtension>().apply {
                 repositories {
                     maven {
                         name = "Test"
-                        url =
-                            URI("file://${project.rootProject.rootDir.absolutePath}/$testRepository")
+                        url = testRepository.toURI()
                     }
                 }
             }

--- a/packages/gradle.properties
+++ b/packages/gradle.properties
@@ -32,6 +32,7 @@ kotlin.android.buildTypeAttribute.keep=false
 # Project setup - See './CONTRIBUTING.md' for description of the project structure and various options.
 # includeSdkModules=true
 # includeTestModules=true
+# Test repository path must be a relative path to the `packages` folder and writte with Linux line seperators.
 testRepository=build/m2-buildrepo/
 # Must either be `debug` or `debugMinified`
 testBuildType=debug

--- a/packages/test-base/src/androidMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/androidMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -20,14 +20,27 @@ import android.annotation.SuppressLint
 import android.os.SystemClock
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 import kotlin.io.path.absolutePathString
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
 actual object PlatformUtils {
     @SuppressLint("NewApi")
-    actual fun createTempDir(prefix: String): String {
-        return Files.createTempDirectory("$prefix-android_tests").absolutePathString()
+    actual fun createTempDir(prefix: String, readOnly: Boolean): String {
+        val dir: Path = Files.createTempDirectory("$prefix-android_tests")
+        if (readOnly) {
+            Files.setPosixFilePermissions(
+                dir,
+                setOf(
+                    PosixFilePermission.GROUP_READ,
+                    PosixFilePermission.OTHERS_READ,
+                    PosixFilePermission.OWNER_READ
+                )
+            )
+        }
+        return dir.absolutePathString()
     }
 
     actual fun deleteTempDir(path: String) {

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -6,7 +6,7 @@ import kotlin.time.ExperimentalTime
 
 // Platform dependant helper methods
 expect object PlatformUtils {
-    fun createTempDir(prefix: String = Utils.createRandomString(16)): String
+    fun createTempDir(prefix: String = Utils.createRandomString(16), readOnly: Boolean = false): String
     fun deleteTempDir(path: String)
     @OptIn(ExperimentalTime::class)
     fun sleep(duration: Duration)

--- a/packages/test-base/src/jvmMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/jvmMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -18,13 +18,26 @@ package io.realm.kotlin.test.platform
 
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 import kotlin.io.path.absolutePathString
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
 actual object PlatformUtils {
-    actual fun createTempDir(prefix: String): String {
-        return Files.createTempDirectory("$prefix-jvm_tests").absolutePathString()
+    actual fun createTempDir(prefix: String, readOnly: Boolean): String {
+        val dir: Path = Files.createTempDirectory("$prefix-jvm_tests")
+        if (readOnly) {
+            Files.setPosixFilePermissions(
+                dir,
+                setOf(
+                    PosixFilePermission.GROUP_READ,
+                    PosixFilePermission.OTHERS_READ,
+                    PosixFilePermission.OWNER_READ
+                )
+            )
+        }
+        return dir.absolutePathString()
     }
 
     actual fun deleteTempDir(path: String) {

--- a/packages/test-base/src/nativeDarwin/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/nativeDarwin/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -23,6 +23,9 @@ import kotlinx.cinterop.cstr
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
+import platform.posix.S_IRGRP
+import platform.posix.S_IROTH
+import platform.posix.S_IRUSR
 import platform.posix.nanosleep
 import platform.posix.pthread_threadid_np
 import platform.posix.timespec
@@ -31,11 +34,14 @@ import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
 actual object PlatformUtils {
-    actual fun createTempDir(prefix: String): String {
+    actual fun createTempDir(prefix: String, readOnly: Boolean): String {
         // X is a special char which will be replace by mkdtemp template
         val mask = prefix.replace('X', 'Z', ignoreCase = true)
         val path = "${platform.Foundation.NSTemporaryDirectory()}$mask"
         platform.posix.mkdtemp(path.cstr)
+        if (readOnly) {
+            platform.posix.chmod(path, (S_IRUSR or S_IRGRP or S_IROTH).toUShort())
+        }
         return path
     }
 

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/AppConfigurationTests.kt
@@ -16,6 +16,7 @@
 
 package io.realm.kotlin.test.mongodb.shared
 
+import io.realm.kotlin.internal.platform.PATH_SEPARATOR
 import io.realm.kotlin.internal.platform.appFilesDirectory
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.AppConfiguration
@@ -24,6 +25,7 @@ import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
+import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestHelper
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -129,7 +131,7 @@ class AppConfigurationTests {
     @Test
     fun syncRootDirectory() {
         val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
-        val expectedRoot = "${appFilesDirectory()}/myCustomDir"
+        val expectedRoot = "${appFilesDirectory()}${PATH_SEPARATOR}myCustomDir"
         val config = builder
             .syncRootDirectory(expectedRoot)
             .build()
@@ -139,7 +141,7 @@ class AppConfigurationTests {
     @Test
     fun syncRootDirectory_writeProtectedDir() {
         val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
-        val dir = "/"
+        val dir = PlatformUtils.createTempDir(readOnly = true)
         assertFailsWith<IllegalArgumentException> { builder.syncRootDirectory(dir) }
     }
 
@@ -147,7 +149,7 @@ class AppConfigurationTests {
     // the configured `AppConfiguration.syncRootDir`
     @Test
     fun syncRootDirectory_appendDirectoryToPath() = runBlocking {
-        val expectedRoot = "${appFilesDirectory()}/myCustomDir"
+        val expectedRoot = "${appFilesDirectory()}${PATH_SEPARATOR}myCustomDir"
         val app = TestApp(builder = {
             it.syncRootDirectory(expectedRoot)
         })
@@ -158,7 +160,7 @@ class AppConfigurationTests {
             // When creating the full path for a synced Realm, we will always append `/mongodb-realm` to
             // the configured `AppConfiguration.syncRootDir`
             val partitionValue = TestHelper.randomPartitionValue()
-            val suffix = "/myCustomDir/mongodb-realm/${user.app.configuration.appId}/${user.identity}/s_$partitionValue.realm"
+            val suffix = "${PATH_SEPARATOR}myCustomDir${PATH_SEPARATOR}mongodb-realm${PATH_SEPARATOR}${user.app.configuration.appId}${PATH_SEPARATOR}${user.id}${PATH_SEPARATOR}s_$partitionValue.realm"
             val config = SyncConfiguration.Builder(user, partitionValue, schema = setOf()).build()
             assertTrue(config.path.endsWith(suffix), "Failed: ${config.path} vs. $suffix")
         } finally {

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncConfigurationTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FlexibleSyncConfigurationTests.kt
@@ -16,6 +16,7 @@
 package io.realm.kotlin.test.mongodb.shared
 
 import io.realm.kotlin.Realm
+import io.realm.kotlin.internal.platform.PATH_SEPARATOR
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.User
@@ -132,7 +133,7 @@ class FlexibleSyncConfigurationTests {
     fun defaultPath() {
         val user: User = app.asTestApp.createUserAndLogin()
         val config: SyncConfiguration = SyncConfiguration.create(user, setOf())
-        assertTrue(config.path.endsWith("/default.realm"), "Path is: ${config.path}")
+        assertTrue(config.path.endsWith("${PATH_SEPARATOR}default.realm"), "Path is: ${config.path}")
     }
 
     @Test
@@ -224,6 +225,6 @@ class FlexibleSyncConfigurationTests {
         val config: SyncConfiguration = SyncConfiguration.Builder(user, setOf())
             .name("custom.realm")
             .build()
-        assertTrue(config.path.endsWith("${app.configuration.appId}/${user.identity}/custom.realm"), "Path is: ${config.path}")
+        assertTrue(config.path.endsWith("${app.configuration.appId}${PATH_SEPARATOR}${user.id}${PATH_SEPARATOR}custom.realm"), "Path is: ${config.path}")
     }
 }


### PR DESCRIPTION
In a number of places, we made assumptions about how the filesystem worked, which broke our tests on Windows. This PR fixes those tests.