### PR TITLE
Log HTTP request when level is set in `LogLevel.log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* [Sync] Http requests where not logged when log level was set in `RealmLog.level`. (Issue [#1456](https://github.com/realm/realm-kotlin/pull/1456)) 
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -324,15 +324,11 @@ public interface AppConfiguration {
 
             val appLogger = ContextLogger("Sdk")
             val networkTransport: (dispatcher: DispatcherHolder) -> NetworkTransport = { dispatcherHolder ->
-                val logger: Logger? = if (logLevel <= LogLevel.DEBUG) {
-                    object : Logger {
-                        override fun log(message: String) {
-                            val obfuscatedMessage = httpLogObfuscator?.obfuscate(message)
-                            appLogger.debug(obfuscatedMessage ?: message)
-                        }
+                val logger: Logger = object : Logger {
+                    override fun log(message: String) {
+                        val obfuscatedMessage = httpLogObfuscator?.obfuscate(message)
+                        appLogger.debug(obfuscatedMessage ?: message)
                     }
-                } else {
-                    null
                 }
                 networkTransport ?: KtorNetworkTransport(
                     // FIXME Add AppConfiguration.Builder option to set timeout as a Duration with default \

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/HttpClientCache.kt
@@ -30,7 +30,7 @@ internal fun createClient(timeoutMs: Long, customLogger: Logger?): HttpClient {
         customLogger?.let {
             install(Logging) {
                 logger = customLogger
-                level = LogLevel.BODY
+                level = LogLevel.ALL
             }
         }
 


### PR DESCRIPTION
Http requests where only logged when loglevel was set in `AppConfiguration`, this PR enables HTTP request logs when set via `LogLevel.log`