### PR TITLE
Add support for @PersistedName on classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Enhancements
 * Avoid tracking unreferenced realm versions through the garbage collector. (Issue [#1234](https://github.com/realm/realm-kotlin/issues/1234))
 * [Sync] All tokens, passwords and custom function arguments are now obfuscated by default, even if `LogLevel` is set to DEBUG, TRACE or ALL. (Issue [#410](https://github.com/realm/realm-kotlin/issues/410))
+* [Sync] `@PersistedName` is now also supported on model classes. (Issue [#1138](https://github.com/realm/realm-kotlin/issues/1138))
 
 ### Fixed
 * None.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/PersistedName.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/PersistedName.kt
@@ -17,15 +17,15 @@
 package io.realm.kotlin.types.annotations
 
 @Retention(AnnotationRetention.SOURCE)
-@Target(AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 @MustBeDocumented
 /**
- * Annotation mapping a Kotlin field name to the field name persisted in the Realm.
+ * Annotation mapping a Kotlin class or field name to the name persisted in the Realm.
  *
  * This is useful when opening the Realm across different SDKs where code style
  * conventions might differ.
- *
- * Queries can be made using either of the names:
+ **
+ * For fields with this annotation, queries can be made using either of the names:
  * ```
  * // Class with field using `@PersistedName`
  * class Example : RealmObject {
@@ -44,6 +44,23 @@ package io.realm.kotlin.types.annotations
  *      .first()
  *      .find()?
  *      .myKotlinName
+ * ```
+ *
+ * For classes with this annotation, raw queries must be made with the persisted name. Note,
+ * only queries involving backlinks use this name:
+ * ```
+ * @PersistedName("RealmExample")
+ * class Example : RealmObject {
+ *      var id: Int = 0
+ *      var child: Child? = null
+ * }
+ *
+ * class Child: RealmObject {
+ *      var name: String = "Jane Doe"
+ * }
+ *
+ * // Query by persisted name
+ * realm.query<Child>("@links.RealmExample.child.id == $0", 42).find()
  * ```
  */
 public annotation class PersistedName(val name: String)

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/IrUtils.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/IrUtils.kt
@@ -29,7 +29,6 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
@@ -80,8 +79,6 @@ import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.IrTypeArgument
 import org.jetbrains.kotlin.ir.types.classFqName
-import org.jetbrains.kotlin.ir.types.classifierOrFail
-import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.impl.IrAbstractSimpleType
 import org.jetbrains.kotlin.ir.types.impl.IrTypeBase
 import org.jetbrains.kotlin.ir.types.makeNullable
@@ -585,8 +582,6 @@ fun getSchemaClassName(clazz: IrClass): String {
         clazz.name.identifier
     }
 }
-
-
 
 /** Finds the line and column of [IrDeclaration] */
 fun IrDeclaration.locationOf(): CompilerMessageSourceLocation {

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/IrUtils.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/IrUtils.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
@@ -79,6 +80,8 @@ import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.IrTypeArgument
 import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.classifierOrFail
+import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.impl.IrAbstractSimpleType
 import org.jetbrains.kotlin.ir.types.impl.IrTypeBase
 import org.jetbrains.kotlin.ir.types.makeNullable
@@ -570,6 +573,20 @@ fun getLinkingObjectPropertyName(backingField: IrField): String {
         }
     }
 }
+
+/**
+ * Returns the underlying schema name for a given class type
+ */
+fun getSchemaClassName(clazz: IrClass): String {
+    return if (clazz.hasAnnotation(PERSISTED_NAME_ANNOTATION)) {
+        @Suppress("UNCHECKED_CAST")
+        return (clazz.getAnnotation(PERSISTED_NAME_ANNOTATION).getValueArgument(0)!! as IrConstImpl<String>).value
+    } else {
+        clazz.name.identifier
+    }
+}
+
+
 
 /** Finds the line and column of [IrDeclaration] */
 fun IrDeclaration.locationOf(): CompilerMessageSourceLocation {

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -87,7 +87,6 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrPropertyReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrSetFieldImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrVarargImpl
-import org.jetbrains.kotlin.ir.interpreter.getAnnotation
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.getClass

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -87,9 +87,10 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrPropertyReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrSetFieldImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrVarargImpl
+import org.jetbrains.kotlin.ir.interpreter.getAnnotation
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrFail
-import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.isNullable
 import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.types.makeNullable
@@ -102,6 +103,7 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.getPropertyGetter
 import org.jetbrains.kotlin.ir.util.getPropertySetter
+import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.isVararg
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.name.Name
@@ -249,7 +251,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         companion: IrClass,
         properties: MutableMap<String, SchemaProperty>?,
     ) {
-        val className = clazz.name.identifier
+        val className = getSchemaClassName(clazz)
         val kPropertyType = kMutableProperty1Class.typeWith(
             companion.parentAsClass.defaultType,
             pluginContext.irBuiltIns.anyNType.makeNullable()
@@ -403,6 +405,8 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         val companionObject = irClass.companionObject() as? IrClass
             ?: fatalError("Companion object not available")
 
+        val className = getSchemaClassName(irClass)
+
         val fields: MutableMap<String, SchemaProperty> =
             SchemaCollector.properties.getOrDefault(irClass, mutableMapOf())
 
@@ -449,7 +453,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                             dispatchReceiver = irGetObject(classInfoClass.companionObject()!!.symbol)
                             var arg = 0
                             // Name
-                            putValueArgument(arg++, irString(irClass.name.identifier))
+                            putValueArgument(arg++, irString(className))
                             // Primary key
                             putValueArgument(
                                 arg++,
@@ -602,8 +606,9 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                                 irString(linkTargetType.classifierOrFail.descriptor.name.identifier)
                                             }
                                             linkingObjectType -> {
-                                                val linkTargetType = getBacklinksTargetType(backingField)
-                                                irString(linkTargetType.classifierOrFail.descriptor.name.identifier)
+                                                val linkTargetType: IrType = getBacklinksTargetType(backingField)
+                                                val classRef: IrClass = linkTargetType.getClass() ?: error("$linkTargetType is not a supported class type.")
+                                                irString(getSchemaClassName(classRef))
                                             }
                                             else -> {
                                                 irString("")

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
@@ -175,13 +175,13 @@ class PersistedNameTests {
             copyToRealm(PersistedNameSample())
         }
 
-        val dynamicSample = realm.asDynamicRealm().query(PersistedNameSample::class.simpleName!!)
+        val dynamicSample = realm.asDynamicRealm().query("AlternativePersistedNameSample")
             .find()
             .single()
 
         assertNotNull(dynamicSample)
         assertEquals("Realm", dynamicSample.getValue("persistedNameStringField"))
-        assertFailsWithMessage<IllegalArgumentException>("Schema for type '${PersistedNameSample::class.simpleName!!}' doesn't contain a property named 'publicNameStringField'") {
+        assertFailsWithMessage<IllegalArgumentException>("Schema for type 'AlternativePersistedNameSample' doesn't contain a property named 'publicNameStringField'") {
             dynamicSample.getValue("publicNameStringField")
         }
     }
@@ -257,7 +257,7 @@ class PersistedNameTests {
 
     @Test
     fun schema_propertyUsesPersistedName() {
-        val realmClass = realm.schema()[PersistedNameSample::class.simpleName!!]!!
+        val realmClass = realm.schema()["AlternativePersistedNameSample"]!!
 
         assertNotNull(realmClass["persistedNameStringField"])
         assertEquals(RealmStorageType.STRING, realmClass["persistedNameStringField"]!!.type.storageType)
@@ -266,7 +266,7 @@ class PersistedNameTests {
 
     @Test
     fun dynamicRealmSchema_propertyUsesPersistedName() {
-        val realmClass = realm.asDynamicRealm().schema()[PersistedNameSample::class.simpleName!!]!!
+        val realmClass = realm.asDynamicRealm().schema()["AlternativePersistedNameSample"]!!
 
         assertNotNull(realmClass["persistedNameStringField"])
         assertEquals(RealmStorageType.STRING, realmClass["persistedNameStringField"]!!.type.storageType)

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
@@ -376,10 +376,10 @@ class PersistedNameTests {
 
     @Test
     fun schemaWithOverlappingClassNamesThrow() {
-        assertFailsWithMessage<java.lang.IllegalArgumentException>("The schema has declared the following class names multiple times: PersistedParent") {
+        assertFailsWithMessage<IllegalArgumentException>("The schema has declared the following class names multiple times: PersistedParent") {
             RealmConfiguration.create(schema = setOf(RealmParent::class, PersistedParent::class, RealmChild::class))
         }
-        assertFailsWithMessage<java.lang.IllegalArgumentException>("The schema has declared the following class names multiple times: PersistedParent") {
+        assertFailsWithMessage<IllegalArgumentException>("The schema has declared the following class names multiple times: PersistedParent") {
             RealmConfiguration.create(schema = setOf(PersistedParent::class, RealmParent::class, RealmChild::class))
         }
     }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
@@ -30,7 +30,6 @@ import io.realm.kotlin.migration.AutomaticSchemaMigration
 import io.realm.kotlin.schema.RealmStorageType
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
-import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.use
 import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmInstant

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
@@ -379,8 +379,15 @@ class PersistedNameTests {
         assertFailsWithMessage<IllegalArgumentException>("The schema has declared the following class names multiple times: PersistedParent") {
             RealmConfiguration.create(schema = setOf(RealmParent::class, PersistedParent::class, RealmChild::class))
         }
+
+        // Clash between model name and @PersistedName
         assertFailsWithMessage<IllegalArgumentException>("The schema has declared the following class names multiple times: PersistedParent") {
             RealmConfiguration.create(schema = setOf(PersistedParent::class, RealmParent::class, RealmChild::class))
+        }
+
+        // Clash between two @PersistedName annotations
+        assertFailsWithMessage<IllegalArgumentException>("The schema has declared the following class names multiple times: PersistedParent") {
+            RealmConfiguration.create(schema = setOf(RealmParent::class, RealmParent2::class, RealmChild::class))
         }
     }
 
@@ -452,6 +459,12 @@ class PersistedNameChildSample : RealmObject {
 
 @PersistedName("PersistedParent")
 class RealmParent(var id: Int) : RealmObject {
+    constructor() : this(0)
+    var child: RealmChild? = null
+}
+
+@PersistedName("PersistedParent")
+class RealmParent2(var id: Int) : RealmObject {
     constructor() : this(0)
     var child: RealmChild? = null
 }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmSchemaTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmSchemaTests.kt
@@ -40,6 +40,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -52,7 +53,7 @@ private val SCHEMA_VARIATION_CLASS_NAME = SchemaVariations::class.simpleName!!
  * This test suite doesn't exhaust all modeling features, but should have full coverage of the
  * schema API code paths.
  */
-public class RealmSchemaTests {
+class RealmSchemaTests {
 
     private lateinit var tmpDir: String
     private lateinit var realm: Realm
@@ -60,8 +61,16 @@ public class RealmSchemaTests {
     @BeforeTest
     fun setup() {
         tmpDir = PlatformUtils.createTempDir()
+        val schema = setOf(
+            SchemaVariations::class,
+            Sample::class,
+            EmbeddedParent::class,
+            EmbeddedChild::class,
+            EmbeddedInnerChild::class,
+            PersistedNameSample::class
+        )
         val configuration =
-            RealmConfiguration.Builder(schema = setOf(SchemaVariations::class, Sample::class, EmbeddedParent::class, EmbeddedChild::class, EmbeddedInnerChild::class))
+            RealmConfiguration.Builder(schema = schema)
                 .directory(tmpDir)
                 .build()
         realm = Realm.open(configuration)
@@ -79,7 +88,7 @@ public class RealmSchemaTests {
     fun realmClass() {
         val schema = realm.schema()
 
-        assertEquals(5, schema.classes.size)
+        assertEquals(6, schema.classes.size)
 
         val schemaVariationsDescriptor = schema[SCHEMA_VARIATION_CLASS_NAME]
             ?: fail("Couldn't find class")
@@ -98,6 +107,13 @@ public class RealmSchemaTests {
         assertEquals(embeddedChildName, embeddedChildDescriptor.name)
         assertTrue(embeddedChildDescriptor.isEmbedded)
         assertNull(embeddedChildDescriptor.primaryKey)
+    }
+
+    @Test
+    fun realmClass_persistedName() {
+        val schema = realm.schema()
+        assertNotNull(schema["AlternativePersistedNameSample"])
+        assertNull(schema["PersistedNameSample"])
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/1138

This PR introduces a new level of complexity to opening Realms as we can only detect schema mismatch as part of creating or opening the Realm.

Our current code set up the native RealmSchema when creating the RealmConfiguration, but the schema isn't validated until the Realm is opened. I opted for placing the checking code for this in the same location, but it also means that we can now throw IllegalArgumentException when creating the RealmConfiguration. 

Not 100% sure what the best approach is, so any feedback here would be nice.