### PR TITLE
Add support for ignoring delegated properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* Realm objects now support ignoring delegated properties . (Issue [#1377](https://github.com/realm/realm-kotlin/pull/1386))
+* Realm objects now support ignoring delegated properties. (Issue [#1377](https://github.com/realm/realm-kotlin/pull/1386))
 
 ### Fixed
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 1.8.1-SNAPSHOT (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* Realm objects now support ignoring delegated properties . (Issue [#1377](https://github.com/realm/realm-kotlin/pull/1386))
+
+### Fixed
+* None.
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.7.20 and above.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.6.4 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Gradle version: 6.7.1.
+* Minimum Android Gradle Plugin version: 4.0.0.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.8.0 (2023-05-01)
 
 ### Breaking Changes

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/Ignore.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/Ignore.kt
@@ -17,7 +17,7 @@
 package io.realm.kotlin.types.annotations
 
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FIELD)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY)
 @MustBeDocumented
 /**
  * Annotation marking a field as ignored inside Realm, meaning that it will not be part of the models' schema.

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -242,7 +242,9 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                 val propertyType = propertyTypeRaw.makeNotNull()
                 val nullable = propertyTypeRaw.isNullable()
                 val excludeProperty =
-                    declaration.backingField!!.hasAnnotation(IGNORE_ANNOTATION) ||
+                    declaration.hasAnnotation(IGNORE_ANNOTATION) ||
+                        declaration.hasAnnotation(TRANSIENT_ANNOTATION) ||
+                        declaration.backingField!!.hasAnnotation(IGNORE_ANNOTATION) ||
                         declaration.backingField!!.hasAnnotation(TRANSIENT_ANNOTATION)
 
                 // Check for property modifiers:

--- a/packages/plugin-compiler/src/test/resources/sample/expected/01_AFTER.ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/sample/expected/01_AFTER.ValidateIrBeforeLowering.ir
@@ -60,10 +60,33 @@ MODULE_FRAGMENT name:<main>
                     obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-id>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
                     propertyName: CONST String type=kotlin.String value="id"
                     value: GET_VAR '<set-?>: kotlin.Long declared in sample.input.Sample.<set-id>' type=kotlin.Long origin=null
+      PROPERTY name:ignoredDelegate visibility:public modality:FINAL [delegated,val]
+        annotations:
+          Ignore
+        FIELD PROPERTY_DELEGATE name:ignoredDelegate$delegate type:kotlin.Lazy<kotlin.String> visibility:private [final]
+          EXPRESSION_BODY
+            CALL 'public final fun lazy <T> (initializer: kotlin.Function0<T of kotlin.LazyKt.lazy>): kotlin.Lazy<T of kotlin.LazyKt.lazy> declared in kotlin.LazyKt' type=kotlin.Lazy<kotlin.String> origin=null
+              <T>: kotlin.String
+              initializer: FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+                FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
+                  BLOCK_BODY
+                    RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in sample.input.Sample.ignoredDelegate$delegate'
+                      CONST String type=kotlin.String value=""
+        FUN DELEGATED_PROPERTY_ACCESSOR name:<get-ignoredDelegate> visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:kotlin.String
+          correspondingProperty: PROPERTY name:ignoredDelegate visibility:public modality:FINAL [delegated,val]
+          $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public final fun <get-ignoredDelegate> (): kotlin.String declared in sample.input.Sample'
+              CALL 'public final fun getValue <T> (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): T of kotlin.LazyKt.getValue [inline,operator] declared in kotlin.LazyKt' type=kotlin.String origin=null
+                <T>: kotlin.String
+                $receiver: GET_FIELD 'FIELD PROPERTY_DELEGATE name:ignoredDelegate$delegate type:kotlin.Lazy<kotlin.String> visibility:private [final]' type=kotlin.Lazy<kotlin.String> origin=null
+                  receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-ignoredDelegate>' type=sample.input.Sample origin=null
+                thisRef: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-ignoredDelegate>' type=sample.input.Sample origin=null
+                property: PROPERTY_REFERENCE 'public final ignoredDelegate: kotlin.String [delegated,val]' field=null getter='public final fun <get-ignoredDelegate> (): kotlin.String declared in sample.input.Sample' setter=null type=kotlin.reflect.KProperty1<sample.input.Sample, kotlin.String> origin=PROPERTY_REFERENCE_FOR_DELEGATE
       PROPERTY name:ignoredString visibility:public modality:FINAL [var]
+        annotations:
+          Ignore
         FIELD PROPERTY_BACKING_FIELD name:ignoredString type:kotlin.String visibility:private
-          annotations:
-            Ignore
           EXPRESSION_BODY
             CONST String type=kotlin.String value=""
         FUN DEFAULT_PROPERTY_ACCESSOR name:<get-ignoredString> visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:kotlin.String

--- a/packages/plugin-compiler/src/test/resources/sample/input/Sample.kt
+++ b/packages/plugin-compiler/src/test/resources/sample/input/Sample.kt
@@ -44,6 +44,9 @@ class Sample : RealmObject {
     var id: Long = Random().nextLong()
 
     @Ignore
+    val ignoredDelegate by lazy { "" }
+
+    @Ignore
     var ignoredString: String = ""
 
     @Transient


### PR DESCRIPTION
Delegated properties did not support the `@Ignore` annotation. This was preventing the users to write their own custom delegated properties.

This would help users to write delegates on Realm types to do any conversion to their own custom types.

#closes https://github.com/realm/realm-kotlin/issues/1381