### PR TITLE
Add support for running Android Unit Tests on the JVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* None
+* Running Android Unit tests on the JVM is now supported instead of throwing `java.lang.NullPointerException`. This includes both pure Android projects (in the `/test` directory) and common tests in Multiplatform projects.
 
 ### Fixed
 * None

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -610,8 +610,8 @@ def runMonkey() {
 def runAndroidUnitTestsOnJvm() {
     try {
         sh """
-            cd examples/kmm-sample/androidApp
-            ./gradlew testDebugUnitTest --stacktrace --no-daemon
+            cd examples/kmm-sample
+            ./gradlew androidApp:testDebugUnitTest --stacktrace --no-daemon
         """
     } catch (err) {
         currentBuild.result = 'FAILURE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,6 +255,7 @@ pipeline {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             runMonkey()
                         }
+                        runAndroidUnitTestsOnJvm()
                     }
                 }
                 stage('Build Android on minimum versions') {
@@ -605,6 +606,19 @@ def runMonkey() {
         currentBuild.stageResult = 'FAILURE'
     }
 }
+
+def runAndroidUnitTestsOnJvm() {
+    try {
+        sh """
+            cd examples/kmm-sample/androidApp
+            ./gradlew testDebugUnitTest --stacktrace --no-daemon
+        """
+    } catch (err) {
+        currentBuild.result = 'FAILURE'
+        currentBuild.stageResult = 'FAILURE'
+    }
+}
+
 
 def runBuildMinAndroidApp() {
     try {

--- a/examples/kmm-sample/androidApp/build.gradle.kts
+++ b/examples/kmm-sample/androidApp/build.gradle.kts
@@ -30,7 +30,9 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     // TODO AUTO-SETUP
-    compileOnly("io.realm.kotlin:library-base:${Realm.version}")
+    implementation("io.realm.kotlin:library-base:${Realm.version}")
+    testImplementation(kotlin("test-junit"))
+    testImplementation("junit:junit:4.12")
 }
 
 android {

--- a/packages/gradle-plugin/src/main/kotlin/io/realm/kotlin/gradle/RealmPlugin.kt
+++ b/packages/gradle-plugin/src/main/kotlin/io/realm/kotlin/gradle/RealmPlugin.kt
@@ -52,6 +52,8 @@ open class RealmPlugin : Plugin<Project> {
 
         project.configurations.all { conf: Configuration ->
             // Ensure that android unit tests uses the Realm JVM variant rather than Android.
+            // This is a bit britle. See https://github.com/realm/realm-kotlin/issues/1404 for
+            // a potential improvement.
             if (conf.name.endsWith("UnitTestRuntimeClasspath")) {
                 conf.resolutionStrategy.dependencySubstitution { ds: DependencySubstitutions ->
                     with(ds) {


### PR DESCRIPTION
Automatically apply the dependency substitution used for our own tests in https://github.com/realm/realm-kotlin/pull/1399 to user projects.

We need to do the dependency substitution manually in our tests as we are not applying the plugin there but just calling the compiler plugin.

With the plugin doing this, running Android tests on the JVM should "just work" for users.

I added a step to our CI pipeline that verifies that this behavior works on Android projects. Kotlin Multiplatform just delegate to Android for this, so I don't think we need to also test Multiplatform projects.