### PR TITLE
Propagate callback user exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* User exception propagation during the `RealmMigration` and `CompactOnLaunchCallback` instead of the generic *User-provided callback failed* `RuntimeException`. (Issue [#1228](https://github.com/realm/realm-kotlin/issues/1228))
+* User exceptions now propagate correctly out from `RealmMigration` and `CompactOnLaunchCallback` instead of just resulting in a generic *User-provided callback failed* `RuntimeException`. (Issue [#1228](https://github.com/realm/realm-kotlin/issues/1228))
 
 ### Fixed
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 1.8.1-SNAPSHOT (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* User exception propagation during the `RealmMigration` and `CompactOnLaunchCallback` instead of the generic *User-provided callback failed* `RuntimeException`. (Issue [#1228](https://github.com/realm/realm-kotlin/issues/1228))
+
+### Fixed
+* None.
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.7.20 and above.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.6.4 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Gradle version: 6.7.1.
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.8.0 (2023-05-01)
 
 ### Breaking Changes

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/Callback.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/Callback.kt
@@ -68,7 +68,7 @@ fun interface MigrationCallback {
         oldRealm: FrozenRealmPointer,
         newRealm: LiveRealmPointer,
         schema: RealmSchemaPointer
-    ): Boolean
+    )
 }
 
 fun interface SubscriptionSetCallback {
@@ -78,7 +78,7 @@ fun interface SubscriptionSetCallback {
 // The underlying Core implementation can also pass in Realm pointer, but since it is not
 // useful during construction, we omit it from this callback as it is only used as a signal.
 fun interface DataInitializationCallback {
-    fun invoke(): Boolean
+    fun invoke()
 }
 
 fun interface AsyncOpenCallback {

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/CoreErrorConverter.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/CoreErrorConverter.kt
@@ -35,14 +35,14 @@ object CoreErrorConverter {
         val errorCode: ErrorCode? = ErrorCode.of(errorCodeNativeValue)
         val message: String = "[$errorCode]: $messageNativeValue"
 
-        return when {
+        return userError ?: when {
             ErrorCode.RLM_ERR_INDEX_OUT_OF_BOUNDS == errorCode ->
                 IndexOutOfBoundsException(message)
             ErrorCategory.RLM_ERR_CAT_INVALID_ARG in categories ->
                 IllegalArgumentException(message)
             ErrorCategory.RLM_ERR_CAT_LOGIC in categories || ErrorCategory.RLM_ERR_CAT_RUNTIME in categories ->
                 IllegalStateException(message)
-            else -> RuntimeException(message) // This can happen when propagating user level exceptions.
+            else -> Error(message) // This can happen when propagating user level exceptions.
         }
     }
 

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -183,7 +183,6 @@ actual object RealmInterop {
         var fileCreated = false
         val callback = DataInitializationCallback {
             fileCreated = true
-            true
         }
         realm_config_set_data_initialization_function(config, callback)
 

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -70,8 +70,8 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 inline jboolean jni_check_exception(JNIEnv *jenv = get_env()) {
     if (jenv->ExceptionCheck()) {
         jthrowable exception = jenv->ExceptionOccurred();
-        realm_register_user_code_callback_error(jenv->NewGlobalRef(exception));
         jenv->ExceptionClear();
+        realm_register_user_code_callback_error(jenv->NewGlobalRef(exception));
         return false;
     }
     return true;

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -48,7 +48,6 @@ bool throw_as_java_exception(JNIEnv *jenv) {
 
         jstring error_message = (jenv)->NewStringUTF(error.message);
         jstring error_path = (jenv)->NewStringUTF(error.path);
-
         jobject exception = (jenv)->CallStaticObjectMethod(
                 error_type_class,
                 error_type_as_exception,
@@ -56,8 +55,9 @@ bool throw_as_java_exception(JNIEnv *jenv) {
                 jint(error.error),
                 error_message,
                 error_path,
-                nullptr
+                static_cast<jobject>(error.usercode_error)
         );
+        (jenv)->DeleteGlobalRef(static_cast<jobject>(error.usercode_error));
 
         realm_clear_last_error();
         (jenv)->Throw(reinterpret_cast<jthrowable>(exception));
@@ -67,12 +67,14 @@ bool throw_as_java_exception(JNIEnv *jenv) {
     }
 }
 
-inline void jni_check_exception(JNIEnv *jenv = get_env()) {
+inline jboolean jni_check_exception(JNIEnv *jenv = get_env()) {
     if (jenv->ExceptionCheck()) {
-        jenv->ExceptionDescribe();
+        jthrowable exception = jenv->ExceptionOccurred();
+        realm_register_user_code_callback_error(jenv->NewGlobalRef(exception));
         jenv->ExceptionClear();
-        throw std::runtime_error("An unexpected Error was thrown from Java.");
+        return false;
     }
+    return true;
 }
 
 inline std::string get_exception_message(JNIEnv *env) {
@@ -125,16 +127,15 @@ bool migration_callback(void *userdata, realm_t *old_realm, realm_t *new_realm,
     auto env = get_env(true);
     static JavaClass java_callback_class(env, "io/realm/kotlin/internal/interop/MigrationCallback");
     static JavaMethod java_callback_method(env, java_callback_class, "migrate",
-                                           "(Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;)Z");
+                                           "(Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;)V");
     // These realm/schema pointers are only valid for the duraction of the
     // migration so don't let ownership follow the NativePointer-objects
-    bool result = env->CallBooleanMethod(static_cast<jobject>(userdata), java_callback_method,
+    env->CallVoidMethod(static_cast<jobject>(userdata), java_callback_method,
                                         wrap_pointer(env, reinterpret_cast<jlong>(old_realm), false),
                                         wrap_pointer(env, reinterpret_cast<jlong>(new_realm), false),
                                         wrap_pointer(env, reinterpret_cast<jlong>(schema))
     );
-    jni_check_exception(env);
-    return result;
+    return jni_check_exception(env);
 }
 
 // TODO OPTIMIZE Abstract pattern for all notification registrations for collections that receives
@@ -501,20 +502,18 @@ bool realm_should_compact_callback(void* userdata, uint64_t total_bytes, uint64_
 
     jobject callback = static_cast<jobject>(userdata);
     jboolean result = env->CallBooleanMethod(callback, java_should_compact_method, jlong(total_bytes), jlong(used_bytes));
-    jni_check_exception(env);
-    return result;
+    return jni_check_exception(env) && result;
 }
 
 bool realm_data_initialization_callback(void* userdata, realm_t* realm) {
     auto env = get_env(true);
     static JavaClass java_data_init_class(env, "io/realm/kotlin/internal/interop/DataInitializationCallback");
-    static JavaMethod java_data_init_method(env, java_data_init_class, "invoke", "()Z");
+    static JavaMethod java_data_init_method(env, java_data_init_class, "invoke", "()V");
 
     (void)realm; // Ignore Realm as we don't expose the Realm in this callback right now.
     jobject callback = static_cast<jobject>(userdata);
-    jboolean result = env->CallBooleanMethod(callback, java_data_init_method);
-    jni_check_exception(env);
-    return result;
+    env->CallVoidMethod(callback, java_data_init_method);
+    return jni_check_exception(env);
 }
 
 static void send_request_via_jvm_transport(JNIEnv *jenv, jobject network_transport, const realm_http_request_t request, jobject j_response_callback) {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -159,26 +159,11 @@ public open class ConfigurationImpl constructor(
                     RealmInterop.realm_begin_read(newRealm)
                     val old = DynamicRealmImpl(this@ConfigurationImpl, oldRealm)
                     val new = DynamicMutableRealmImpl(this@ConfigurationImpl, newRealm)
-                    @Suppress("TooGenericExceptionCaught")
-                    try {
-                        userMigration.migrate(object : AutomaticSchemaMigration.MigrationContext {
-                            override val oldRealm: DynamicRealm = old
-                            override val newRealm: DynamicMutableRealm = new
-                        })
-                        true
-                    } catch (e: Throwable) {
-                        // Returning false will cause Realm.open to fail with a
-                        // RuntimeException with a text saying "User-provided callback failed"
-                        // which is the closest that we can get across platforms, so dump the
-                        // actual exception to stdout, so users have a chance to see what is
-                        // actually failing
-                        // TODO Should we dump the actual exceptions in a platform specific way
-                        //  https://github.com/realm/realm-kotlin/issues/665
-                        e.printStackTrace()
-                        false
-                    }
+                    userMigration.migrate(object : AutomaticSchemaMigration.MigrationContext {
+                        override val oldRealm: DynamicRealm = old
+                        override val newRealm: DynamicMutableRealm = new
+                    })
                 }
-                else -> TODO("Unsupported migration") // Should never be hit, but build is sometimes complaining that when is not exhausted
             }
         }
 

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
@@ -19,6 +19,7 @@ package io.realm.kotlin.test.shared
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.entities.Sample
+import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.platform.platformFileSystem
 import io.realm.kotlin.test.util.use
@@ -153,8 +154,6 @@ class CompactOnLaunchTests {
             .compactOnLaunch { _, _ -> throw IllegalStateException("Boom") }
             .build()
 
-        // TODO We should find a better way to propagate exceptions
-        // TODO This throws IllegalArgumentException on JVM but RuntimeException on macOS.
-        assertFailsWith<RuntimeException> { Realm.open(config) }
+        assertFailsWithMessage<IllegalStateException>("Boom") { Realm.open(config) }
     }
 }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
@@ -30,7 +30,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/migration/RealmMigrationTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/migration/RealmMigrationTests.kt
@@ -223,7 +223,7 @@ class RealmMigrationTests {
 
         // TODO Provide better error messages for exception in callbacks
         //  https://github.com/realm/realm-kotlin/issues/665
-        assertFailsWithMessage<RuntimeException>("User-provided callback failed") {
+        assertFailsWithMessage<RuntimeException>("User error") {
             Realm.open(newConfiguration)
         }
     }


### PR DESCRIPTION
This PR adds support for propagating user exceptions on the following callbacks:

- Migration
- Should compact on launch
- Realm data initialization

Client reset handlers do not support user exception propagation as it is not implemented in `SyncError` yet. https://github.com/realm/realm-core/issues/6569

Closes #1228 