### PR TITLE
Use async open for FLX Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 * None.
 
 ### Enhancements
-* [Sync] Optimized the opening of Flexible Sync Realms when  `waitForInitialRemoteData` is used. (Issue [#1438](https://github.com/realm/realm-kotlin/issues/1438))
+* [Sync] Optimized the opening of Flexible Sync Realms when `waitForInitialRemoteData` is used. (Issue [#1438](https://github.com/realm/realm-kotlin/issues/1438))
 
 ### Fixed
-* None
+* [Sync] Using `SyncConfiguration.waitForInitialRemoteData()` would require a network connection, even after opening the realm file for the first time. (Issue [#1439](https://github.com/realm/realm-kotlin/pull/1439)) 
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## 1.10.1-SNAPSHOT (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* [Sync] Optimized the opening of Flexible Sync Realms when  `waitForInitialRemoteData` is used. (Issue [#1438](https://github.com/realm/realm-kotlin/issues/1438))
+
+### Fixed
+* None
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.8.0 and above. The K2 compiler is not supported yet.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.7.0 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Kbson 0.3.0.
+* Minimum Gradle version: 6.8.3.
+* Minimum Android Gradle Plugin version: 4.1.3.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.10.0 (2023-06-28)
 
 ### Breaking Changes

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -72,7 +72,12 @@ internal class SyncConfigurationImpl(
         // async open first do download the server side Realm. This is much much faster than
         // creating the Realm locally first and then downloading (and integrating) changes into
         // that.
-        if (partitionValue != null && initialRemoteData != null) {
+        //
+        // Flexible Sync Realms with `waitForInitialRemoteData` enabled will use async open
+        // in order to prevent overloading the server with schema updates. By itself, it isn't
+        // a big problem, but if many thousands or millions of devices all connect at the same
+        // time it puts unnecessary pressure on the server.
+        if (initialRemoteData != null) {
             // Channel to work around not being able to use `suspendCoroutine` to wrap the callback, as
             // that results in the `Continuation` being frozen, which breaks it.
             val channel = Channel<Any>(1)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -35,6 +35,7 @@ import io.realm.kotlin.internal.interop.SyncBeforeClientResetHandler
 import io.realm.kotlin.internal.interop.SyncErrorCallback
 import io.realm.kotlin.internal.interop.sync.SyncError
 import io.realm.kotlin.internal.interop.sync.SyncSessionResyncMode
+import io.realm.kotlin.internal.platform.fileExists
 import io.realm.kotlin.mongodb.exceptions.ClientResetRequiredException
 import io.realm.kotlin.mongodb.exceptions.DownloadingRealmTimeOutException
 import io.realm.kotlin.mongodb.subscriptions
@@ -48,6 +49,7 @@ import io.realm.kotlin.mongodb.sync.SyncClientResetStrategy
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.mongodb.sync.SyncMode
 import io.realm.kotlin.mongodb.sync.SyncSession
+import kotlinx.atomicfu.AtomicBoolean
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.TimeoutCancellationException
@@ -69,15 +71,17 @@ internal class SyncConfigurationImpl(
 
     override suspend fun openRealm(realm: RealmImpl): Pair<FrozenRealmReference, Boolean> {
         // Partition-based Realms with `waitForInitialRemoteData` enabled will use
-        // async open first do download the server side Realm. This is much much faster than
+        // async open first do download the server side Realm. This is much faster than
         // creating the Realm locally first and then downloading (and integrating) changes into
         // that.
         //
         // Flexible Sync Realms with `waitForInitialRemoteData` enabled will use async open
         // in order to prevent overloading the server with schema updates. By itself, it isn't
-        // a big problem, but if many thousands or millions of devices all connect at the same
-        // time it puts unnecessary pressure on the server.
-        if (initialRemoteData != null) {
+        // a big problem, but if many thousands of devices all connect at the same time it puts
+        // unnecessary pressure on the server.
+        val fileExists: Boolean = fileExists(configuration.path)
+        val asyncOpenCreatedRealmFile: AtomicBoolean = atomic(false)
+        if (initialRemoteData != null && !fileExists) {
             // Channel to work around not being able to use `suspendCoroutine` to wrap the callback, as
             // that results in the `Continuation` being frozen, which breaks it.
             val channel = Channel<Any>(1)
@@ -100,7 +104,10 @@ internal class SyncConfigurationImpl(
                     }
                 }
                 when (result) {
-                    is Boolean -> { /* Do nothing, opening the Realm will follow below */ }
+                    is Boolean -> {
+                        // Track whether or not async open created the file.
+                        asyncOpenCreatedRealmFile.value = true
+                    }
                     is Throwable -> throw result
                     else -> throw IllegalStateException("Unexpected value: $result")
                 }
@@ -114,9 +121,18 @@ internal class SyncConfigurationImpl(
             }
         }
 
-        // Open the local Realm file. This will also include any data potentially downloaded
+        // Open the local Realm file. This will include any data potentially downloaded
         // by Async Open above.
-        return configuration.openRealm(realm)
+        //
+        // Core will track whether or not the file was created as part of opening for the first
+        // time, but that might conflicts with us potentially using async open before calling
+        // this method.
+        //
+        // So there are two possibilities for the file to be created:
+        // 1) .waitForInitialRemoteData caused async open to be used, which created the file.
+        // 2) The synced Realm was opened locally first (without async open), which then created the file.
+        val result: Pair<FrozenRealmReference, Boolean> = configuration.openRealm(realm)
+        return Pair(result.first, result.second || asyncOpenCreatedRealmFile.value)
     }
 
     override suspend fun initializeRealmData(realm: RealmImpl, realmFileCreated: Boolean) {


### PR DESCRIPTION
Closes #1438 

I also discovered that we didn't check whether a realm file existed or not before triggering `waitForInitialRemoteData`, this meant that if `waitForInitialRemoteData` was enabled, the device would always require a network connection before opening the realm file, even after being opened for the first time.

It isn't really possible to write a test for this since it would require us to be able to cut the internet connection between opening the Realm for the first and second time. But I verified the behavior manually.