### PR TITLE
Explore API possible for asymmetric sync

### DIFF
--- a/examples/kmm-sample/shared/src/commonMain/kotlin/io/realm/example/kmmsample/ExpressionRepository.kt
+++ b/examples/kmm-sample/shared/src/commonMain/kotlin/io/realm/example/kmmsample/ExpressionRepository.kt
@@ -35,7 +35,7 @@ class ExpressionRepository {
         copyToRealm(Expression().apply { expressionString = expression })
     }
 
-    fun expressions(): List<Expression> = realm.query<Expression>().find()
+    fun expressions(): List<Expression> = realm.query(Expression::class).find()
 
     fun observeChanges(): Flow<List<Expression>> =
         realm.query<Expression>().asFlow().map { resultsChange: ResultsChange<Expression> ->

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/ClassInfo.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/ClassInfo.kt
@@ -29,11 +29,18 @@ data class ClassInfo(
 ) {
 
     val isEmbedded = flags and ClassFlags.RLM_CLASS_EMBEDDED != 0
+    val isAsymmetric = flags and ClassFlags.RLM_CLASS_EMBEDDED != 0
 
     companion object {
         // Convenience wrapper to ease maintaining compiler plugin
-        fun create(name: String, primaryKey: String?, numProperties: Long, isEmbedded: Boolean = false): ClassInfo {
-            val flags: Int = (if (isEmbedded) ClassFlags.RLM_CLASS_EMBEDDED else ClassFlags.RLM_CLASS_NORMAL)
+        fun create(name: String, primaryKey: String?, numProperties: Long, isEmbedded: Boolean = false, isAsymmetric: Boolean = false): ClassInfo {
+            val flags: Int = if (isEmbedded) {
+                ClassFlags.RLM_CLASS_EMBEDDED
+            } else if (isAsymmetric) {
+                ClassFlags.RLM_CLASS_ASYMMETRIC
+            } else {
+                ClassFlags.RLM_CLASS_NORMAL
+            }
             return ClassInfo(name, primaryKey ?: SCHEMA_NO_VALUE, numProperties, 0, flags = flags)
         }
     }

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmEnums.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmEnums.kt
@@ -31,6 +31,7 @@ expect enum class SchemaMode {
 expect object ClassFlags {
     val RLM_CLASS_NORMAL: Int
     val RLM_CLASS_EMBEDDED: Int
+    val RLM_CLASS_ASYMMETRIC: Int
 }
 
 expect enum class PropertyType {

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/ClassFlags.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/ClassFlags.kt
@@ -19,4 +19,5 @@ package io.realm.kotlin.internal.interop
 actual object ClassFlags {
     actual val RLM_CLASS_NORMAL = realm_class_flags_e.RLM_CLASS_NORMAL
     actual val RLM_CLASS_EMBEDDED = realm_class_flags_e.RLM_CLASS_EMBEDDED
+    actual val RLM_CLASS_ASYMMETRIC = realm_class_flags_e.RLM_CLASS_ASYMMETRIC
 }

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmEnums.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmEnums.kt
@@ -48,6 +48,7 @@ actual enum class SchemaMode(override val nativeValue: realm_schema_mode) : Nati
 actual object ClassFlags {
     actual val RLM_CLASS_NORMAL = realm_wrapper.RLM_CLASS_NORMAL.toInt()
     actual val RLM_CLASS_EMBEDDED = realm_wrapper.RLM_CLASS_EMBEDDED.toInt()
+    actual val RLM_CLASS_ASYMMETRIC = realm_wrapper.RLM_CLASS_ASYMMETRIC.toInt()
 }
 
 actual enum class PropertyType(override val nativeValue: UInt) : NativeEnumerated {

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
@@ -17,6 +17,7 @@ package io.realm.kotlin
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.RealmSingleQuery
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
 import io.realm.kotlin.types.RealmObject
 import kotlin.reflect.KClass
 
@@ -103,7 +104,7 @@ public interface MutableRealm : TypedRealm {
         clazz: KClass<T>,
         query: String,
         vararg args: Any?
-    ): RealmQuery<T>
+    ): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject
 
     /**
      * Delete objects from the underlying Realm.
@@ -138,7 +139,7 @@ public interface MutableRealm : TypedRealm {
      * @param schemaClass the class whose objects should be removed.
      * @throws IllegalArgumentException if the class does not exist within the schema.
      */
-    public fun delete(schemaClass: KClass<out BaseRealmObject>)
+    public fun <T: BaseRealmObject> delete(schemaClass: KClass<T>) where T: RealmObject, T: EmbeddedRealmObject
 }
 
 /**
@@ -146,6 +147,6 @@ public interface MutableRealm : TypedRealm {
  *
  * Reified convenience wrapper of [MutableRealm.delete].
  */
-public inline fun <reified T : BaseRealmObject> MutableRealm.delete() {
+public inline fun <reified T : BaseRealmObject> MutableRealm.delete() where T: RealmObject, T: EmbeddedRealmObject {
     delete(T::class)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/MutableRealm.kt
@@ -104,7 +104,7 @@ public interface MutableRealm : TypedRealm {
         clazz: KClass<T>,
         query: String,
         vararg args: Any?
-    ): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject
+    ): RealmQuery<T> where T: Queryable
 
     /**
      * Delete objects from the underlying Realm.
@@ -139,7 +139,7 @@ public interface MutableRealm : TypedRealm {
      * @param schemaClass the class whose objects should be removed.
      * @throws IllegalArgumentException if the class does not exist within the schema.
      */
-    public fun <T: BaseRealmObject> delete(schemaClass: KClass<T>) where T: RealmObject, T: EmbeddedRealmObject
+    public fun <T: BaseRealmObject> delete(schemaClass: KClass<T>) where T: Deleteable, T: Queryable
 }
 
 /**
@@ -147,6 +147,6 @@ public interface MutableRealm : TypedRealm {
  *
  * Reified convenience wrapper of [MutableRealm.delete].
  */
-public inline fun <reified T : BaseRealmObject> MutableRealm.delete() where T: RealmObject, T: EmbeddedRealmObject {
+public inline fun <reified T : BaseRealmObject> MutableRealm.delete() where T: Deleteable, T: Queryable {
     delete(T::class)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Queryable.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Queryable.kt
@@ -1,0 +1,12 @@
+package io.realm.kotlin
+
+import io.realm.kotlin.dynamic.DynamicMutableRealm
+
+/**
+ * A **queryable** is an entity that can be queried as a top-level object in a Realm.
+ *
+ * @see Realm.query
+ * @see MutableRealm.query
+ * @see DynamicMutableRealm.query
+ */
+public interface Queryable

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
@@ -145,7 +145,7 @@ public interface Realm : TypedRealm {
         clazz: KClass<T>,
         query: String,
         vararg args: Any?
-    ): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject
+    ): RealmQuery<T> where T: Queryable
 
     /**
      * Modify the underlying Realm file in a suspendable transaction on the default Realm Write

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Realm.kt
@@ -24,6 +24,7 @@ import io.realm.kotlin.internal.platform.isWindows
 import io.realm.kotlin.notifications.RealmChange
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
 import io.realm.kotlin.types.RealmObject
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -144,7 +145,7 @@ public interface Realm : TypedRealm {
         clazz: KClass<T>,
         query: String,
         vararg args: Any?
-    ): RealmQuery<T>
+    ): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject
 
     /**
      * Modify the underlying Realm file in a suspendable transaction on the default Realm Write

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/TypedRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/TypedRealm.kt
@@ -32,7 +32,7 @@ public interface TypedRealm : BaseRealm {
         clazz: KClass<T>,
         query: String = TRUE_PREDICATE,
         vararg args: Any?
-    ): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject
+    ): RealmQuery<T> where T: Queryable
 
     /**
      * Makes an unmanaged in-memory copy of an already persisted

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/TypedRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/TypedRealm.kt
@@ -4,8 +4,10 @@ import io.realm.kotlin.ext.realmDictionaryOf
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.TRUE_PREDICATE
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
 import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.RealmSet
 import io.realm.kotlin.types.TypedRealmObject
 import kotlin.reflect.KClass
@@ -30,7 +32,7 @@ public interface TypedRealm : BaseRealm {
         clazz: KClass<T>,
         query: String = TRUE_PREDICATE,
         vararg args: Any?
-    ): RealmQuery<T>
+    ): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject
 
     /**
      * Makes an unmanaged in-memory copy of an already persisted

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/MutableRealmExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/MutableRealmExt.kt
@@ -18,6 +18,8 @@ import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.TRUE_PREDICATE
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmObject
 
 /**
  * Returns a [RealmQuery] matching the predicate represented by [query].
@@ -27,4 +29,4 @@ import io.realm.kotlin.types.BaseRealmObject
 public inline fun <reified T : BaseRealmObject> MutableRealm.query(
     query: String = TRUE_PREDICATE,
     vararg args: Any?
-): RealmQuery<T> = query(T::class, query, *args)
+): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject = query(T::class, query, *args)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/MutableRealmExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/MutableRealmExt.kt
@@ -15,6 +15,7 @@
 package io.realm.kotlin.ext
 
 import io.realm.kotlin.MutableRealm
+import io.realm.kotlin.Queryable
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.TRUE_PREDICATE
 import io.realm.kotlin.types.BaseRealmObject
@@ -29,4 +30,4 @@ import io.realm.kotlin.types.RealmObject
 public inline fun <reified T : BaseRealmObject> MutableRealm.query(
     query: String = TRUE_PREDICATE,
     vararg args: Any?
-): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject = query(T::class, query, *args)
+): RealmQuery<T> where T: Queryable = query(T::class, query, *args)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmExt.kt
@@ -19,6 +19,8 @@ import io.realm.kotlin.Realm
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.TRUE_PREDICATE
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmObject
 
 /**
  * Returns a [RealmQuery] matching the predicate represented by [query].
@@ -28,4 +30,4 @@ import io.realm.kotlin.types.BaseRealmObject
 public inline fun <reified T : BaseRealmObject> Realm.query(
     query: String = TRUE_PREDICATE,
     vararg args: Any?
-): RealmQuery<T> = query(T::class, query, *args)
+): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject = query(T::class, query, *args)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/RealmExt.kt
@@ -15,6 +15,7 @@
  */
 package io.realm.kotlin.ext
 
+import io.realm.kotlin.Queryable
 import io.realm.kotlin.Realm
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.TRUE_PREDICATE
@@ -30,4 +31,4 @@ import io.realm.kotlin.types.RealmObject
 public inline fun <reified T : BaseRealmObject> Realm.query(
     query: String = TRUE_PREDICATE,
     vararg args: Any?
-): RealmQuery<T> where T : RealmObject, T: EmbeddedRealmObject = query(T::class, query, *args)
+): RealmQuery<T> where T: Queryable = query(T::class, query, *args)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/TypedRealmExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/TypedRealmExt.kt
@@ -16,6 +16,7 @@
 
 package io.realm.kotlin.ext
 
+import io.realm.kotlin.Queryable
 import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.TRUE_PREDICATE
@@ -34,4 +35,4 @@ import io.realm.kotlin.types.RealmObject
 public inline fun <reified T : BaseRealmObject> TypedRealm.query(
     query: String = TRUE_PREDICATE,
     vararg args: Any?
-): RealmQuery<T>  where T : RealmObject, T: EmbeddedRealmObject = query(T::class, query, *args)
+): RealmQuery<T>  where T: Queryable = query(T::class, query, *args)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/TypedRealmExt.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/ext/TypedRealmExt.kt
@@ -20,6 +20,8 @@ import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.TRUE_PREDICATE
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmObject
 
 /**
  * Returns a [RealmQuery] matching the predicate represented by [query].
@@ -32,4 +34,4 @@ import io.realm.kotlin.types.BaseRealmObject
 public inline fun <reified T : BaseRealmObject> TypedRealm.query(
     query: String = TRUE_PREDICATE,
     vararg args: Any?
-): RealmQuery<T> = query(T::class, query, *args)
+): RealmQuery<T>  where T : RealmObject, T: EmbeddedRealmObject = query(T::class, query, *args)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalMutableRealm.kt
@@ -17,6 +17,7 @@ package io.realm.kotlin.internal
 
 import io.realm.kotlin.Deleteable
 import io.realm.kotlin.MutableRealm
+import io.realm.kotlin.Queryable
 import io.realm.kotlin.UpdatePolicy
 import io.realm.kotlin.ext.isValid
 import io.realm.kotlin.types.BaseRealmObject
@@ -64,7 +65,7 @@ internal interface InternalMutableRealm : MutableRealm {
         deleteable.asInternalDeleteable().delete()
     }
 
-    override fun <T: BaseRealmObject> delete(schemaClass: KClass<T>) where T: RealmObject, T: EmbeddedRealmObject {
+    override fun <T: BaseRealmObject> delete(schemaClass: KClass<T>) where T: Deleteable, T: Queryable {
         try {
             delete(query(schemaClass).find())
         } catch (err: IllegalStateException) {
@@ -86,7 +87,9 @@ internal interface InternalMutableRealm : MutableRealm {
             //  modify them after creation. I do however suspect it will make inserting the objects
             //  much more difficult since it would change our compiler infrastructure quite a bit.
             //  This needs to be discussed.
-            delete(schemaClass)
+            if (schemaClass.isInstance(Deleteable::class)) {
+                delete(schemaClass as Deleteable)
+            }
         }
     }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalTypedRealm.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalTypedRealm.kt
@@ -16,6 +16,7 @@
 
 package io.realm.kotlin.internal
 
+import io.realm.kotlin.Queryable
 import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.ext.isManaged
 import io.realm.kotlin.ext.isValid
@@ -25,7 +26,9 @@ import io.realm.kotlin.internal.schema.RealmSchemaImpl
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.schema.RealmSchema
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
 import io.realm.kotlin.types.RealmDictionary
+import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.TypedRealmObject
 import kotlin.reflect.KClass
 
@@ -52,7 +55,7 @@ internal interface InternalTypedRealm : TypedRealm {
         clazz: KClass<T>,
         query: String,
         vararg args: Any?
-    ): RealmQuery<T> {
+    ): RealmQuery<T> where T: Queryable {
         val className = configuration.mediator.companionOf(clazz).`io_realm_kotlin_className`
         return ObjectQuery(
             realmReference,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/MutableLiveRealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/MutableLiveRealmImpl.kt
@@ -16,9 +16,12 @@
 
 package io.realm.kotlin.internal
 
+import io.realm.kotlin.Queryable
 import io.realm.kotlin.internal.interop.LiveRealmPointer
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmObject
 import kotlin.reflect.KClass
 
 /**
@@ -40,5 +43,5 @@ public class MutableLiveRealmImpl(
         clazz: KClass<T>,
         query: String,
         vararg args: Any?
-    ): RealmQuery<T> = super.query(clazz, query, *args)
+    ): RealmQuery<T> where T: Queryable = super.query(clazz, query, *args)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
@@ -18,6 +18,7 @@ package io.realm.kotlin.internal
 
 import io.realm.kotlin.Configuration
 import io.realm.kotlin.MutableRealm
+import io.realm.kotlin.Queryable
 import io.realm.kotlin.Realm
 import io.realm.kotlin.dynamic.DynamicRealm
 import io.realm.kotlin.internal.dynamic.DynamicRealmImpl
@@ -35,6 +36,8 @@ import io.realm.kotlin.notifications.internal.InitialRealmImpl
 import io.realm.kotlin.notifications.internal.UpdatedRealmImpl
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmObject
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
@@ -179,7 +182,7 @@ public class RealmImpl private constructor(
         clazz: KClass<T>,
         query: String,
         vararg args: Any?
-    ): RealmQuery<T> {
+    ): RealmQuery<T> where T: Queryable {
         return super.query(clazz, query, *args)
     }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/SuspendableWriter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/SuspendableWriter.kt
@@ -17,6 +17,7 @@
 package io.realm.kotlin.internal
 
 import io.realm.kotlin.MutableRealm
+import io.realm.kotlin.Queryable
 import io.realm.kotlin.ext.isManaged
 import io.realm.kotlin.ext.isValid
 import io.realm.kotlin.internal.interop.RealmInterop
@@ -26,6 +27,8 @@ import io.realm.kotlin.internal.schema.RealmClassImpl
 import io.realm.kotlin.internal.schema.RealmSchemaImpl
 import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmObject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
@@ -53,7 +56,11 @@ internal class SuspendableWriter(private val owner: RealmImpl, val dispatcher: C
         override val realmReference: LiveRealmReference
             get() = super.realmReference
 
-        override fun <T : BaseRealmObject> query(clazz: KClass<T>, query: String, vararg args: Any?): RealmQuery<T> {
+        override fun <T : BaseRealmObject> query(
+            clazz: KClass<T>,
+            query: String,
+            vararg args: Any?
+        ): RealmQuery<T> where T: Queryable {
             return super.query(clazz, query, *args)
         }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/schema/RealmClassImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/schema/RealmClassImpl.kt
@@ -19,6 +19,7 @@ package io.realm.kotlin.internal.schema
 import io.realm.kotlin.internal.interop.ClassInfo
 import io.realm.kotlin.internal.interop.PropertyInfo
 import io.realm.kotlin.schema.RealmClass
+import io.realm.kotlin.schema.RealmClassKind
 import io.realm.kotlin.schema.RealmProperty
 import io.realm.kotlin.schema.ValuePropertyType
 
@@ -39,6 +40,15 @@ public data class RealmClassImpl(
     }
 
     override val isEmbedded: Boolean = cinteropClass.isEmbedded
+
+    override val kind: RealmClassKind
+        get() = if (cinteropClass.isEmbedded) {
+                RealmClassKind.EMBEDDED
+            } else if (cinteropClass.isAsymmetric) {
+                RealmClassKind.ASYMMETRIC
+            } else {
+                RealmClassKind.STANDARD
+            }
 
     override fun get(key: String): RealmProperty? = properties.firstOrNull { it.name == key }
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/schema/RealmClass.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/schema/RealmClass.kt
@@ -39,7 +39,13 @@ public interface RealmClass {
     /**
      * Returns whether or not the class is embedded.
      */
+    @Deprecated("This property has been deprecated.", ReplaceWith("isEmbedded == RealmClassKind.EMBEDDED", "io.realm.kotlin.schema.RealmClassKind"))
     public val isEmbedded: Boolean
+
+    /**
+     * Returns what type of Realm class this is.
+     */
+    public val kind: RealmClassKind
 
     /**
      * Index operator to lookup a specific [RealmProperty] from its persisted property name.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/schema/RealmClassKind.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/schema/RealmClassKind.kt
@@ -1,0 +1,19 @@
+package io.realm.kotlin.schema
+
+/**
+ * TODO
+ */
+public enum class RealmClassKind {
+    /**
+     * TODO
+     */
+    STANDARD,
+    /**
+     * TODO
+     */
+    EMBEDDED,
+    /**
+     * TODO
+     */
+    ASYMMETRIC
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/AsymmetricRealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/AsymmetricRealmObject.kt
@@ -1,0 +1,6 @@
+package io.realm.kotlin.types
+
+/**
+ * TODO
+ */
+public interface AsymmetricRealmObject: TypedRealmObject

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/EmbeddedRealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/EmbeddedRealmObject.kt
@@ -16,6 +16,9 @@
 
 package io.realm.kotlin.types
 
+import io.realm.kotlin.Deleteable
+import io.realm.kotlin.Queryable
+
 /**
  * Marker interface to define an embedded model.
  *
@@ -26,4 +29,4 @@ package io.realm.kotlin.types
  * - They cannot have fields annotated with `@PrimaryKey`.
  * - When a parent object is deleted, all embedded objects are also deleted.
  */
-public interface EmbeddedRealmObject : TypedRealmObject
+public interface EmbeddedRealmObject : TypedRealmObject, Deleteable, Queryable

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmObject.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmObject.kt
@@ -16,7 +16,10 @@
 
 package io.realm.kotlin.types
 
+import io.realm.kotlin.Deleteable
+import io.realm.kotlin.Queryable
+
 /**
  * Marker interface to define a model (managed by Realm).
  */
-public interface RealmObject : TypedRealmObject
+public interface RealmObject : TypedRealmObject, Deleteable, Queryable

--- a/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/MutableRealmTests.kt
+++ b/packages/test-base/src/androidAndroidTest/kotlin/io/realm/kotlin/test/shared/MutableRealmTests.kt
@@ -33,6 +33,7 @@ import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.query.RealmSingleQuery
 import io.realm.kotlin.test.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.types.AsymmetricRealmObject
 import io.realm.kotlin.types.RealmInstant
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -601,12 +602,17 @@ class MutableRealmTests {
         }
     }
 
+    class Foo: AsymmetricRealmObject {
+        var name: String = "foo"
+    }
+
     @Test
     fun delete_realmQuery() {
         realm.writeBlocking {
             for (i in 0..9) {
                 copyToRealm(Sample().apply { intField = i % 2 })
             }
+//            query(Foo::class, "")
             assertEquals(10, query<Sample>().count().find())
             val deleteable: RealmQuery<Sample> = query<Sample>("intField = 1")
             delete(deleteable)


### PR DESCRIPTION
We might want to add Asymmetric Sync sooner, rather than later. This PR explores what it would mean for our type system: https://www.mongodb.com/docs/realm/sdk/dotnet/sync/asymmetric-sync/

Initially, I thought it would be simple, but there are some edge cases around the Deletable interface that makes it a bit tricky. This will need to be discussed.