### PR TITLE
Add support for Realm.compactRealm()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Realm logs will now contain more debug information from the underlying database when `LogLevel.DEBUG` or below is enabled.
 * Default log level has been changed from `LogLevel.WARN` to `LogLevel.INFO`.
 * Avoid tracking unreferenced realm versions through the garbage collector. (Issue [#1234](https://github.com/realm/realm-kotlin/issues/1234))
+* `Realm.compactRealm(configuration)` has been added as way to compact a Realm file without having to open it. (Issue [#571](https://github.com/realm/realm-kotlin/issues/571))
 * [Sync] All tokens, passwords and custom function arguments are now obfuscated by default, even if `LogLevel` is set to DEBUG, TRACE or ALL. (Issue [#410](https://github.com/realm/realm-kotlin/issues/410))
 * [Sync] `@PersistedName` is now also supported on model classes. (Issue [#1138](https://github.com/realm/realm-kotlin/issues/1138))
 

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -267,6 +267,7 @@ expect object RealmInterop {
     fun realm_is_frozen(realm: RealmPointer): Boolean
     fun realm_close(realm: RealmPointer)
     fun realm_delete_files(path: String)
+    fun realm_compact(realm: RealmPointer): Boolean
     fun realm_convert_with_config(
         realm: RealmPointer,
         config: RealmConfigurationPointer,

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -247,6 +247,12 @@ actual object RealmInterop {
         }
     }
 
+    actual fun realm_compact(realm: RealmPointer): Boolean {
+        val compacted = booleanArrayOf(false)
+        realmc.realm_compact(realm.cptr(), compacted)
+        return compacted.first()
+    }
+
     actual fun realm_convert_with_config(
         realm: RealmPointer,
         config: RealmConfigurationPointer,

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -599,6 +599,14 @@ actual object RealmInterop {
         }
     }
 
+    actual fun realm_compact(realm: RealmPointer): Boolean {
+        memScoped {
+            val compacted = alloc<BooleanVar>()
+            checkedBooleanResult(realm_wrapper.realm_compact(realm.cptr(), compacted.ptr))
+            return compacted.value
+        }
+    }
+
     actual fun realm_convert_with_config(
         realm: RealmPointer,
         config: RealmConfigurationPointer,

--- a/packages/jni-swig-stub/realm.i
+++ b/packages/jni-swig-stub/realm.i
@@ -356,7 +356,7 @@ bool realm_object_is_valid(const realm_object_t*);
 // bool output parameter
 %apply bool* OUTPUT { bool* out_found, bool* did_create, bool* did_delete_realm, bool* out_inserted,
                       bool* erased, bool* out_erased, bool* did_refresh, bool* did_run,
-                      bool* found, bool* out_collection_was_cleared };
+                      bool* found, bool* out_collection_was_cleared, bool* did_compact };
 
 // uint64_t output parameter for realm_get_num_versions
 %apply int64_t* OUTPUT { uint64_t* out_versions_count };

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
@@ -19,7 +19,6 @@ import io.realm.kotlin.internal.InternalConfiguration
 import io.realm.kotlin.internal.RealmImpl
 import io.realm.kotlin.internal.interop.Constants
 import io.realm.kotlin.internal.interop.RealmInterop
-import io.realm.kotlin.internal.platform.OS_NAME
 import io.realm.kotlin.internal.platform.fileExists
 import io.realm.kotlin.internal.platform.isWindows
 import io.realm.kotlin.notifications.RealmChange

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
@@ -19,7 +19,9 @@ import io.realm.kotlin.internal.InternalConfiguration
 import io.realm.kotlin.internal.RealmImpl
 import io.realm.kotlin.internal.interop.Constants
 import io.realm.kotlin.internal.interop.RealmInterop
+import io.realm.kotlin.internal.platform.OS_NAME
 import io.realm.kotlin.internal.platform.fileExists
+import io.realm.kotlin.internal.platform.isWindows
 import io.realm.kotlin.notifications.RealmChange
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.types.BaseRealmObject
@@ -99,6 +101,28 @@ public interface Realm : TypedRealm {
         public fun deleteRealm(configuration: Configuration) {
             if (!fileExists(configuration.path)) return
             RealmInterop.realm_delete_files(configuration.path)
+        }
+
+        /**
+         * Compacts the Realm file defined by the given configuration. Compaction can only succeed
+         * if all references to the Realm file has been closed.
+         *
+         * This method is not available on Windows (JVM), and will throw an [NotImplementedError]
+         * there.
+         *
+         * @param configuration configuration for the Realm to compact.
+         * @return `true` if compaction succeeded, `false` if not.
+         */
+        public fun compactRealm(configuration: Configuration): Boolean {
+            if (isWindows()) {
+                throw NotImplementedError("Realm.compact() is not supported on Windows. See https://github.com/realm/realm-core/issues/4111 for more information.")
+            }
+            if (!fileExists(configuration.path)) return false
+            val config = (configuration as InternalConfiguration)
+            val (dbPointer, _) = RealmInterop.realm_open(config.createNativeConfiguration())
+            return RealmInterop.realm_compact(dbPointer).also {
+                RealmInterop.realm_close(dbPointer)
+            }
         }
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -128,3 +128,8 @@ internal expect fun currentTime(): RealmInstant
  * JVM and macOS: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-callable/
  */
 public expect fun <K : Any?, V : Any?> returnType(field: KMutableProperty1<K, V>): KType
+
+/**
+ * Returns whether or not we are running on Windows
+ */
+public fun isWindows(): Boolean = OS_NAME.contains("windows", ignoreCase = true)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -132,4 +132,4 @@ public expect fun <K : Any?, V : Any?> returnType(field: KMutableProperty1<K, V>
 /**
  * Returns whether or not we are running on Windows
  */
-public fun isWindows(): Boolean = OS_NAME.contains("windows", ignoreCase = true)
+public expect fun isWindows(): Boolean

--- a/packages/library-base/src/jvm/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/jvm/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -61,3 +61,5 @@ private fun preparePath(directoryPath: String) {
         throw IllegalArgumentException("Provided directory is a file: $directoryPath")
     }
 }
+
+public actual fun isWindows(): Boolean = OS_NAME.contains("windows", ignoreCase = true)

--- a/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
+++ b/packages/library-base/src/nativeDarwin/kotlin/io/realm/kotlin/internal/platform/SystemUtils.kt
@@ -136,3 +136,5 @@ private fun preparePath(directoryPath: String, dir: NSURL) {
         }
     }
 }
+
+public actual fun isWindows(): Boolean = false

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmTests.kt
@@ -27,6 +27,7 @@ import io.realm.kotlin.ext.query
 import io.realm.kotlin.ext.version
 import io.realm.kotlin.internal.platform.OS_NAME
 import io.realm.kotlin.internal.platform.PATH_SEPARATOR
+import io.realm.kotlin.internal.platform.isWindows
 import io.realm.kotlin.query.find
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
@@ -471,7 +472,7 @@ class RealmTests {
                     // We expect the following files: db file, .lock, .management, .note.
                     // On Linux and Mac, the .note is used to control notifications. This mechanism
                     // is not used on Windows, so the file is not present there.
-                    val expectedFiles = if (OS_NAME.contains("windows", ignoreCase = true)) {
+                    val expectedFiles = if (isWindows()) {
                         3
                     } else {
                         4
@@ -632,6 +633,29 @@ class RealmTests {
             assertFailsWith<IllegalArgumentException> {
                 realm.writeCopyTo(configB)
             }
+        }
+    }
+
+    @Test
+    fun compactRealm() {
+        realm.close()
+        if (isWindows()) {
+            assertFailsWith<NotImplementedError> {
+                Realm.compactRealm(configuration)
+            }
+        } else {
+            assertTrue(Realm.compactRealm(configuration))
+        }
+    }
+
+    @Test
+    fun compactRealm_failsIfOpen() {
+        if (isWindows()) {
+            assertFailsWith<NotImplementedError> {
+                Realm.compactRealm(configuration)
+            }
+        } else {
+            assertFalse(Realm.compactRealm(configuration))
         }
     }
 

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/RealmTests.kt
@@ -25,7 +25,6 @@ import io.realm.kotlin.ext.isManaged
 import io.realm.kotlin.ext.isValid
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.ext.version
-import io.realm.kotlin.internal.platform.OS_NAME
 import io.realm.kotlin.internal.platform.PATH_SEPARATOR
 import io.realm.kotlin.internal.platform.isWindows
 import io.realm.kotlin.query.find


### PR DESCRIPTION
Closes #571 

This adds support for a manual compact method which has come up a few times as something people want to do (instead of having to open the Realm for either `compactOnLaunch` or `writeCopyTo`). This method also exists in Realm Java.

Core currently has a warning about this method not being safe on Windows, so we are currently throwing an exception on JVM there. See https://github.com/realm/realm-core/issues/4111 for more context.