### PR TITLE
Add support for authentication flows

### DIFF
--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
@@ -23,6 +23,8 @@ import io.realm.kotlin.mongodb.exceptions.AuthException
 import io.realm.kotlin.mongodb.exceptions.InvalidCredentialsException
 import io.realm.kotlin.mongodb.internal.AppConfigurationImpl
 import io.realm.kotlin.mongodb.internal.AppImpl
+import io.realm.kotlin.mongodb.sync.ConnectionStateChange
+import kotlinx.coroutines.flow.Flow
 
 /**
  * An **App** is the main client-side entry point for interacting with an **Atlas App Services
@@ -100,6 +102,14 @@ public interface App {
      * communicating with App Services. See [AppException] for details.
      */
     public suspend fun login(credentials: Credentials): User
+
+    /**
+     * Create a [Flow] of [AuthenticationChange]-events to receive notifications of updates to all
+     * app user auth states like login and logout.
+     *
+     * @return a [Flow] of authentication events for users associated with this app.
+     */
+    public fun authenticationChangeAsFlow(): Flow<AuthenticationChange>;
 
     /**
      * Close the app instance and release all underlying resources.

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AuthenticationChange.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AuthenticationChange.kt
@@ -1,0 +1,40 @@
+package io.realm.kotlin.mongodb
+
+/**
+ * TODO
+ */
+public data class AuthenticationChange(
+    /**
+     * TODO
+     */
+    public val type: Type,
+    /**
+     * TODO
+     */
+    public val user: User
+) {
+
+    /**
+     * TODO
+     */
+    public enum class Type {
+        /**
+         * TODO
+         */
+        LOGGED_IN,
+        /**
+         * TODO
+         */
+        LOGGED_OUT
+    }
+
+    /**
+     * TODO
+     */
+    public fun didLogIn(): Boolean = (type == Type.LOGGED_IN)
+
+    /**
+     * TODO
+     */
+    public fun didLogOut(): Boolean = (type == Type.LOGGED_OUT)
+}

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
@@ -94,6 +94,7 @@ public class UserImpl(
         }
 
     override suspend fun logOut() {
+        val reportLoggedOut = loggedIn
         Channel<Result<Unit>>(1).use { channel ->
             RealmInterop.realm_app_log_out(
                 app.nativePointer,
@@ -103,11 +104,16 @@ public class UserImpl(
                 }
             )
             return@use channel.receive()
-                .getOrThrow()
+                .getOrThrow().also {
+                    if (reportLoggedOut) {
+                        app.reportUserLoggedOut(this)
+                    }
+                }
         }
     }
 
     override suspend fun remove(): User {
+        val reportLogOut = loggedIn
         Channel<Result<Unit>>(1).use { channel ->
             RealmInterop.realm_app_remove_user(
                 app.nativePointer,
@@ -117,7 +123,11 @@ public class UserImpl(
                 }
             )
             return@use channel.receive()
-                .getOrThrow()
+                .getOrThrow().also {
+                    if (reportLogOut) {
+                        app.reportUserLoggedOut(this)
+                    }
+                }
         }
         return this
     }
@@ -135,7 +145,9 @@ public class UserImpl(
                 }
             )
             return@use channel.receive()
-                .getOrThrow()
+                .getOrThrow().also {
+                    app.reportUserLoggedOut(this)
+                }
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/749

Opening this PR with a few design decisions we need to agree on:

- [ ] In Realm Java, we only report loggedIn/loggedOut, but there also exists a REMOVED state (which is loggedOut with extra semantics). Should we also expose removed in this flow?
- [ ] Currently, I expose an `AuthenticationChange` with a `AuthenticationChange.Type` change. Is that a good approach? There exist two alternatives: 1) Instead reuse the `User.State` which has the same semantics 2) Our object notifications use sealed classes, should we do this instead? Which would also allow us to remove the `Type` enum? I'm probably slightly leaning toward this alternative.
- [ ] #namingIsHard, `authenticationChangeAsFlow` mirrors, kinda, the `SyncSession.connectionStateAsFlow()` as API, not sure if a better name exists?