### PR TITLE
Core 13.9.0 and unified RealmLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## 1.8.0 (YYYY-MM-DD)
 
 ### Breaking Changes
-* None.
+* `RealmLog` is now a global singleton shared between all Realm API's. Previously log configuration happened using the `log` builder method on `AppConfiguration`, `SyncConfiguration` or `RealmConfiguration`. These API's are still present and for apps only using a single Atlas App ID, the behaviour is the same. For apps that have configured multiple Atlas App ID's, it will no longer be possible to configure different log levels and loggers for each app. Instead, the last `AppConfiguration` created will override the logger configuration from other `AppConfiguration`s.
 
 ### Enhancements
+* Multiple processes can now access the same encrypted Realm instead of throwing `Encrypted interprocess sharing is currently unsupported`. (Core Issue [#1845](https://github.com/realm/realm-core/issues/1845))
+* Added a public `RealmLog` class that replaces `AppConfiguration.Builder.log()`. (Issue [#XXX](XXX))
+* Realm logs will now contain more debug information from the underlying database when `LogLevel.TRACE` or below is enabled.
 * Avoid tracking unreferenced realm versions through the garbage collector. (Issue [#1234](https://github.com/realm/realm-kotlin/issues/1234))
 * [Sync] All tokens, passwords and custom function arguments are now obfuscated by default, even if `LogLevel` is set to DEBUG, TRACE or ALL. (Issue [#410](https://github.com/realm/realm-kotlin/issues/410))
 
@@ -24,7 +27,7 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* None.
+* Updated to Realm Core 13.9.0, commit 48e47abd9b25609079785cd7c5316ab4d978ecee.
 
 
 ## 1.7.1 (YYYY-MM-DD)

--- a/packages/cinterop/src/androidAndroidTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/androidAndroidTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -46,7 +46,7 @@ class CinteropTest {
 
     @Test
     fun version() {
-        assertEquals("13.5.0", realmc.realm_get_library_version())
+        assertEquals("13.9.0", realmc.realm_get_library_version())
     }
 
     // Test various schema migration with automatic flag:

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/Callback.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/Callback.kt
@@ -42,7 +42,7 @@ interface SyncSessionTransferCompletionCallback {
     fun invoke(error: SyncErrorCode?)
 }
 
-interface SyncLogCallback {
+interface LogCallback {
     // Passes core log levels as shorts to avoid unnecessary jumping between the SDK and JNI
     fun log(logLevel: Short, message: String?)
 }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -601,11 +601,9 @@ expect object RealmInterop {
         basePath: String
     )
 
-    fun realm_sync_client_config_set_log_callback(
-        syncClientConfig: RealmSyncClientConfigurationPointer,
-        callback: SyncLogCallback
-    )
-    fun realm_sync_client_config_set_log_level(syncClientConfig: RealmSyncClientConfigurationPointer, level: CoreLogLevel)
+    fun realm_set_log_callback(level: CoreLogLevel, callback: LogCallback)
+
+    fun realm_set_log_level(level: CoreLogLevel)
 
     fun realm_sync_client_config_set_metadata_mode(
         syncClientConfig: RealmSyncClientConfigurationPointer,

--- a/packages/cinterop/src/jvm/jni/java_class_global_def.hpp
+++ b/packages/cinterop/src/jvm/jni/java_class_global_def.hpp
@@ -52,7 +52,7 @@ private:
         , m_io_realm_kotlin_internal_interop_long_pointer_wrapper(env, "io/realm/kotlin/internal/interop/LongPointerWrapper", false)
         , m_io_realm_kotlin_internal_interop_sync_sync_error(env, "io/realm/kotlin/internal/interop/sync/SyncError", false)
         , m_io_realm_kotlin_internal_interop_sync_app_error(env, "io/realm/kotlin/internal/interop/sync/AppError", false)
-        , m_io_realm_kotlin_internal_interop_sync_log_callback(env, "io/realm/kotlin/internal/interop/SyncLogCallback", false)
+        , m_io_realm_kotlin_internal_interop_log_callback(env, "io/realm/kotlin/internal/interop/LogCallback", false)
         , m_io_realm_kotlin_internal_interop_sync_error_callback(env, "io/realm/kotlin/internal/interop/SyncErrorCallback", false)
         , m_io_realm_kotlin_internal_interop_sync_jvm_sync_session_transfer_completion_callback(env, "io/realm/kotlin/internal/interop/sync/JVMSyncSessionTransferCompletionCallback", false)
         , m_io_realm_kotlin_internal_interop_sync_response_callback_impl(env, "io/realm/kotlin/internal/interop/sync/ResponseCallbackImpl", false)
@@ -77,7 +77,7 @@ private:
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_long_pointer_wrapper;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_sync_error;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_app_error;
-    jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_log_callback;
+    jni_util::JavaClass m_io_realm_kotlin_internal_interop_log_callback;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_error_callback;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_jvm_sync_session_transfer_completion_callback;
     jni_util::JavaClass m_io_realm_kotlin_internal_interop_sync_response_callback_impl;
@@ -150,9 +150,9 @@ public:
         return instance()->m_io_realm_kotlin_internal_interop_sync_app_error;
     }
 
-    inline static const jni_util::JavaClass& sync_log_callback()
+    inline static const jni_util::JavaClass& log_callback()
     {
-        return instance()->m_io_realm_kotlin_internal_interop_sync_log_callback;
+        return instance()->m_io_realm_kotlin_internal_interop_log_callback;
     }
 
     inline static const jni_util::JavaClass& sync_error_callback()

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1198,18 +1198,12 @@ actual object RealmInterop {
         realmc.realm_sync_client_config_set_base_file_path(syncClientConfig.cptr(), basePath)
     }
 
-    actual fun realm_sync_client_config_set_log_callback(
-        syncClientConfig: RealmSyncClientConfigurationPointer,
-        callback: SyncLogCallback
-    ) {
-        realmc.set_log_callback(syncClientConfig.cptr(), callback)
+    actual fun realm_set_log_callback(level: CoreLogLevel, callback: LogCallback) {
+        realmc.set_log_callback(level.priority, callback)
     }
 
-    actual fun realm_sync_client_config_set_log_level(
-        syncClientConfig: RealmSyncClientConfigurationPointer,
-        level: CoreLogLevel
-    ) {
-        realmc.realm_sync_client_config_set_log_level(syncClientConfig.cptr(), level.priority)
+    actual fun realm_set_log_level(level: CoreLogLevel) {
+        realmc.realm_set_log_level(level.priority)
     }
 
     actual fun realm_sync_client_config_set_metadata_mode(

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -2279,18 +2279,19 @@ actual object RealmInterop {
     }
 
     actual fun realm_set_log_callback(level: CoreLogLevel, callback: LogCallback) {
-//        realm_wrapper.realm_set_log_callback(
-//            staticCFunction { userData, logLevel, message ->
-//                val userDataLogCallback = safeUserData<LogCallback>(userData)
-//                userDataLogCallback.log(logLevel.toShort(), message?.toKString())
-//            },
-//            StableRef.create(callback).asCPointer(),
-//            staticCFunction { userData -> disposeUserData<() -> LogCallback>(userData) }
-//        )
+        realm_wrapper.realm_set_log_callback(
+            staticCFunction { userData, logLevel, message ->
+                val userDataLogCallback = safeUserData<LogCallback>(userData)
+                userDataLogCallback.log(logLevel.toShort(), message?.toKString())
+            },
+            level.priority.toUInt(),
+            StableRef.create(callback).asCPointer(),
+            staticCFunction { userData -> disposeUserData<() -> LogCallback>(userData) }
+        )
     }
 
     actual fun realm_set_log_level(level: CoreLogLevel) {
-//        realm_wrapper.realm_set_log_level(level.priority.toUInt())
+        realm_wrapper.realm_set_log_level(level.priority.toUInt())
     }
 
     actual fun realm_sync_client_config_set_metadata_mode(

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -19,7 +19,6 @@
 package io.realm.kotlin.internal.interop
 
 import io.realm.kotlin.internal.interop.Constants.ENCRYPTION_KEY_LENGTH
-import io.realm.kotlin.internal.interop.RealmInterop.realm_dictionary_get_changes
 import io.realm.kotlin.internal.interop.sync.ApiKeyWrapper
 import io.realm.kotlin.internal.interop.sync.AppError
 import io.realm.kotlin.internal.interop.sync.AuthProvider
@@ -2279,29 +2278,19 @@ actual object RealmInterop {
         realm_wrapper.realm_sync_client_config_set_base_file_path(syncClientConfig.cptr(), basePath)
     }
 
-    actual fun realm_sync_client_config_set_log_callback(
-        syncClientConfig: RealmSyncClientConfigurationPointer,
-        callback: SyncLogCallback
-    ) {
-        realm_wrapper.realm_sync_client_config_set_log_callback(
-            syncClientConfig.cptr(),
-            staticCFunction { userData, logLevel, message ->
-                val userDataLogCallback = safeUserData<SyncLogCallback>(userData)
-                userDataLogCallback.log(logLevel.toShort(), message?.toKString())
-            },
-            StableRef.create(callback).asCPointer(),
-            staticCFunction { userData -> disposeUserData<() -> SyncLogCallback>(userData) }
-        )
+    actual fun realm_set_log_callback(level: CoreLogLevel, callback: LogCallback) {
+//        realm_wrapper.realm_set_log_callback(
+//            staticCFunction { userData, logLevel, message ->
+//                val userDataLogCallback = safeUserData<LogCallback>(userData)
+//                userDataLogCallback.log(logLevel.toShort(), message?.toKString())
+//            },
+//            StableRef.create(callback).asCPointer(),
+//            staticCFunction { userData -> disposeUserData<() -> LogCallback>(userData) }
+//        )
     }
 
-    actual fun realm_sync_client_config_set_log_level(
-        syncClientConfig: RealmSyncClientConfigurationPointer,
-        level: CoreLogLevel
-    ) {
-        realm_wrapper.realm_sync_client_config_set_log_level(
-            syncClientConfig.cptr(),
-            level.priority.toUInt()
-        )
+    actual fun realm_set_log_level(level: CoreLogLevel) {
+//        realm_wrapper.realm_set_log_level(level.priority.toUInt())
     }
 
     actual fun realm_sync_client_config_set_metadata_mode(

--- a/packages/cinterop/src/nativeDarwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/nativeDarwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -82,7 +82,7 @@ import kotlin.test.assertTrue
 class CinteropTest {
     @Test
     fun version() {
-        assertEquals("13.5.0", realm_get_library_version()!!.toKString())
+        assertEquals("13.9.0", realm_get_library_version()!!.toKString())
     }
 
     @Test

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -679,23 +679,24 @@ realm_http_transport_t* realm_network_transport_new(jobject network_transport) {
                                     });
 }
 
-void set_log_callback(realm_sync_client_config_t* sync_client_config, jobject log_callback) {
+void set_log_callback(jint j_log_level, jobject log_callback) {
     auto jenv = get_env(false);
-    realm_sync_client_config_set_log_callback(sync_client_config,
-                                              [](void* userdata, realm_log_level_e level, const char* message) {
-                                                  auto log_callback = static_cast<jobject>(userdata);
-                                                  auto jenv = get_env(true);
-                                                  static JavaMethod log_method(jenv,
-                                                                               JavaClassGlobalDef::sync_log_callback(),
-                                                                               "log",
-                                                                               "(SLjava/lang/String;)V");
-                                                  jenv->CallVoidMethod(log_callback, log_method, level, to_jstring(jenv, message));
-                                                  jni_check_exception(jenv);
-                                              },
-                                              jenv->NewGlobalRef(log_callback), // userdata is the log callback
-                                              [](void* userdata) {
-                                                  get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
-                                              });
+    auto log_level = static_cast<realm_log_level_e>(j_log_level);
+    realm_set_log_callback([](void* userdata, realm_log_level_e level, const char* message) {
+                                  auto log_callback = static_cast<jobject>(userdata);
+                                  auto jenv = get_env(true);
+                                  static JavaMethod log_method(jenv,
+                                                               JavaClassGlobalDef::log_callback(),
+                                                               "log",
+                                                               "(SLjava/lang/String;)V");
+                                  jenv->CallVoidMethod(log_callback, log_method, level, to_jstring(jenv, message));
+                                  jni_check_exception(jenv);
+                              },
+                              log_level,
+                              jenv->NewGlobalRef(log_callback), // userdata is the log callback
+                              [](void* userdata) {
+                                  get_env(true)->DeleteGlobalRef(static_cast<jobject>(userdata));
+                              });
 }
 
 jobject convert_to_jvm_sync_error(JNIEnv* jenv, const realm_sync_error_t& error) {

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -45,7 +45,7 @@ realm_http_transport_t*
 realm_network_transport_new(jobject network_transport);
 
 void
-set_log_callback(realm_sync_client_config_t* sync_client_config, jobject log_callback);
+set_log_callback(jint log_level, jobject log_callback);
 
 realm_t*
 open_realm_with_scheduler(int64_t config_ptr, jobject dispatchScheduler);

--- a/packages/library-base/proguard-rules-consumer-common.pro
+++ b/packages/library-base/proguard-rules-consumer-common.pro
@@ -60,7 +60,7 @@
     # TODO OPTIMIZE Only keep actually required symbols
     *;
 }
--keep class io.realm.kotlin.internal.interop.SyncLogCallback {
+-keep class io.realm.kotlin.internal.interop.LogCallback {
     # TODO OPTIMIZE Only keep actually required symbols
     *;
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
@@ -75,6 +75,7 @@ public fun interface InitialDataCallback {
 /**
  * Configuration for log events created by a Realm instance.
  */
+@Deprecated("Use io.realm.kotlin.log.RealmLog instead.")
 public data class LogConfiguration(
     /**
      * The [LogLevel] for which all log events of equal or higher priority will be reported.
@@ -111,6 +112,7 @@ public interface Configuration {
     /**
      * The log configuration used for the realm instance.
      */
+    @Deprecated("Use io.realm.kotlin.log.RealmLog instead.")
     public val log: LogConfiguration
 
     /**
@@ -201,7 +203,6 @@ public interface Configuration {
         // 'name' must be nullable as it is optional when getting SyncClient's default path!
         protected abstract var name: String?
         protected var logLevel: LogLevel = LogLevel.WARN
-        protected var removeSystemLogger: Boolean = false
         protected var userLoggers: List<RealmLogger> = listOf()
         protected var maxNumberOfActiveVersions: Long = Long.MAX_VALUE
         protected var notificationDispatcher: CoroutineDispatcher? = null
@@ -260,6 +261,7 @@ public interface Configuration {
          * installed by default that will redirect to the common logging framework on the platform,
          * i.e. LogCat on Android and NSLog on iOS.
          */
+        @Deprecated("Use io.realm.kotlin.log.RealmLog instead.")
         public open fun log(
             level: LogLevel = LogLevel.WARN,
             customLoggers: List<RealmLogger> = emptyList()
@@ -370,16 +372,6 @@ public interface Configuration {
          */
         public fun inMemory(): S =
             apply { this.inMemory = true } as S
-
-        /**
-         * Removes the default system logger from being installed. If no custom loggers have
-         * been configured, no log events will be reported, regardless of the configured
-         * log level.
-         *
-         * @see [Configuration.SharedBuilder.log]
-         */
-        // TODO Evaluate if this should be part of the public API. For now keep it internal.
-        internal fun removeSystemLogger() = apply { this.removeSystemLogger = true } as S
 
         protected fun validateEncryptionKey(encryptionKey: ByteArray): ByteArray {
             if (encryptionKey.size != Realm.ENCRYPTION_KEY_LENGTH) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
@@ -114,10 +114,9 @@ public interface RealmConfiguration : Configuration {
         }
 
         override fun build(): RealmConfiguration {
+            // Configure logging during creation of SyncConfiguration to keep old behavior for
+            // configuring logging. This should be removed when `LogConfiguration` is removed.
             val allLoggers = mutableListOf<RealmLogger>()
-            if (!removeSystemLogger) {
-                allLoggers.add(createDefaultSystemLogger(Realm.DEFAULT_LOG_TAG))
-            }
             allLoggers.addAll(userLoggers)
 
             // Sync configs might not set 'name' but local configs always do, therefore it will

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
@@ -18,7 +18,6 @@ package io.realm.kotlin
 
 import io.realm.kotlin.internal.RealmConfigurationImpl
 import io.realm.kotlin.internal.platform.appFilesDirectory
-import io.realm.kotlin.internal.platform.createDefaultSystemLogger
 import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
 import io.realm.kotlin.log.RealmLogger
 import io.realm.kotlin.migration.RealmMigration

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/BaseRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/BaseRealmImpl.kt
@@ -17,6 +17,7 @@ package io.realm.kotlin.internal
 
 import io.realm.kotlin.BaseRealm
 import io.realm.kotlin.internal.interop.RealmInterop
+import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.notifications.internal.Callback
 import io.realm.kotlin.notifications.internal.Cancellable
 import io.realm.kotlin.types.BaseRealmObject
@@ -53,10 +54,8 @@ public abstract class BaseRealmImpl internal constructor(
         return super.isClosed()
     }
 
-    internal val log: RealmLog = RealmLog(configuration = configuration.log)
-
     init {
-        log.info("Realm opened $this")
+        RealmLog.info("Realm opened: ${configuration.path}")
     }
 
     override fun schemaVersion(): Long {
@@ -96,7 +95,7 @@ public abstract class BaseRealmImpl internal constructor(
 
     // Not all sub classes of `BaseRealm` can be closed by users.
     internal open fun close() {
-        log.info("Realm closed: $this")
+        RealmLog.info("Realm closed: $this ${configuration.path}")
     }
 
     override fun toString(): String = "${this::class.simpleName}[${this.configuration.path}}]"

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -136,6 +136,11 @@ public open class ConfigurationImpl constructor(
         this.initialDataCallback = initialDataCallback
         this.inMemory = inMemory
 
+        // Configure logging during creation of a (Realm/Sync)Configuration to keep old behavior
+        // for configuring logging. This should be removed when `LogConfiguration` is removed.
+        io.realm.kotlin.log.RealmLog.logLevel = log.level
+        log.loggers.forEach { io.realm.kotlin.log.RealmLog.addLogger(it) }
+
         // We need to freeze `compactOnLaunchCallback` reference on initial thread for Kotlin Native
         val compactCallback = compactOnLaunchCallback?.let { callback ->
             object : io.realm.kotlin.internal.interop.CompactOnLaunchCallback {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/LiveRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/LiveRealm.kt
@@ -22,11 +22,11 @@ import io.realm.kotlin.internal.interop.RealmSchemaPointer
 import io.realm.kotlin.internal.interop.SynchronizableObject
 import io.realm.kotlin.internal.platform.WeakReference
 import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.log.RealmLog
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import io.realm.kotlin.log.RealmLog
 
 /**
  * A live realm that can be updated and receive notifications on data and schema changes when

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
@@ -29,6 +29,7 @@ import io.realm.kotlin.internal.schema.RealmSchemaImpl
 import io.realm.kotlin.internal.util.DispatcherHolder
 import io.realm.kotlin.internal.util.Validation.sdkError
 import io.realm.kotlin.internal.util.terminateWhen
+import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.notifications.RealmChange
 import io.realm.kotlin.notifications.internal.InitialRealmImpl
 import io.realm.kotlin.notifications.internal.UpdatedRealmImpl
@@ -99,7 +100,7 @@ public class RealmImpl private constructor(
     //  Maybe we could just rely on the notifier to issue the initial frozen version, but that
     //  would require us to sync that up. Didn't address this as we already have a todo on fixing
     //  constructing the initial frozen version in the initialization of updatableRealm.
-    private val versionTracker = VersionTracker(this, log)
+    private val versionTracker = VersionTracker(this)
 
     // Injection point for synchronized Realms. This property should only be used to hold state
     // required by synchronized realms. See `SyncedRealmContext` for more details.
@@ -119,7 +120,7 @@ public class RealmImpl private constructor(
                 configuration.initializeRealmData(this@RealmImpl, fileCreated)
             }
             if (!realmStateFlow.tryEmit(State.OPEN)) {
-                log.warn("Cannot signal internal open")
+                RealmLog.warn("Cannot signal internal open")
             }
         } catch (ex: Throwable) {
             // Something went wrong initializing Realm, delete the file, so initialization logic
@@ -132,7 +133,7 @@ public class RealmImpl private constructor(
                     // Ignore. See https://github.com/realm/realm-kotlin/issues/851
                     // Currently there is no reliable way to delete a synchronized
                     // Realm. So ignore if this fails for now.
-                    log.debug(
+                    RealmLog.debug(
                         "An error happened while trying to reset the realm after " +
                             "opening it for the first time failed. The realm must be manually " +
                             "deleted if `initialData` and `initialSubscriptions` should run " +
@@ -227,7 +228,7 @@ public class RealmImpl private constructor(
             }
             if (newest != null) {
                 _realmReference.value = newest.snapshot
-                log.debug("$this ADVANCING $version -> ${_realmReference.value?.version()}")
+                RealmLog.debug("$this ADVANCING $version -> ${_realmReference.value?.version()}")
             }
         }
         return _realmReference.value ?: sdkError("Accessing realmReference before realm has been opened")
@@ -254,7 +255,7 @@ public class RealmImpl private constructor(
             }
         }
         if (!realmStateFlow.tryEmit(State.CLOSED)) {
-            log.warn("Cannot signal internal close")
+            RealmLog.warn("Cannot signal internal close")
         }
         notificationDispatcherHolder.close()
         writeDispatcherHolder.close()

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/SuspendableWriter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/SuspendableWriter.kt
@@ -24,6 +24,7 @@ import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.internal.platform.threadId
 import io.realm.kotlin.internal.schema.RealmClassImpl
 import io.realm.kotlin.internal.schema.RealmSchemaImpl
+import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.types.BaseRealmObject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -77,7 +78,7 @@ internal class SuspendableWriter(private val owner: RealmImpl, val dispatcher: C
     suspend fun updateSchema(schema: RealmSchemaImpl) {
         return withContext(dispatcher) {
             transactionMutex.withLock {
-                realm.log.debug("Updating schema: $schema")
+                RealmLog.debug("Updating schema: $schema")
                 val classPropertyList = schema.classes.map { realmClass: RealmClassImpl ->
                     realmClass.cinteropClass to realmClass.cinteropProperties
                 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/VersionTracker.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/VersionTracker.kt
@@ -20,6 +20,7 @@ import io.realm.kotlin.VersionId
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.RealmPointer
 import io.realm.kotlin.internal.platform.WeakReference
+import io.realm.kotlin.log.RealmLog
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 
@@ -29,7 +30,7 @@ import kotlinx.atomicfu.atomic
  *
  * NOTE: This is not thread safe, so synchronization should be enforced by the owner/caller.
  */
-internal class VersionTracker(private val owner: BaseRealmImpl, private val log: RealmLog) {
+internal class VersionTracker(private val owner: BaseRealmImpl) {
     // Set of currently open realms. Storing the native pointer explicitly to enable us to close
     // the realm when the RealmReference is no longer referenced anymore.
     private val intermediateReferences: AtomicRef<Set<Pair<RealmPointer, WeakReference<RealmReference>>>> = atomic(mutableSetOf())
@@ -37,13 +38,13 @@ internal class VersionTracker(private val owner: BaseRealmImpl, private val log:
     fun trackAndCloseExpiredReferences(realmReference: FrozenRealmReference? = null) {
         val references = mutableSetOf<Pair<RealmPointer, WeakReference<RealmReference>>>()
         realmReference?.let {
-            log.trace("$owner TRACK-VERSION ${realmReference.version()}")
+            RealmLog.trace("$owner TRACK-VERSION ${realmReference.version()}")
             references.add(Pair(realmReference.dbPointer, WeakReference(it)))
         }
         intermediateReferences.value.forEach { entry ->
             val (pointer, ref) = entry
             if (ref.get() == null) {
-                log.trace("$owner CLOSE-FREED ${RealmInterop.realm_get_version_id(pointer)}")
+                RealmLog.trace("$owner CLOSE-FREED ${RealmInterop.realm_get_version_id(pointer)}")
                 RealmInterop.realm_close(pointer)
             } else {
                 references.add(entry)
@@ -58,7 +59,7 @@ internal class VersionTracker(private val owner: BaseRealmImpl, private val log:
 
     fun close() {
         intermediateReferences.value.forEach { (pointer, _) ->
-            log.trace("$owner CLOSE-ACTIVE ${VersionId(RealmInterop.realm_get_version_id(pointer))}")
+            RealmLog.trace("$owner CLOSE-ACTIVE ${VersionId(RealmInterop.realm_get_version_id(pointer))}")
             RealmInterop.realm_close(pointer)
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/LogLevel.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/LogLevel.kt
@@ -24,25 +24,4 @@ public enum class LogLevel(public val priority: Int) {
     ERROR(5),
     WTF(6),
     NONE(7);
-
-    public companion object {
-        /**
-         * Converts a Core log level value to a library log level value. Values that represent the
-         * same level from the library perspective are folded together.
-         *
-         * For internal use only.
-         */
-        public fun fromCoreLogLevel(coreLogLevel: CoreLogLevel): LogLevel = when (coreLogLevel) {
-            CoreLogLevel.RLM_LOG_LEVEL_ALL,
-            CoreLogLevel.RLM_LOG_LEVEL_TRACE -> TRACE
-            CoreLogLevel.RLM_LOG_LEVEL_DEBUG -> DEBUG
-            CoreLogLevel.RLM_LOG_LEVEL_DETAIL,
-            CoreLogLevel.RLM_LOG_LEVEL_INFO -> INFO
-            CoreLogLevel.RLM_LOG_LEVEL_WARNING -> WARN
-            CoreLogLevel.RLM_LOG_LEVEL_ERROR -> ERROR
-            CoreLogLevel.RLM_LOG_LEVEL_FATAL -> WTF
-            CoreLogLevel.RLM_LOG_LEVEL_OFF -> NONE
-            else -> throw IllegalArgumentException("Invalid core log level: $coreLogLevel")
-        }
-    }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/LogLevel.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/LogLevel.kt
@@ -2,7 +2,6 @@ package io.realm.kotlin.log
 
 import io.realm.kotlin.Configuration
 import io.realm.kotlin.Configuration.SharedBuilder
-import io.realm.kotlin.internal.interop.CoreLogLevel
 import io.realm.kotlin.log.LogLevel.TRACE
 import io.realm.kotlin.log.LogLevel.WTF
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/RealmLog.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/RealmLog.kt
@@ -1,0 +1,250 @@
+package io.realm.kotlin.log
+
+import io.realm.kotlin.Realm
+import io.realm.kotlin.internal.interop.CoreLogLevel
+import io.realm.kotlin.internal.interop.RealmInterop
+import io.realm.kotlin.internal.interop.LogCallback
+import io.realm.kotlin.internal.interop.SynchronizableObject
+import io.realm.kotlin.internal.platform.createDefaultSystemLogger
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.SynchronizedObject
+
+/**
+ * Logger class used by Realm components. One logger is created for each Realm instance.
+ */
+public object RealmLog {
+
+    /**
+     * TODO
+     */
+    public var logLevel: LogLevel = LogLevel.WARN
+        set(value) {
+            RealmInterop.realm_set_log_level(value.toCoreLogLevel())
+            field = value
+        }
+
+    private val tag: String = Realm.DEFAULT_LOG_TAG
+    private val systemLoggerInstalled = atomic<RealmLogger?>(null)
+    private val loggersMutex = SynchronizableObject()
+    private val loggers: MutableList<RealmLogger> = mutableListOf()
+
+    init {
+        val initialLevel = logLevel.toCoreLogLevel()
+        registerDefaultSystemLogger()
+        RealmInterop.realm_set_log_callback(initialLevel, object: LogCallback {
+            override fun log(logLevel: Short, message: String?) {
+                doLog(fromCoreLogLevel(CoreLogLevel.valueFromPriority(logLevel)), null, message)
+            }
+        })
+    }
+
+    private fun LogLevel.toCoreLogLevel(): CoreLogLevel {
+        return when(this) {
+            LogLevel.ALL -> CoreLogLevel.RLM_LOG_LEVEL_ALL
+            LogLevel.TRACE -> CoreLogLevel.RLM_LOG_LEVEL_TRACE
+            LogLevel.DEBUG -> CoreLogLevel.RLM_LOG_LEVEL_DEBUG
+            LogLevel.INFO -> CoreLogLevel.RLM_LOG_LEVEL_INFO
+            LogLevel.WARN -> CoreLogLevel.RLM_LOG_LEVEL_WARNING
+            LogLevel.ERROR -> CoreLogLevel.RLM_LOG_LEVEL_ERROR
+            LogLevel.WTF -> CoreLogLevel.RLM_LOG_LEVEL_FATAL
+            LogLevel.NONE -> CoreLogLevel.RLM_LOG_LEVEL_OFF
+        }
+    }
+
+    private fun fromCoreLogLevel(level: CoreLogLevel): LogLevel {
+        return when (level) {
+            CoreLogLevel.RLM_LOG_LEVEL_ALL,
+            CoreLogLevel.RLM_LOG_LEVEL_TRACE -> LogLevel.TRACE
+            CoreLogLevel.RLM_LOG_LEVEL_DEBUG -> LogLevel.DEBUG
+            CoreLogLevel.RLM_LOG_LEVEL_DETAIL,
+            CoreLogLevel.RLM_LOG_LEVEL_INFO -> LogLevel.INFO
+            CoreLogLevel.RLM_LOG_LEVEL_WARNING -> LogLevel.WARN
+            CoreLogLevel.RLM_LOG_LEVEL_ERROR -> LogLevel.ERROR
+            CoreLogLevel.RLM_LOG_LEVEL_FATAL -> LogLevel.WTF
+            CoreLogLevel.RLM_LOG_LEVEL_OFF -> LogLevel.NONE
+            else -> throw IllegalArgumentException("Invalid core log level: $level")
+        }
+    }
+
+    /**
+     * TODO
+     */
+    public fun addLogger(logger: RealmLogger) {
+        loggersMutex.withLock {
+            loggers.add(logger)
+        }
+    }
+
+    /**
+     * TODO
+     */
+    public fun removeLogger(logger: RealmLogger): Boolean {
+        loggersMutex.withLock {
+            return loggers.remove(logger)
+        }
+    }
+
+    /**
+     * TODO
+     */
+    public fun removeAllLoggers(removeDefaultSystemLogger: Boolean = false): Boolean {
+        loggersMutex.withLock {
+            return loggers.removeAll {
+                if (!removeDefaultSystemLogger) {
+                    it != systemLoggerInstalled.value
+                } else {
+                    true
+                }
+            }
+        }
+    }
+
+    /**
+     * TODO
+     */
+    public fun registerDefaultSystemLogger(): Boolean {
+        loggersMutex.withLock {
+            if (systemLoggerInstalled.value == null) {
+                val systemLogger = createDefaultSystemLogger(Realm.DEFAULT_LOG_TAG)
+                loggers.add(systemLogger)
+                systemLoggerInstalled.value = systemLogger
+                return true
+            }
+            return false
+        }
+    }
+
+    /**
+     * TODO
+     */
+    public fun trace(throwable: Throwable?) {
+        doLog(LogLevel.TRACE, throwable, null)
+    }
+
+    /**
+     * TODO
+     */
+    public fun trace(throwable: Throwable?, message: String, vararg args: Any?) {
+        doLog(LogLevel.TRACE, throwable, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun trace(message: String, vararg args: Any?) {
+        doLog(LogLevel.TRACE, null, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun debug(throwable: Throwable?) {
+        doLog(LogLevel.DEBUG, throwable, null)
+    }
+
+    /**
+     * TODO
+     */
+    public fun debug(throwable: Throwable?, message: String, vararg args: Any?) {
+        doLog(LogLevel.DEBUG, throwable, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun debug(message: String, vararg args: Any?) {
+        doLog(LogLevel.DEBUG, null, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun info(throwable: Throwable?) {
+        doLog(LogLevel.INFO, throwable, null)
+    }
+
+    /**
+     * TODO
+     */
+    public fun info(throwable: Throwable?, message: String, vararg args: Any?) {
+        doLog(LogLevel.INFO, throwable, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun info(message: String, vararg args: Any?) {
+        doLog(LogLevel.INFO, null, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun warn(throwable: Throwable?) {
+        doLog(LogLevel.WARN, throwable, null)
+    }
+
+    /**
+     * TODO
+     */
+    public fun warn(throwable: Throwable?, message: String, vararg args: Any?) {
+        doLog(LogLevel.WARN, throwable, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun warn(message: String, vararg args: Any?) {
+        doLog(LogLevel.WARN, null, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun error(throwable: Throwable?) {
+        doLog(LogLevel.ERROR, throwable, null)
+    }
+
+    /**
+     * TODO
+     */
+    public fun error(throwable: Throwable?, message: String, vararg args: Any?) {
+        doLog(LogLevel.ERROR, throwable, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun error(message: String, vararg args: Any?) {
+        doLog(LogLevel.ERROR, null, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun wtf(throwable: Throwable?) {
+        doLog(LogLevel.WTF, throwable, null)
+    }
+
+    /**
+     * TODO
+     */
+    public fun wtf(throwable: Throwable?, message: String, vararg args: Any?) {
+        doLog(LogLevel.WTF, throwable, message, *args)
+    }
+
+    /**
+     * TODO
+     */
+    public fun wtf(message: String, vararg args: Any?) {
+        doLog(LogLevel.WTF, null, message, *args)
+    }
+
+    private fun doLog(level: LogLevel, throwable: Throwable?, message: String?, vararg args: Any?) {
+        if (level.priority >= logLevel.priority) {
+            loggers.forEach {
+                it.log(level, throwable, message, *args)
+            }
+        }
+    }
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/RealmLog.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/log/RealmLog.kt
@@ -2,12 +2,11 @@ package io.realm.kotlin.log
 
 import io.realm.kotlin.Realm
 import io.realm.kotlin.internal.interop.CoreLogLevel
-import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.LogCallback
+import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.SynchronizableObject
 import io.realm.kotlin.internal.platform.createDefaultSystemLogger
 import kotlinx.atomicfu.atomic
-import kotlinx.atomicfu.locks.SynchronizedObject
 
 /**
  * Logger class used by Realm components. One logger is created for each Realm instance.
@@ -23,47 +22,20 @@ public object RealmLog {
             field = value
         }
 
-    private val tag: String = Realm.DEFAULT_LOG_TAG
-    private val systemLoggerInstalled = atomic<RealmLogger?>(null)
     private val loggersMutex = SynchronizableObject()
+    private val systemLoggerInstalled = atomic<RealmLogger?>(null)
     private val loggers: MutableList<RealmLogger> = mutableListOf()
 
     init {
-        val initialLevel = logLevel.toCoreLogLevel()
         registerDefaultSystemLogger()
-        RealmInterop.realm_set_log_callback(initialLevel, object: LogCallback {
-            override fun log(logLevel: Short, message: String?) {
-                doLog(fromCoreLogLevel(CoreLogLevel.valueFromPriority(logLevel)), null, message)
+        RealmInterop.realm_set_log_callback(
+            logLevel.toCoreLogLevel(),
+            object : LogCallback {
+                override fun log(logLevel: Short, message: String?) {
+                    doLog(fromCoreLogLevel(CoreLogLevel.valueFromPriority(logLevel)), null, message)
+                }
             }
-        })
-    }
-
-    private fun LogLevel.toCoreLogLevel(): CoreLogLevel {
-        return when(this) {
-            LogLevel.ALL -> CoreLogLevel.RLM_LOG_LEVEL_ALL
-            LogLevel.TRACE -> CoreLogLevel.RLM_LOG_LEVEL_TRACE
-            LogLevel.DEBUG -> CoreLogLevel.RLM_LOG_LEVEL_DEBUG
-            LogLevel.INFO -> CoreLogLevel.RLM_LOG_LEVEL_INFO
-            LogLevel.WARN -> CoreLogLevel.RLM_LOG_LEVEL_WARNING
-            LogLevel.ERROR -> CoreLogLevel.RLM_LOG_LEVEL_ERROR
-            LogLevel.WTF -> CoreLogLevel.RLM_LOG_LEVEL_FATAL
-            LogLevel.NONE -> CoreLogLevel.RLM_LOG_LEVEL_OFF
-        }
-    }
-
-    private fun fromCoreLogLevel(level: CoreLogLevel): LogLevel {
-        return when (level) {
-            CoreLogLevel.RLM_LOG_LEVEL_ALL,
-            CoreLogLevel.RLM_LOG_LEVEL_TRACE -> LogLevel.TRACE
-            CoreLogLevel.RLM_LOG_LEVEL_DEBUG -> LogLevel.DEBUG
-            CoreLogLevel.RLM_LOG_LEVEL_DETAIL,
-            CoreLogLevel.RLM_LOG_LEVEL_INFO -> LogLevel.INFO
-            CoreLogLevel.RLM_LOG_LEVEL_WARNING -> LogLevel.WARN
-            CoreLogLevel.RLM_LOG_LEVEL_ERROR -> LogLevel.ERROR
-            CoreLogLevel.RLM_LOG_LEVEL_FATAL -> LogLevel.WTF
-            CoreLogLevel.RLM_LOG_LEVEL_OFF -> LogLevel.NONE
-            else -> throw IllegalArgumentException("Invalid core log level: $level")
-        }
+        )
     }
 
     /**
@@ -245,6 +217,34 @@ public object RealmLog {
             loggers.forEach {
                 it.log(level, throwable, message, *args)
             }
+        }
+    }
+
+    private fun LogLevel.toCoreLogLevel(): CoreLogLevel {
+        return when (this) {
+            LogLevel.ALL -> CoreLogLevel.RLM_LOG_LEVEL_ALL
+            LogLevel.TRACE -> CoreLogLevel.RLM_LOG_LEVEL_TRACE
+            LogLevel.DEBUG -> CoreLogLevel.RLM_LOG_LEVEL_DEBUG
+            LogLevel.INFO -> CoreLogLevel.RLM_LOG_LEVEL_INFO
+            LogLevel.WARN -> CoreLogLevel.RLM_LOG_LEVEL_WARNING
+            LogLevel.ERROR -> CoreLogLevel.RLM_LOG_LEVEL_ERROR
+            LogLevel.WTF -> CoreLogLevel.RLM_LOG_LEVEL_FATAL
+            LogLevel.NONE -> CoreLogLevel.RLM_LOG_LEVEL_OFF
+        }
+    }
+
+    private fun fromCoreLogLevel(level: CoreLogLevel): LogLevel {
+        return when (level) {
+            CoreLogLevel.RLM_LOG_LEVEL_ALL,
+            CoreLogLevel.RLM_LOG_LEVEL_TRACE -> LogLevel.TRACE
+            CoreLogLevel.RLM_LOG_LEVEL_DEBUG -> LogLevel.DEBUG
+            CoreLogLevel.RLM_LOG_LEVEL_DETAIL,
+            CoreLogLevel.RLM_LOG_LEVEL_INFO -> LogLevel.INFO
+            CoreLogLevel.RLM_LOG_LEVEL_WARNING -> LogLevel.WARN
+            CoreLogLevel.RLM_LOG_LEVEL_ERROR -> LogLevel.ERROR
+            CoreLogLevel.RLM_LOG_LEVEL_FATAL -> LogLevel.WTF
+            CoreLogLevel.RLM_LOG_LEVEL_OFF -> LogLevel.NONE
+            else -> throw IllegalArgumentException("Invalid core log level: $level")
         }
     }
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -19,12 +19,10 @@ package io.realm.kotlin.mongodb
 import io.ktor.client.plugins.logging.Logger
 import io.realm.kotlin.LogConfiguration
 import io.realm.kotlin.Realm
-import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.internal.interop.sync.MetadataMode
 import io.realm.kotlin.internal.interop.sync.NetworkTransport
 import io.realm.kotlin.internal.platform.appFilesDirectory
 import io.realm.kotlin.internal.platform.canWrite
-import io.realm.kotlin.internal.platform.createDefaultSystemLogger
 import io.realm.kotlin.internal.platform.directoryExists
 import io.realm.kotlin.internal.platform.fileExists
 import io.realm.kotlin.internal.platform.prepareRealmDirectoryPath

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmConfigurationTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmConfigurationTests.kt
@@ -271,15 +271,6 @@ class RealmConfigurationTests {
         assertEquals(logger, config.log.loggers.last())
     }
 
-    @Suppress("invisible_member")
-    @Test
-    fun removeSystemLogger() {
-        val config: RealmConfiguration = RealmConfiguration.Builder(schema = setOf(Sample::class))
-            .removeSystemLogger()
-            .build()
-        assertTrue(config.log.loggers.isEmpty())
-    }
-
     @Test
     fun defaultMaxNumberOfActiveVersions() {
         val config = RealmConfiguration.create(schema = setOf(Sample::class))


### PR DESCRIPTION
This PR upgrades to Core 13.9.0, which includes support for opening encrypted synced Realms across processes.

It also includes the new unified `RealmLog` API. Details are here: https://docs.google.com/document/d/1Okr1jTBunco0S524GBc_RU9PKZPWLXIsdPJd4Q1U-Qw/edit#heading=h.uqpta4k6ounk

But basically, we are now surfacing an API similar to the one in Realm Java, where there is a global `RealmLog` singleton. All the old logger APIs are still present but marked as deprecated. The new implementation is a breaking change in the corner case where you have multiple apps with different log setups, for all other use cases, there should be no behavioral change.

The logs will now include Core storage information as well.

**API**
```
public object class RealmLog {
    public var logLevel: LogLevel = LogLevel.WARN
    public fun addLogger(logger: RealmLogger)
    public fun removeLogger(logger: RealmLogger): Boolean
    public fun removeAllLoggers(removeDefaultSystemLogger: Boolean = false): Boolean
    public fun registerDefaultSystemLogger(): Boolean
    
    // All log methods
    trace(...)
    debug(...)
    info(...)
    warn(...)
    error(...)
    wtf(...)

}

```

**TODO**
- [ ] Dokka
- [ ] Unit tests for all new public methods
- [ ] Cleanup

