### PR TITLE
Add implementation for equals, hascode, and toString to unmanaged RealmList and RealmSet

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmListInternal.kt
@@ -46,13 +46,21 @@ import kotlin.reflect.KClass
 /**
  * Implementation for unmanaged lists, backed by a [MutableList].
  */
-internal class UnmanagedRealmList<E> : RealmList<E>, InternalDeleteable, MutableList<E> by mutableListOf() {
+internal class UnmanagedRealmList<E>(
+    private val backingList: MutableList<E> = mutableListOf()
+) : RealmList<E>, InternalDeleteable, MutableList<E> by backingList {
     override fun asFlow(): Flow<ListChange<E>> =
         throw UnsupportedOperationException("Unmanaged lists cannot be observed.")
 
     override fun delete() {
         throw UnsupportedOperationException("Unmanaged lists cannot be deleted.")
     }
+
+    override fun toString(): String = "UnmanagedRealmList{${joinToString()}}"
+
+    override fun equals(other: Any?): Boolean = backingList == other
+
+    override fun hashCode(): Int = backingList.hashCode()
 }
 
 /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmSetInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmSetInternal.kt
@@ -18,6 +18,7 @@ package io.realm.kotlin.internal
 
 import io.realm.kotlin.UpdatePolicy
 import io.realm.kotlin.Versioned
+import io.realm.kotlin.ext.realmSetOf
 import io.realm.kotlin.internal.RealmValueArgumentConverter.convertToQueryArgs
 import io.realm.kotlin.internal.interop.Callback
 import io.realm.kotlin.internal.interop.ClassKey
@@ -46,7 +47,9 @@ import kotlin.reflect.KClass
 /**
  * Implementation for unmanaged sets, backed by a [MutableSet].
  */
-internal class UnmanagedRealmSet<E> : RealmSet<E>, InternalDeleteable, MutableSet<E> by mutableSetOf() {
+internal class UnmanagedRealmSet<E>(
+    private val backingSet: MutableSet<E> = mutableSetOf()
+) : RealmSet<E>, InternalDeleteable, MutableSet<E> by backingSet {
     override fun asFlow(): Flow<SetChange<E>> {
         throw UnsupportedOperationException("Unmanaged sets cannot be observed.")
     }
@@ -54,6 +57,12 @@ internal class UnmanagedRealmSet<E> : RealmSet<E>, InternalDeleteable, MutableSe
     override fun delete() {
         throw UnsupportedOperationException("Unmanaged sets cannot be deleted.")
     }
+
+    override fun toString(): String = "UnmanagedRealmSet{${joinToString()}}"
+
+    override fun equals(other: Any?): Boolean = backingSet == other
+
+    override fun hashCode(): Int = backingSet.hashCode()
 }
 
 /**

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmListTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmListTests.kt
@@ -95,6 +95,21 @@ class RealmListTests : EmbeddedObjectCollectionQueryTests {
         realm = Realm.open(configuration)
     }
 
+    @Test
+    fun testing() {
+        val a = mutableListOf<Int>().apply {
+            add(1)
+        }
+
+        val b = mutableListOf<Int>().apply {
+            add(1)
+        }
+
+        assertEquals(a.hashCode(), b.hashCode())
+
+        assertEquals(realmListOf(1), realmListOf(1))
+    }
+
     @AfterTest
     fun tearDown() {
         if (this::realm.isInitialized && !realm.isClosed()) {
@@ -110,6 +125,17 @@ class RealmListTests : EmbeddedObjectCollectionQueryTests {
 
         val realmListFromArgs: RealmList<String> = realmListOf("1", "2")
         assertContentEquals(listOf("1", "2"), realmListFromArgs)
+    }
+
+    @Test
+    fun unmanagedRealmList_equalsHash() {
+        assertEquals(realmListOf("1", "2"), realmListOf("1", "2"))
+        assertEquals(realmListOf("1", "2").hashCode(), realmListOf("1", "2").hashCode())
+    }
+
+    @Test
+    fun unmanagedRealmList_toString() {
+        assertEquals("""UnmanagedRealmList{1, 2}""", realmListOf("1", "2").toString())
     }
 
     @Test

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmSetTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmSetTests.kt
@@ -24,6 +24,7 @@ import io.realm.kotlin.entities.SampleWithPrimaryKey
 import io.realm.kotlin.entities.set.RealmSetContainer
 import io.realm.kotlin.ext.asRealmObject
 import io.realm.kotlin.ext.query
+import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.realmSetOf
 import io.realm.kotlin.ext.toRealmSet
 import io.realm.kotlin.query.RealmQuery
@@ -150,6 +151,17 @@ class RealmSetTests : CollectionQueryTests {
 
         val realmSetFromArgs: RealmSet<String> = realmSetOf("1", "2")
         assertContentEquals(listOf("1", "2"), realmSetFromArgs)
+    }
+
+    @Test
+    fun unmanagedRealmSet_equalsHash() {
+        assertEquals(realmSetOf("1", "2"), realmSetOf("1", "2"))
+        assertEquals(realmSetOf("1", "2").hashCode(), realmSetOf("1", "2").hashCode())
+    }
+
+    @Test
+    fun unmanagedRealmSet_toString() {
+        assertEquals("""UnmanagedRealmSet{1, 2}""", realmSetOf("1", "2").toString())
     }
 
     @Test


### PR DESCRIPTION
Adds equals, hashcode, and toString to unmanaged lists and sets. It would default to the MutableList and MutableSet behaviors.