### PR TITLE
Compact database when less than 50 pct is used

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
@@ -64,7 +64,7 @@ public interface Realm : TypedRealm {
         public val DEFAULT_COMPACT_ON_LAUNCH_CALLBACK: CompactOnLaunchCallback =
             CompactOnLaunchCallback { totalBytes, usedBytes ->
                 val thresholdSize = (50 * 1024 * 1024).toLong()
-                totalBytes > thresholdSize && usedBytes.toDouble() / totalBytes.toDouble() >= 0.5
+                totalBytes > thresholdSize && usedBytes.toDouble() / totalBytes.toDouble() <= 0.5
             }
 
         /**

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
@@ -69,10 +69,11 @@ class CompactOnLaunchTests {
     fun defaultCallback_boundaries() {
         val callback = Realm.DEFAULT_COMPACT_ON_LAUNCH_CALLBACK
         assertFalse(callback.shouldCompact(50 * 1024 * 1024, 40 * 1024 * 1024))
-        assertFalse(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024))
-        assertFalse(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 3))
+        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024))
+        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 3))
         assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 4))
-        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 5))
+        assertFalse(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 5))
+        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25))
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the logic behind the `DEFAULT_COMPACT_ON_LAUNCH_CALLBACK` so it adheres to the existing doc comments.

The database is now compacted when the default `compactOnLaunch()` implementation is used, when it is larger than 50MB and more than 50% can be reclaimed.

Resolves #1380