### PR TITLE
Fix RealmInstant accepting invalid constructor parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## 1.10.2 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* `RealmInstant` could be instantiated with invalid arguments. (Issue [#1443](https://github.com/realm/realm-kotlin/issues/1443))
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.8.0 and above. The K2 compiler is not supported yet.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.7.0 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Kbson 0.3.0.
+* Minimum Gradle version: 6.8.3.
+* Minimum Android Gradle Plugin version: 4.1.3.
+* Minimum Android SDK: 16.
+
+### Internal
+* None
+
+
 ## 1.10.1 (2023-06-30)
 
 ### Breaking Changes

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmInstant.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmInstant.kt
@@ -65,6 +65,7 @@ public interface RealmInstant : Comparable<RealmInstant> {
          * to either [MIN] or [MAX].
          */
         public fun from(epochSeconds: Long, nanosecondAdjustment: Int): RealmInstant {
+            @Suppress("ComplexCondition")
             if ((epochSeconds > 0 && nanosecondAdjustment < 0) || (epochSeconds < 0 && nanosecondAdjustment > 0)) {
                 throw IllegalArgumentException("Arguments must be both positive or negative.")
             }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmInstant.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmInstant.kt
@@ -65,10 +65,13 @@ public interface RealmInstant : Comparable<RealmInstant> {
          * to either [MIN] or [MAX].
          */
         public fun from(epochSeconds: Long, nanosecondAdjustment: Int): RealmInstant {
+            if ((epochSeconds > 0 && nanosecondAdjustment < 0) || (epochSeconds < 0 && nanosecondAdjustment > 0)) {
+                throw IllegalArgumentException("Arguments must be both positive or negative.")
+            }
             val secAdjustment: Long = (nanosecondAdjustment / SEC_AS_NANOSECOND).toLong()
             val nsAdjustment: Int = nanosecondAdjustment % SEC_AS_NANOSECOND
-            var s: Long = epochSeconds + secAdjustment
-            var ns: Int = nsAdjustment
+            val s: Long = epochSeconds + secAdjustment
+            val ns: Int = nsAdjustment
             if (((epochSeconds.xor(s)).and(secAdjustment.xor(s))) < 0) {
                 return if (epochSeconds < 0) MIN else MAX
             }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmInstantTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmInstantTests.kt
@@ -10,6 +10,7 @@ import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.internal.toDuration
 import io.realm.kotlin.internal.toRealmInstant
 import io.realm.kotlin.query.find
+import io.realm.kotlin.test.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.types.RealmInstant
 import kotlinx.coroutines.delay
@@ -114,14 +115,6 @@ class RealmInstantTests {
             assertEquals(0, zeroMinusOne.epochSeconds)
             assertEquals(-1, zeroMinusOne.nanosecondsOfSecond)
         }
-
-        roundTrip(RealmInstant.from(-1, 2_000_000_200)) { crossingZeroFromNegative ->
-            assertEquals(RealmInstant.from(1, 200), crossingZeroFromNegative)
-        }
-
-        roundTrip(RealmInstant.from(1, -2_000_000_200)) { crossingZeroFromPositive ->
-            assertEquals(RealmInstant.from(-1, -200), crossingZeroFromPositive)
-        }
     }
 
     // Store value and retrieve it again
@@ -204,6 +197,17 @@ class RealmInstantTests {
             val duration1 = ts1.epochSeconds.seconds + ts1.nanosecondsOfSecond.nanoseconds
             val duration2 = ts2.epochSeconds.seconds + ts2.nanosecondsOfSecond.nanoseconds
             assertTrue(duration2 > duration1)
+        }
+    }
+
+    @Test
+    fun mismatchingSign_throws() {
+        assertFailsWithMessage<IllegalArgumentException>("Arguments must be both positive or negative.") {
+            RealmInstant.from(Long.MAX_VALUE, Int.MIN_VALUE)
+        }
+
+        assertFailsWithMessage<IllegalArgumentException>("Arguments must be both positive or negative.") {
+            RealmInstant.from(Long.MIN_VALUE, Int.MAX_VALUE)
         }
     }
 


### PR DESCRIPTION
RealmInstant requires that both constructor's parameters be positive or negative, but never a mix of them. 