### PR TITLE
Fix persisted name object links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 1.8.1-SNAPSHOT (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* Objects that were renamed using `@PersistedName` couldn't be linked. (Issue [#1377](https://github.com/realm/realm-kotlin/issues/1377))
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.7.20 and above.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.6.4 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Gradle version: 6.7.1.
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.8.0 (2023-05-01)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* Objects that were renamed using `@PersistedName` couldn't be linked. (Issue [#1377](https://github.com/realm/realm-kotlin/issues/1377))
+* Objects that were renamed using `@PersistedName` couldn't be referenced as a direct link in a model class. (Issue [#1377](https://github.com/realm/realm-kotlin/issues/1377))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -591,7 +591,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                         when (type) {
                                             objectType -> {
                                                 // Collections of type RealmObject require the type parameter be retrieved from the generic argument
-                                                val linkTargetType = when (collectionTypeSymbol) {
+                                                when (collectionTypeSymbol) {
                                                     PROPERTY_COLLECTION_TYPE_NONE ->
                                                         backingField.type
                                                     PROPERTY_COLLECTION_TYPE_LIST,
@@ -602,17 +602,13 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                                     else ->
                                                         error("Unsupported collection type '$collectionTypeSymbol' for field ${entry.key}")
                                                 }
-                                                irString(linkTargetType.classifierOrFail.descriptor.name.identifier)
                                             }
-                                            linkingObjectType -> {
-                                                val linkTargetType: IrType = getBacklinksTargetType(backingField)
-                                                val classRef: IrClass = linkTargetType.getClass() ?: error("$linkTargetType is not a supported class type.")
-                                                irString(getSchemaClassName(classRef))
-                                            }
-                                            else -> {
-                                                irString("")
-                                            }
-                                        }
+                                            linkingObjectType -> getBacklinksTargetType(backingField)
+                                            else ->  null
+                                        }?.let { linkTargetType: IrType ->
+                                            val classRef: IrClass = linkTargetType.getClass() ?: error("$linkTargetType is not a supported class type.")
+                                            irString(getSchemaClassName(classRef))
+                                        } ?: irString("")
                                     )
                                     // Link property name
                                     putValueArgument(

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -604,7 +604,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                                 }
                                             }
                                             linkingObjectType -> getBacklinksTargetType(backingField)
-                                            else ->  null
+                                            else -> null
                                         }?.let { linkTargetType: IrType ->
                                             val classRef: IrClass = linkTargetType.getClass() ?: error("$linkTargetType is not a supported class type.")
                                             irString(getSchemaClassName(classRef))

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/PersistedNameTests.kt
@@ -374,7 +374,6 @@ class PersistedNameTests {
         }
     }
 
-
     @Test
     fun persistedName_on_objectLink() {
         val config = RealmConfiguration
@@ -510,8 +509,7 @@ class Parent : RealmObject {
     var child: Child? = null
 }
 
-@PersistedName(name="RenamedChild")
+@PersistedName(name = "RenamedChild")
 class Child : RealmObject {
     var name = "child"
 }
-


### PR DESCRIPTION
Fixes the issue where objects that had defined a persisted name were not able to be linked.

The Realm failed to load by throwing an exception when loading the schema.

#closes https://github.com/realm/realm-kotlin/issues/1377