### PR TITLE
Add support for running tests on Cloud QA

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -66,6 +66,7 @@ object Versions {
     // Must be built with same (major.minor!?) kotlin version as 'kotlin' variable below, to be binary compatible with kotlin
     const val atomicfu = "0.18.5" // https://github.com/Kotlin/kotlinx.atomicfu
     const val autoService = "1.0" // https://mvnrepository.com/artifact/com.google.auto.service/auto-service
+    const val buildkonfig = "0.13.3" // https://github.com/yshrsmz/BuildKonfig
     // Not currently used, so mostly here for documentation. Core requires minimum 3.15, but 3.18.1 is available through the Android SDK.
     // Build also tested successfully with 3.21.4 (latest release).
     const val cmake = "3.22.1"

--- a/packages/gradle.properties
+++ b/packages/gradle.properties
@@ -35,3 +35,16 @@ kotlin.android.buildTypeAttribute.keep=false
 testRepository=build/m2-buildrepo/
 # Must either be `debug` or `debugMinified`
 testBuildType=debug
+
+# Properties controlling which test server to run sync tests against. Default is a local
+# test server that has been started by calling `<root>/tools/sync_test_server/start_local_server.sh`
+syncTestUrl=http://localhost:9090
+syncTestAppNamePrefix=test-app
+syncTestLoginEmail=unique_user@domain.com
+syncTestLoginPassword=password
+
+# If the public/private apiKey is set, it will take precedence when logging into the Admin API that controls the app
+# syncTestUrl=https://realm-qa.mongodb.com
+# syncTestLoginPublicApiKey=replace-with-value
+# synctestLoginPrivateApiKey=replace-with-value
+# syncTestClusterName=replace-with-value

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -308,7 +308,7 @@ public interface AppConfiguration {
                     // FIXME Add AppConfiguration.Builder option to set timeout as a Duration with default \
                     //  constant in AppConfiguration.Companion
                     //  https://github.com/realm/realm-kotlin/issues/408
-                    timeoutMs = 15000,
+                    timeoutMs = 60000,
                     dispatcherFactory = appNetworkDispatcherFactory,
                     logger = logger
                 )

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
@@ -10,6 +10,7 @@ import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyConfirmedException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
 import io.realm.kotlin.mongodb.exceptions.UserNotFoundException
+import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
@@ -242,7 +243,7 @@ class EmailPasswordAuthWithEmailConfirmTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(appName = "email-confirm", initialSetup = { app: BaasApp, service: Service ->
+        app = TestApp(appName = "${SyncServerConfig.appPrefix}-em-cnfrm", initialSetup = { app: BaasApp, service: Service ->
             addEmailProvider(app, autoConfirm = false)
         })
     }
@@ -280,7 +281,7 @@ class EmailPasswordAuthWithCustomFunctionTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(appName = "email-custom", initialSetup = { app: BaasApp, service: Service ->
+        app = TestApp(appName = "${SyncServerConfig.appPrefix}-em-cstm", initialSetup = { app: BaasApp, service: Service ->
             addEmailProvider(app, autoConfirm = false, runConfirmationFunction = true)
         })
     }

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/EmailPasswordAuthTests.kt
@@ -10,10 +10,10 @@ import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyConfirmedException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
 import io.realm.kotlin.mongodb.exceptions.UserNotFoundException
-import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
+import io.realm.kotlin.test.mongodb.syncServerAppName
 import io.realm.kotlin.test.mongodb.util.BaasApp
 import io.realm.kotlin.test.mongodb.util.Service
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.addEmailProvider
@@ -243,7 +243,7 @@ class EmailPasswordAuthWithEmailConfirmTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(appName = "${SyncServerConfig.appPrefix}-em-cnfrm", initialSetup = { app: BaasApp, service: Service ->
+        app = TestApp(appName = syncServerAppName("em-cnfrm"), initialSetup = { app: BaasApp, service: Service ->
             addEmailProvider(app, autoConfirm = false)
         })
     }
@@ -281,7 +281,7 @@ class EmailPasswordAuthWithCustomFunctionTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(appName = "${SyncServerConfig.appPrefix}-em-cstm", initialSetup = { app: BaasApp, service: Service ->
+        app = TestApp(appName = syncServerAppName("em-cstm"), initialSetup = { app: BaasApp, service: Service ->
             addEmailProvider(app, autoConfirm = false, runConfirmationFunction = true)
         })
     }

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FunctionsTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FunctionsTests.kt
@@ -27,6 +27,7 @@ import io.realm.kotlin.mongodb.exceptions.FunctionExecutionException
 import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.mongodb.ext.call
 import io.realm.kotlin.test.assertFailsWithMessage
+import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.mongodb.util.BaasApp
@@ -128,7 +129,7 @@ class FunctionsTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp("functions") { app: BaasApp, service: Service ->
+        app = TestApp("${SyncServerConfig.appPrefix}-funcs") { app: BaasApp, service: Service ->
             initializeDefault(app, service)
             app.addFunction(FIRST_ARG_FUNCTION)
             app.addFunction(NULL_FUNCTION)

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FunctionsTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/FunctionsTests.kt
@@ -27,9 +27,9 @@ import io.realm.kotlin.mongodb.exceptions.FunctionExecutionException
 import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.mongodb.ext.call
 import io.realm.kotlin.test.assertFailsWithMessage
-import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
+import io.realm.kotlin.test.mongodb.syncServerAppName
 import io.realm.kotlin.test.mongodb.util.BaasApp
 import io.realm.kotlin.test.mongodb.util.Service
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.AUTHORIZED_ONLY_FUNCTION
@@ -129,7 +129,7 @@ class FunctionsTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp("${SyncServerConfig.appPrefix}-funcs") { app: BaasApp, service: Service ->
+        app = TestApp(syncServerAppName("funcs")) { app: BaasApp, service: Service ->
             initializeDefault(app, service)
             app.addFunction(FIRST_ARG_FUNCTION)
             app.addFunction(NULL_FUNCTION)

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/HttpLogObfuscatorTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/HttpLogObfuscatorTests.kt
@@ -24,6 +24,7 @@ import io.realm.kotlin.mongodb.GoogleAuthType
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.ext.call
 import io.realm.kotlin.test.CustomLogCollector
+import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initializeDefault
@@ -118,7 +119,7 @@ class HttpLogObfuscatorTests {
 
     private fun initApp(): TestApp {
         return TestApp(
-            appName = "obfuscator",
+            appName = "${SyncServerConfig.appPrefix}-obfsctr",
             logLevel = LogLevel.DEBUG,
             customLogger = ObfuscatorLoggerInspector(channel),
             initialSetup = { app, service ->
@@ -143,7 +144,7 @@ class HttpLogObfuscatorTests {
     fun nullObfuscator() = runBlocking {
         val logger = CustomLogCollector("NULL-OBFUSCATOR", LogLevel.DEBUG)
         app = TestApp(
-            appName = "null-obfuscator",
+            appName = "${SyncServerConfig.appPrefix}-null-obf",
             logLevel = LogLevel.DEBUG,
             builder = { it.httpLogObfuscator(null) },
             customLogger = logger,

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/HttpLogObfuscatorTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/HttpLogObfuscatorTests.kt
@@ -24,8 +24,8 @@ import io.realm.kotlin.mongodb.GoogleAuthType
 import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.ext.call
 import io.realm.kotlin.test.CustomLogCollector
-import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TestApp
+import io.realm.kotlin.test.mongodb.syncServerAppName
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initializeDefault
 import io.realm.kotlin.test.util.receiveOrFail
@@ -119,7 +119,7 @@ class HttpLogObfuscatorTests {
 
     private fun initApp(): TestApp {
         return TestApp(
-            appName = "${SyncServerConfig.appPrefix}-obfsctr",
+            appName = syncServerAppName("obfsctr"),
             logLevel = LogLevel.DEBUG,
             customLogger = ObfuscatorLoggerInspector(channel),
             initialSetup = { app, service ->
@@ -144,7 +144,7 @@ class HttpLogObfuscatorTests {
     fun nullObfuscator() = runBlocking {
         val logger = CustomLogCollector("NULL-OBFUSCATOR", LogLevel.DEBUG)
         app = TestApp(
-            appName = "${SyncServerConfig.appPrefix}-null-obf",
+            appName = syncServerAppName("null-obf"),
             logLevel = LogLevel.DEBUG,
             builder = { it.httpLogObfuscator(null) },
             customLogger = logger,

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ProgressListenerTests.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/ProgressListenerTests.kt
@@ -58,7 +58,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 private const val TEST_SIZE = 500
-private val TIMEOUT = 15.seconds
+private val TIMEOUT = 30.seconds
 
 private val schema = setOf(SyncObjectWithAllTypes::class)
 
@@ -97,7 +97,7 @@ class ProgressListenerTests {
                     )
                     // We are not sure when the realm actually knows of the remote changes and consider
                     // them current, so wait a bit
-                    delay(3.seconds)
+                    delay(10.seconds)
                     realm.syncSession.progressAsFlow(Direction.DOWNLOAD, ProgressMode.CURRENT_CHANGES)
                         .run {
                             withTimeout(TIMEOUT) {

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/internal/KtorNetworkTransportTest.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/internal/KtorNetworkTransportTest.kt
@@ -23,6 +23,7 @@ import io.realm.kotlin.internal.platform.singleThreadDispatcher
 import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
 import io.realm.kotlin.internal.util.use
 import io.realm.kotlin.mongodb.internal.KtorNetworkTransport
+import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TEST_SERVER_BASE_URL
 import io.realm.kotlin.test.mongodb.util.AppServicesClient
 import io.realm.kotlin.test.mongodb.util.BaasApp
@@ -51,7 +52,7 @@ internal class KtorNetworkTransportTest {
         val dispatcherFactory = CoroutineDispatcherFactory.unmanaged(dispatcher)
 
         transport = KtorNetworkTransport(
-            timeoutMs = 5000,
+            timeoutMs = 60000,
             dispatcherFactory = dispatcherFactory
         )
 
@@ -61,7 +62,7 @@ internal class KtorNetworkTransportTest {
                 debug = false,
                 dispatcher = dispatcher
             ).run {
-                getOrCreateApp("ktor-network-test") { app: BaasApp, service: Service ->
+                getOrCreateApp("${SyncServerConfig.appPrefix}-ktor") { app: BaasApp, service: Service ->
                     initialize(app, TEST_METHODS)
                 }
             }

--- a/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/internal/KtorNetworkTransportTest.kt
+++ b/packages/test-sync/src/androidAndroidTest/kotlin/io/realm/kotlin/test/mongodb/shared/internal/KtorNetworkTransportTest.kt
@@ -23,8 +23,8 @@ import io.realm.kotlin.internal.platform.singleThreadDispatcher
 import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
 import io.realm.kotlin.internal.util.use
 import io.realm.kotlin.mongodb.internal.KtorNetworkTransport
-import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TEST_SERVER_BASE_URL
+import io.realm.kotlin.test.mongodb.syncServerAppName
 import io.realm.kotlin.test.mongodb.util.AppServicesClient
 import io.realm.kotlin.test.mongodb.util.BaasApp
 import io.realm.kotlin.test.mongodb.util.KtorTestAppInitializer.initialize
@@ -62,7 +62,7 @@ internal class KtorNetworkTransportTest {
                 debug = false,
                 dispatcher = dispatcher
             ).run {
-                getOrCreateApp("${SyncServerConfig.appPrefix}-ktor") { app: BaasApp, service: Service ->
+                getOrCreateApp(syncServerAppName("ktor")) { app: BaasApp, service: Service ->
                     initialize(app, TEST_METHODS)
                 }
             }

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
@@ -39,8 +39,8 @@ import io.realm.kotlin.test.util.TestHelper
 import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 
-val TEST_APP_PARTITION = "${SyncServerConfig.appPrefix}-pbs" // With Partion-based Sync
-val TEST_APP_FLEX = "${SyncServerConfig.appPrefix}-flx" // With Flexible Sync
+val TEST_APP_PARTITION = syncServerAppName("pbs") // With Partion-based Sync
+val TEST_APP_FLEX = syncServerAppName("flx") // With Flexible Sync
 val TEST_APP_CLUSTER_NAME = SyncServerConfig.clusterName
 
 val TEST_SERVER_BASE_URL = SyncServerConfig.url
@@ -194,3 +194,7 @@ suspend fun App.createUserAndLogIn(
 
 suspend fun App.logIn(email: String, password: String): User =
     this.login(Credentials.emailPassword(email, password))
+
+fun syncServerAppName(appNameSuffix: String): String {
+    return "${SyncServerConfig.appPrefix}-$appNameSuffix"
+}

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
@@ -39,11 +39,11 @@ import io.realm.kotlin.test.util.TestHelper
 import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 
-const val TEST_APP_PARTITION = "test-app-partition" // With Partion-based Sync
-const val TEST_APP_FLEX = "test-app-flex" // With Flexible Sync
+val TEST_APP_PARTITION = "${SyncServerConfig.appPrefix}-pbs" // With Partion-based Sync
+val TEST_APP_FLEX = "${SyncServerConfig.appPrefix}-flx" // With Flexible Sync
+val TEST_APP_CLUSTER_NAME = SyncServerConfig.clusterName
 
-const val TEST_SERVER_BASE_URL = "http://127.0.0.1:9090"
-
+val TEST_SERVER_BASE_URL = SyncServerConfig.url
 const val DEFAULT_PASSWORD = "password1234"
 
 /**
@@ -128,6 +128,15 @@ open class TestApp private constructor(
     }
 
     companion object {
+        // Expose a try-with-resource pattern for Apps
+        inline fun TestApp.use(action: (TestApp) -> Unit) {
+            try {
+                action(this)
+            } finally {
+                this.close()
+            }
+        }
+
         @Suppress("LongParameterList")
         fun build(
             debug: Boolean,

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/HttpClient.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/HttpClient.kt
@@ -31,7 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 
 // TODO Consider moving it to util package?
 fun defaultClient(name: String, debug: Boolean, block: HttpClientConfig<*>.() -> Unit = {}): HttpClient {
-    val timeout = 5.seconds.inWholeMilliseconds
+    val timeout = 60.seconds.inWholeMilliseconds
     return createPlatformClient {
         // Charset defaults to UTF-8 (https://ktor.io/docs/http-plain-text.html#configuration)
         install(HttpTimeout) {

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/TestAppInitializer.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/TestAppInitializer.kt
@@ -339,9 +339,9 @@ object TestAppInitializer {
         }
 
         val (type: String, config: String) = if (TEST_APP_CLUSTER_NAME.isEmpty()) {
-            Pair("mongodb", "{ \"uri\": \"mongodb://localhost:26000\" }")
+            "mongodb" to """{ "uri": "mongodb://localhost:26000" }"""
         } else {
-            Pair("mongodb-atlas", "{ \"clusterName\": \"${TEST_APP_CLUSTER_NAME}\" }")
+            "mongodb-atlas" to """{ "clusterName": "$TEST_APP_CLUSTER_NAME" }"""
         }
         addService(
             """

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/TestAppInitializer.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/TestAppInitializer.kt
@@ -15,6 +15,7 @@
  */
 package io.realm.kotlin.test.mongodb.util
 
+import io.realm.kotlin.test.mongodb.TEST_APP_CLUSTER_NAME
 import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
 import io.realm.kotlin.test.mongodb.TEST_APP_PARTITION
 import kotlinx.serialization.decodeFromString
@@ -337,12 +338,17 @@ object TestAppInitializer {
             enable(true)
         }
 
+        val (type: String, config: String) = if (TEST_APP_CLUSTER_NAME.isEmpty()) {
+            Pair("mongodb", "{ \"uri\": \"mongodb://localhost:26000\" }")
+        } else {
+            Pair("mongodb-atlas", "{ \"clusterName\": \"${TEST_APP_CLUSTER_NAME}\" }")
+        }
         addService(
             """
             {
                 "name": "BackingDB",
-                "type": "mongodb",
-                "config": { "uri": "mongodb://localhost:26000" }
+                "type": "$type",
+                "config": $config
             }
             """.trimIndent()
         ).let { service: Service ->

--- a/tools/delete-cloud-qa-apps.sh
+++ b/tools/delete-cloud-qa-apps.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Script for deleting all apps with a given prefix on `https://realm-qa.mongodb.com`
+# Based on https://www.mongodb.com/docs/atlas/app-services/manage-apps/delete/delete-with-api/
+#
+# All apps can be deleted by calling `sh delete-cloud-qa-apps.sh "" "<publicKey>" "<privateKey>"`
+#
+set -euo pipefail
+
+usage() {
+cat <<EOF
+Usage: $0 "appNamePrefix" "publicApiKey" "privateApiKey"
+EOF
+}
+
+if [ "$#" -ne 3 ]; then
+  usage
+  exit 1
+fi
+
+APP_ID="$1"
+PUBLIC_KEY="$2"
+PRIVATE_KEY="$3"
+
+# Login to the Admin API 
+ACCESS_TOKEN=`curl --fail --location --request POST 'https://realm-qa.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login' \
+--header 'Content-Type: application/json' \
+--data-raw "{
+    \"username\": \"$PUBLIC_KEY\",
+    \"apiKey\": \"$PRIVATE_KEY\"
+
+}" | jq -r .access_token`
+
+# Find GroupId
+GROUP_ID=`curl --fail --location --request GET 'https://realm-qa.mongodb.com/api/admin/v3.0/auth/profile' \
+--header "Authorization: Bearer $ACCESS_TOKEN" | jq -r .roles[0].group_id`
+
+# Find all apps
+APPS=`curl --fail --location --request GET "https://realm-qa.mongodb.com/api/admin/v3.0/groups/$GROUP_ID/apps" \
+ --header "Authorization: Bearer $ACCESS_TOKEN"`
+
+# Delete all apps matching the given prefix
+echo $APPS \
+ | jq -r ".[] | select(.name | contains(\"$APP_ID\")) | ._id" \
+ | xargs -I{} curl --fail --location --request DELETE "https://realm-qa.mongodb.com/api/admin/v3.0/groups/$GROUP_ID/apps/{}" \
+   --header "Authorization: Bearer $ACCESS_TOKEN"


### PR DESCRIPTION
This PR adds support for running all Sync integration tests on either a local BAAS server or on Cloud QA. If running on Cloud, a Cluster must have been set up before starting the tests and the name of that cluster must be provided.

Cleaning up apps are optional as they will be wiped periodically on Cloud anyway, but it is recommended if running tests multiple times in a row.

API Keys can be found in 1Password.