### PR TITLE
Fix compact on launch to run when less than 50% is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 1.8.1-SNAPSHOT (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* The default compact-on-launch callback trigger 50% or more of the space could be reclaimed was reversed. (Issue [#1380](https://github.com/realm/realm-kotlin/issues/1380))
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.7.20 and above.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.6.4 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Gradle version: 6.7.1.
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+### Contributors
+*  [Tim Klingeleers](https://github.com/Mardaneus86)
+
+
 ## 1.8.0 (2023-05-01)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * None.
 
 ### Contributors
-*  [Tim Klingeleers](https://github.com/Mardaneus86)
+*  [Tim Klingeleers](https://github.com/Mardaneus86) for fixing the default `compactOnLaunch` logic. 
 
 
 ## 1.8.0 (2023-05-01)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
@@ -64,7 +64,7 @@ public interface Realm : TypedRealm {
         public val DEFAULT_COMPACT_ON_LAUNCH_CALLBACK: CompactOnLaunchCallback =
             CompactOnLaunchCallback { totalBytes, usedBytes ->
                 val thresholdSize = (50 * 1024 * 1024).toLong()
-                totalBytes > thresholdSize && usedBytes.toDouble() / totalBytes.toDouble() >= 0.5
+                totalBytes > thresholdSize && usedBytes.toDouble() / totalBytes.toDouble() <= 0.5
             }
 
         /**

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
@@ -69,10 +69,11 @@ class CompactOnLaunchTests {
     fun defaultCallback_boundaries() {
         val callback = Realm.DEFAULT_COMPACT_ON_LAUNCH_CALLBACK
         assertFalse(callback.shouldCompact(50 * 1024 * 1024, 40 * 1024 * 1024))
-        assertFalse(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024))
-        assertFalse(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 3))
+        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024))
+        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 3))
         assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 4))
-        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 5))
+        assertFalse(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 5))
+        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25))
     }
 
     @Test

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
@@ -101,7 +101,7 @@ class CompactOnLaunchTests {
             usage = 0.51
         )
 
-        // File size > 50MB, only reclaims if usage >= 0.5
+        // File size > 50MB, only reclaims if usage < 0.5
         assert(
             shouldCompact = true,
             fileSize = 50.MB + 1.Bytes,

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
@@ -81,9 +81,9 @@ class CompactOnLaunchTests {
             assertFalse(shouldCompact(totalBytes = 50.MB, usage = 0.49))
             assertFalse(shouldCompact(totalBytes = 50.MB, usage = 0.5))
             assertFalse(shouldCompact(totalBytes = 50.MB, usage = 0.51))
-            // File size > 50MB, only reclaims if usage < 0.5
-            assertFalse(shouldCompact(totalBytes = 50.MB + 1.B, usage = 0.49))
-            assertFalse(shouldCompact(totalBytes = 50.MB + 1.B, usage = 0.5))
+            // File size > 50MB, only reclaims if usage <= 0.5
+            assertTrue(shouldCompact(totalBytes = 50.MB + 1.B, usage = 0.49))
+            assertTrue(shouldCompact(totalBytes = 50.MB + 1.B, usage = 0.5))
             assertFalse(shouldCompact(totalBytes = 50.MB + 1.B, usage = 0.51))
         }
     }

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
@@ -65,15 +65,59 @@ class CompactOnLaunchTests {
         assertEquals(Realm.DEFAULT_COMPACT_ON_LAUNCH_CALLBACK, config.compactOnLaunchCallback)
     }
 
+    private val Int.MB get() = (this * 1024 * 1024).toLong()
+
+    private val Int.Bytes get() = (this).toLong()
+
     @Test
     fun defaultCallback_boundaries() {
+        // This callback will only return [True] if the file is above 50 MB and 50% or more of the space can be reclaimed.
         val callback = Realm.DEFAULT_COMPACT_ON_LAUNCH_CALLBACK
-        assertFalse(callback.shouldCompact(50 * 1024 * 1024, 40 * 1024 * 1024))
-        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024))
-        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 3))
-        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 4))
-        assertFalse(callback.shouldCompact(50 * 1024 * 1024 + 8, 25 * 1024 * 1024 + 5))
-        assertTrue(callback.shouldCompact(50 * 1024 * 1024 + 8, 25))
+
+        fun assert(shouldCompact: Boolean, fileSize: Long, usage: Double) {
+            assertEquals(
+                expected = shouldCompact,
+                actual = callback.shouldCompact(
+                    totalBytes = fileSize,
+                    usedBytes = (fileSize * usage).toLong()
+                ),
+                message = "fileSize: $fileSize usage: $usage"
+            )
+        }
+
+        // File size <= 50MB, it will never reclaim
+        assert(
+            shouldCompact = false,
+            fileSize = 50.MB,
+            usage = 0.49
+        )
+        assert(
+            shouldCompact = false,
+            fileSize = 50.MB,
+            usage = 0.5
+        )
+        assert(
+            shouldCompact = false,
+            fileSize = 50.MB,
+            usage = 0.51
+        )
+
+        // File size > 50MB, only reclaims if usage >= 0.5
+        assert(
+            shouldCompact = true,
+            fileSize = 50.MB + 1.Bytes,
+            usage = 0.49
+        )
+        assert(
+            shouldCompact = true,
+            fileSize = 50.MB + 1.Bytes,
+            usage = 0.5
+        )
+        assert(
+            shouldCompact = false,
+            fileSize = 50.MB + 1.Bytes,
+            usage = 0.51
+        )
     }
 
     @Test

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/CompactOnLaunchTests.kt
@@ -30,7 +30,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 


### PR DESCRIPTION
Replacement for https://github.com/realm/realm-kotlin/pull/1382 to get CI validation.

Closes https://github.com/realm/realm-kotlin/issues/1380