### PR TITLE
Enable profiling for memory tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* None
+* Bumped Android Gradle Version to 7.3.1.
+* Enabled profiling for unit test modules.
 
 
 ## 1.9.1 (2023-06-08)

--- a/benchmarks/androidApp/build.gradle.kts
+++ b/benchmarks/androidApp/build.gradle.kts
@@ -27,6 +27,10 @@ android {
         testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"] = "None"
     }
 
+    buildFeatures {
+        buildConfig = false
+    }
+
     testBuildType = "release"
     buildTypes {
         debug {

--- a/benchmarks/androidApp/build.gradle.kts
+++ b/benchmarks/androidApp/build.gradle.kts
@@ -27,10 +27,6 @@ android {
         testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"] = "None"
     }
 
-    buildFeatures {
-        buildConfig = false
-    }
-
     testBuildType = "release"
     buildTypes {
         debug {

--- a/benchmarks/androidApp/src/androidTest/AndroidManifest.xml
+++ b/benchmarks/androidApp/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="io.realm.kotlin.benchmarks.android">
+    package="io.realm.kotlin.benchmarks.android.test">
 
     <!--
       Important: disable debugging for accurate performance results

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -101,7 +101,7 @@ object Versions {
         const val targetSdk = 33
         const val compileSdkVersion = 33
         const val buildToolsVersion = "33.0.0"
-        const val buildTools = "7.2.2" // https://maven.google.com/web/index.html?q=gradle#com.android.tools.build:gradle
+        const val buildTools = "7.3.1" // https://maven.google.com/web/index.html?q=gradle#com.android.tools.build:gradle
         const val ndkVersion = "23.2.8568313"
         const val r8 = "4.0.48" // See https://developer.android.com/build/kotlin-support
     }

--- a/packages/test-base/src/androidMain/AndroidManifest.xml
+++ b/packages/test-base/src/androidMain/AndroidManifest.xml
@@ -18,5 +18,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.realm.testapp">
     <application>
+        <profileable android:shell="true"/>
     </application>
 </manifest>

--- a/packages/test-sync/src/androidMain/AndroidManifest.xml
+++ b/packages/test-sync/src/androidMain/AndroidManifest.xml
@@ -20,6 +20,8 @@
 
     <application
         android:largeHeap="true"
-        android:networkSecurityConfig="@xml/network_security_config"/>
+        android:networkSecurityConfig="@xml/network_security_config">
+        <profileable android:shell="true"/>
+    </application>
 
 </manifest>


### PR DESCRIPTION
With these changes, it is now possible to profile unit tests running.

Note, that the "low overhead"-mode requires a non-debuggable emulator that is minimum API 29.

I tested with the latest API 34 arme-v8a emulator which worked fine.

If you run profilers from the "run-command", note, it doesn't automatically open and attach the session, which can make timing tricky on short-lived tests:

![image](https://github.com/realm/realm-kotlin/assets/406066/bf0515a3-18aa-48ea-bd7e-5ee4dcf87d86)

Instead, this must be done manually:

![image](https://github.com/realm/realm-kotlin/assets/406066/b953cd87-f6ad-4fde-bbc1-7c08160fdd6a)

This can be done by running the test in debug mode, set a breakpoint, attach the session, and then continue the test. But be aware that the profiler is now running on a debug build.

But then the output should work:

![image](https://github.com/realm/realm-kotlin/assets/406066/cdb911fe-7801-4188-bd42-a0f5c0fbf839)
