### PR TITLE
Disable Relinker on API 23 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Generic arguments have been cleaned up. In a lot of places, `BaseRealmObject` was accepted as input. This was too broad and could result in runtime exceptions. In those places the argument has been restricted to the correct `TypedRealmObject`.
 
 ### Enhancements
+* Loading the native library on Android above API 22 is no longer using Relinker, but now uses the normal `System.loadLibrary()`.
 * Running Android Unit tests on the JVM is now supported instead of throwing `java.lang.NullPointerException`. This includes both pure Android projects (in the `/test` directory) and common tests in Multiplatform projects.
 * Support for passing list, sets or iterable arguments to queries with `IN`-operators, e.g. `query<TYPE>("<field> IN $0", listOf(1,2,3))`. (Issue [#929](https://github.com/realm/realm-kotlin/issues/929))
 * [Sync] Support for `RealmQuery.subscribe()` and `RealmResults.subscribe()` as an easy way to create subscriptions in the background while continuing to use the query result. This API is experimental. (Issue [#1363](https://github.com/realm/realm-kotlin/issues/1363))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Minimum Android SDK: 16.
 
 ### Internal
-* Updated to Realm Core 13.15.0, commit d86103556a139686836dd565862e1a8b36917c76.
+* Updated to Realm Core 13.15.2, commit b8f3244a316f512ad48c761e11e4a135f729ad23.
 * Bumped Android Gradle Version to 7.3.1.
 * Add bundle ID sync connection parameter.
 * Enabled profiling for unit test modules.

--- a/packages/cinterop/src/androidInstrumentedTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/androidInstrumentedTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -44,11 +44,6 @@ import kotlin.test.assertTrue
 @RunWith(AndroidJUnit4::class)
 class CinteropTest {
 
-    @Test
-    fun version() {
-        assertEquals("13.15.0", realmc.realm_get_library_version())
-    }
-
     // Test various schema migration with automatic flag:
     //  - If you add or remove a class you don't need to update the schema version.
     //  - If you add/remove a column you need to set a greater version number for migration.

--- a/packages/cinterop/src/androidMain/kotlin/io/realm/kotlin/internal/AndroidUtils.kt
+++ b/packages/cinterop/src/androidMain/kotlin/io/realm/kotlin/internal/AndroidUtils.kt
@@ -13,7 +13,7 @@ import com.getkeepsafe.relinker.ReLinker
 fun loadAndroidNativeLibs(context: Context, version: String) {
     // Only use Relinker below API 23, since all bugs it fixes are only present there.
     // Also, see if this might fix https://github.com/realm/realm-kotlin/issues/1202
-    if (android.os.Build.VERSION.SDK_INT < 23 ) {
+    if (android.os.Build.VERSION.SDK_INT < 23) {
         ReLinker.loadLibrary(context, "realmc", version)
     } else {
         System.loadLibrary("realmc")

--- a/packages/cinterop/src/androidMain/kotlin/io/realm/kotlin/internal/AndroidUtils.kt
+++ b/packages/cinterop/src/androidMain/kotlin/io/realm/kotlin/internal/AndroidUtils.kt
@@ -10,6 +10,7 @@ import com.getkeepsafe.relinker.ReLinker
  *
  * On JVM and Native, this will happen automatically when first loading the RealmInterop class.
  */
+@Suppress("MagicNumber")
 fun loadAndroidNativeLibs(context: Context, version: String) {
     // Only use Relinker below API 23, since all bugs it fixes are only present there.
     // Also, see if this might fix https://github.com/realm/realm-kotlin/issues/1202

--- a/packages/cinterop/src/androidMain/kotlin/io/realm/kotlin/internal/AndroidUtils.kt
+++ b/packages/cinterop/src/androidMain/kotlin/io/realm/kotlin/internal/AndroidUtils.kt
@@ -11,5 +11,11 @@ import com.getkeepsafe.relinker.ReLinker
  * On JVM and Native, this will happen automatically when first loading the RealmInterop class.
  */
 fun loadAndroidNativeLibs(context: Context, version: String) {
-    ReLinker.loadLibrary(context, "realmc", version)
+    // Only use Relinker below API 23, since all bugs it fixes are only present there.
+    // Also, see if this might fix https://github.com/realm/realm-kotlin/issues/1202
+    if (android.os.Build.VERSION.SDK_INT < 23 ) {
+        ReLinker.loadLibrary(context, "realmc", version)
+    } else {
+        System.loadLibrary("realmc")
+    }
 }

--- a/packages/cinterop/src/nativeDarwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
+++ b/packages/cinterop/src/nativeDarwinTest/kotlin/io/realm/kotlin/test/CinteropTest.kt
@@ -54,11 +54,9 @@ import realm_wrapper.realm_config_set_path
 import realm_wrapper.realm_config_set_schema
 import realm_wrapper.realm_config_set_schema_mode
 import realm_wrapper.realm_config_set_schema_version
-import realm_wrapper.realm_errno
 import realm_wrapper.realm_error_t
 import realm_wrapper.realm_find_class
 import realm_wrapper.realm_get_last_error
-import realm_wrapper.realm_get_library_version
 import realm_wrapper.realm_get_num_classes
 import realm_wrapper.realm_get_schema
 import realm_wrapper.realm_open
@@ -80,10 +78,6 @@ import kotlin.test.assertTrue
 // These test are not thought as being exhaustive, but is more to provide a playground for
 // experiments and maybe more relevant for reproduction of C-API issues.
 class CinteropTest {
-    @Test
-    fun version() {
-        assertEquals("13.15.0", realm_get_library_version()!!.toKString())
-    }
 
     @Test
     fun cinterop_cinterop() {


### PR DESCRIPTION
An attempt at fixing #https://github.com/realm/realm-kotlin/issues/1202,  but since we have never been able to reproduce it it's just a guess. But regardless, Relinker should not be needed at those API levels anyway.

Also bumps to the latest core version and removes the version checks which are just getting in our way for every core release, without providing any real value.
