### PR TITLE
Fix `RealmLog` does not log sync events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Fixed
 * `RealmInstant` could be instantiated with invalid arguments. (Issue [#1443](https://github.com/realm/realm-kotlin/issues/1443))
 * `equals` and `hashCode` on unmanaged `RealmList` and `RealmSet` resulted in incorrect values. (Issue [#1454](https://github.com/realm/realm-kotlin/pull/1454))
-* [Sync] HTTP requests were not logged when the log level was set in `RealmLog.level`. (Issue [#1456](https://github.com/realm/realm-kotlin/pull/1456)) 
+* [Sync] HTTP requests were not logged when the log level was set in `RealmLog.level`. (Issue [#1456](https://github.com/realm/realm-kotlin/pull/1456))
+* [Sync] `RealmLog.level` was set to `WARN` after creating an `App` or instantiating a `Realm`
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * `RealmInstant` could be instantiated with invalid arguments. (Issue [#1443](https://github.com/realm/realm-kotlin/issues/1443))
 * `equals` and `hashCode` on unmanaged `RealmList` and `RealmSet` resulted in incorrect values. (Issue [#1454](https://github.com/realm/realm-kotlin/pull/1454))
 * [Sync] HTTP requests were not logged when the log level was set in `RealmLog.level`. (Issue [#1456](https://github.com/realm/realm-kotlin/pull/1456))
-* [Sync] `RealmLog.level` was set to `WARN` after creating an `App` or instantiating a `Realm`
+* [Sync] `RealmLog.level` is set to `WARN` after creating an `App` or `Realm` configuration. (Issue [#1456](https://github.com/realm/realm-kotlin/pull/1459))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
@@ -22,6 +22,7 @@ import io.realm.kotlin.internal.REALM_FILE_EXTENSION
 import io.realm.kotlin.internal.platform.PATH_SEPARATOR
 import io.realm.kotlin.internal.realmObjectCompanionOrNull
 import io.realm.kotlin.log.LogLevel
+import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.log.RealmLogger
 import io.realm.kotlin.types.BaseRealmObject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -225,7 +226,7 @@ public interface Configuration {
 
         // 'name' must be nullable as it is optional when getting SyncClient's default path!
         protected abstract var name: String?
-        protected var logLevel: LogLevel = LogLevel.WARN
+        protected var logLevel: LogLevel = RealmLog.level
         protected var appConfigLoggers: List<RealmLogger> = listOf()
         protected var realmConfigLoggers: List<RealmLogger> = listOf()
         protected var maxNumberOfActiveVersions: Long = Long.MAX_VALUE

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -125,7 +125,7 @@ public interface AppConfiguration {
         private var baseUrl: String = DEFAULT_BASE_URL
         private var dispatcher: CoroutineDispatcher? = null
         private var encryptionKey: ByteArray? = null
-        private var logLevel: LogLevel = LogLevel.WARN
+        private var logLevel: LogLevel = RealmLog.level
         private var syncRootDirectory: String = appFilesDirectory()
         private var userLoggers: List<RealmLogger> = listOf()
         private var networkTransport: NetworkTransport? = null

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/AppConfiguration.kt
@@ -125,7 +125,7 @@ public interface AppConfiguration {
         private var baseUrl: String = DEFAULT_BASE_URL
         private var dispatcher: CoroutineDispatcher? = null
         private var encryptionKey: ByteArray? = null
-        private var logLevel: LogLevel = RealmLog.level
+        private var logLevel: LogLevel? = null
         private var syncRootDirectory: String = appFilesDirectory()
         private var userLoggers: List<RealmLogger> = listOf()
         private var networkTransport: NetworkTransport? = null
@@ -309,8 +309,12 @@ public interface AppConfiguration {
             // configuring logging. This should be removed when `LogConfiguration` is removed.
             val allLoggers = mutableListOf<RealmLogger>()
             allLoggers.addAll(userLoggers)
-            val logConfig = LogConfiguration(this.logLevel, allLoggers)
-            RealmLog.level = logLevel
+
+            val logConfig = this.logLevel?.let {
+                RealmLog.level = it
+                LogConfiguration(it, allLoggers)
+            }
+
             userLoggers.forEach { RealmLog.add(it) }
 
             val appNetworkDispatcherFactory = if (dispatcher != null) {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppConfigurationImpl.kt
@@ -48,7 +48,7 @@ public class AppConfigurationImpl @OptIn(ExperimentalKBsonSerializerApi::class) 
     internal val networkTransportFactory: (dispatcher: DispatcherHolder) -> NetworkTransport,
     override val metadataMode: MetadataMode,
     override val syncRootDirectory: String,
-    public val logger: LogConfiguration,
+    public val logger: LogConfiguration?,
     override val appName: String?,
     override val appVersion: String?,
     internal val bundleId: String,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
@@ -375,9 +375,10 @@ public interface SyncConfiguration : Configuration {
                 throw IllegalArgumentException("A valid, logged in user is required.")
             }
             // Prime builder with log configuration from AppConfiguration
-            val appLog = (user as UserImpl).app.configuration.logger
-            this.logLevel = appLog.level
-            this.appConfigLoggers = appLog.loggers
+            (user as UserImpl).app.configuration.logger?.let { appLog ->
+                this.logLevel = appLog.level
+                this.appConfigLoggers = appLog.loggers
+            }
         }
 
         /**

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmConfigurationTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmConfigurationTests.kt
@@ -1,3 +1,4 @@
+@file:Suppress("invisible_member", "invisible_reference")
 /*
  * Copyright 2021 Realm Inc.
  *
@@ -480,18 +481,15 @@ class RealmConfigurationTests {
 
     @Test
     fun logLevelDoesNotGetOverwrittenByConfig() {
-        val originalLogLevel = RealmLog.level
-        try {
-            val expectedLogLevel = LogLevel.ALL
-            RealmLog.level = expectedLogLevel
+        val expectedLogLevel = LogLevel.ALL
+        RealmLog.level = expectedLogLevel
 
-            RealmConfiguration.Builder(setOf(Sample::class))
-                .build()
+        RealmConfiguration.Builder(setOf(Sample::class))
+            .build()
 
-            assertEquals(expectedLogLevel, RealmLog.level)
-        } finally {
-            RealmLog.level = originalLogLevel
-        }
+        assertEquals(expectedLogLevel, RealmLog.level)
+
+        RealmLog.reset()
     }
 
     private fun assertFailsWithEncryptionKey(builder: RealmConfiguration.Builder, keyLength: Int) {

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmConfigurationTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmConfigurationTests.kt
@@ -25,6 +25,7 @@ import io.realm.kotlin.internal.platform.appFilesDirectory
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
 import io.realm.kotlin.log.LogLevel
+import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.migration.AutomaticSchemaMigration
 import io.realm.kotlin.test.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
@@ -474,6 +475,22 @@ class RealmConfigurationTests {
             .inMemory()
         assertFailsWithMessage<IllegalStateException>("Cannot combine `initialRealmFile` and `inMemory` configuration options") {
             builder.build()
+        }
+    }
+
+    @Test
+    fun logLevelDoesNotGetOverwrittenByConfig() {
+        val originalLogLevel = RealmLog.level
+        try {
+            val expectedLogLevel = LogLevel.ALL
+            RealmLog.level = expectedLogLevel
+
+            RealmConfiguration.Builder(setOf(Sample::class))
+                .build()
+
+            assertEquals(expectedLogLevel, RealmLog.level)
+        } finally {
+            RealmLog.level = originalLogLevel
         }
     }
 

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
@@ -77,7 +77,7 @@ open class TestApp private constructor(
     constructor(
         appName: String = TEST_APP_PARTITION,
         dispatcher: CoroutineDispatcher = singleThreadDispatcher("test-app-dispatcher"),
-        logLevel: LogLevel = LogLevel.WARN,
+        logLevel: LogLevel? = null,
         builder: (AppConfiguration.Builder) -> AppConfiguration.Builder = { it },
         debug: Boolean = false,
         customLogger: RealmLogger? = null,
@@ -147,7 +147,7 @@ open class TestApp private constructor(
         fun build(
             debug: Boolean,
             appName: String,
-            logLevel: LogLevel,
+            logLevel: LogLevel?,
             customLogger: RealmLogger?,
             dispatcher: CoroutineDispatcher,
             builder: (AppConfiguration.Builder) -> AppConfiguration.Builder,
@@ -166,16 +166,21 @@ open class TestApp private constructor(
                     AppAdminImpl(this, baasApp)
                 }
             }
+
             @Suppress("invisible_member", "invisible_reference")
             var config = AppConfiguration.Builder(appAdmin.clientAppId)
                 .baseUrl(TEST_SERVER_BASE_URL)
                 .networkTransport(networkTransport)
                 .ejson(ejson)
-                .log(
-                    logLevel,
-                    if (customLogger == null) emptyList<RealmLogger>()
-                    else listOf<RealmLogger>(customLogger)
-                )
+                .apply {
+                    if (logLevel != null) {
+                        log(
+                            logLevel,
+                            if (customLogger == null) emptyList<RealmLogger>()
+                            else listOf<RealmLogger>(customLogger)
+                        )
+                    }
+                }
 
             val app = App.create(
                 builder(config)

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
@@ -77,7 +77,7 @@ open class TestApp private constructor(
     constructor(
         appName: String = TEST_APP_PARTITION,
         dispatcher: CoroutineDispatcher = singleThreadDispatcher("test-app-dispatcher"),
-        logLevel: LogLevel? = null,
+        logLevel: LogLevel? = LogLevel.WARN,
         builder: (AppConfiguration.Builder) -> AppConfiguration.Builder = { it },
         debug: Boolean = false,
         customLogger: RealmLogger? = null,

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
@@ -1,3 +1,4 @@
+@file:Suppress("invisible_member", "invisible_reference") // Needed to call session.simulateError()
 /*
  * Copyright 2021 Realm Inc.
  *
@@ -174,7 +175,7 @@ class AppConfigurationTests {
         }
     }
 
-//    @Test // TODO we need an IO framework to test this properly, see https://github.com/realm/realm-kotlin/issues/699
+    //    @Test // TODO we need an IO framework to test this properly, see https://github.com/realm/realm-kotlin/issues/699
 //    fun syncRootDirectory_dirIsAFile() {
 //        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
 //        val file = File(tempFolder.newFolder(), "dummyfile")
@@ -418,17 +419,14 @@ class AppConfigurationTests {
 
     @Test
     fun logLevelDoesNotGetOverwrittenByConfig() {
-        val originalLogLevel = RealmLog.level
-        try {
-            val expectedLogLevel = LogLevel.ALL
-            RealmLog.level = expectedLogLevel
+        val expectedLogLevel = LogLevel.ALL
+        RealmLog.level = expectedLogLevel
 
-            AppConfiguration.create("")
+        AppConfiguration.create("")
 
-            assertEquals(expectedLogLevel, RealmLog.level)
-        } finally {
-            RealmLog.level = originalLogLevel
-        }
+        assertEquals(expectedLogLevel, RealmLog.level)
+
+        RealmLog.reset()
     }
 
     @Test

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
@@ -19,6 +19,8 @@ package io.realm.kotlin.test.mongodb.common
 import io.realm.kotlin.internal.platform.PATH_SEPARATOR
 import io.realm.kotlin.internal.platform.appFilesDirectory
 import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.log.LogLevel
+import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.AppConfiguration
 import io.realm.kotlin.mongodb.internal.AppConfigurationImpl
@@ -413,6 +415,21 @@ class AppConfigurationTests {
 //        assertTrue(headerSet.get())
 //        looperThread.testComplete()
 //    }
+
+    @Test
+    fun logLevelDoesNotGetOverwrittenByConfig() {
+        val originalLogLevel = RealmLog.level
+        try {
+            val expectedLogLevel = LogLevel.ALL
+            RealmLog.level = expectedLogLevel
+
+            AppConfiguration.create("")
+
+            assertEquals(expectedLogLevel, RealmLog.level)
+        } finally {
+            RealmLog.level = originalLogLevel
+        }
+    }
 
     @Test
     fun injectedBundleId() {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
@@ -547,7 +547,7 @@ class SyncConfigTests {
         assertFailsWith<IllegalArgumentException> { builder.encryptionKey(byteArrayOf(1, 2, 3)) }
     }
 
-//    @Test
+    //    @Test
 //    fun initialData() {
 //        val user: User = createTestUser(app)
 //        val config = configFactory.createSyncConfigurationBuilder(user)
@@ -600,7 +600,7 @@ class SyncConfigTests {
         }
     }
 
-//
+    //
 //    // Check that it is possible for multiple users to reference the same Realm URL while each user still use their
 //    // own copy on the filesystem. This is e.g. what happens if a Realm is shared using a PermissionOffer.
 //    @Test
@@ -1228,26 +1228,26 @@ class SyncConfigTests {
 
     @Test
     fun logLevelDoesNotGetOverwrittenByConfig() {
-        val originalLogLevel = RealmLog.level
-        try {
-            val expectedLogLevel = LogLevel.ALL
-            RealmLog.level = expectedLogLevel
+        app.asTestApp.close()
+        // Prevent AppConfiguration to set a log level
+        app = TestApp(logLevel = null)
 
-            val (email, password) = randomEmail() to "password1234"
-            val user = runBlocking {
-                app.createUserAndLogIn(email, password)
-            }
+        val expectedLogLevel = LogLevel.ALL
 
-            SyncConfiguration.Builder(
-                schema = setOf(ParentPk::class, ChildPk::class),
-                user = user,
-                partitionValue = partitionValue
-            ).build()
+        RealmLog.level = expectedLogLevel
 
-            assertEquals(expectedLogLevel, RealmLog.level)
-        } finally {
-            RealmLog.level = originalLogLevel
+        val (email, password) = randomEmail() to "password1234"
+        val user = runBlocking {
+            app.createUserAndLogIn(email, password)
         }
+
+        SyncConfiguration.Builder(
+            schema = setOf(ParentPk::class, ChildPk::class),
+            user = user,
+            partitionValue = partitionValue
+        ).build()
+
+        assertEquals(expectedLogLevel, RealmLog.level)
     }
 
     private fun createTestUser(): User = runBlocking {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
@@ -1226,6 +1226,30 @@ class SyncConfigTests {
         assertTrue(config.syncClientResetStrategy is RecoverOrDiscardUnsyncedChangesStrategy)
     }
 
+    @Test
+    fun logLevelDoesNotGetOverwrittenByConfig() {
+        val originalLogLevel = RealmLog.level
+        try {
+            val expectedLogLevel = LogLevel.ALL
+            RealmLog.level = expectedLogLevel
+
+            val (email, password) = randomEmail() to "password1234"
+            val user = runBlocking {
+                app.createUserAndLogIn(email, password)
+            }
+
+            SyncConfiguration.Builder(
+                schema = setOf(ParentPk::class, ChildPk::class),
+                user = user,
+                partitionValue = partitionValue
+            ).build()
+
+            assertEquals(expectedLogLevel, RealmLog.level)
+        } finally {
+            RealmLog.level = originalLogLevel
+        }
+    }
+
     private fun createTestUser(): User = runBlocking {
         val (email, password) = randomEmail() to "password1234"
         app.createUserAndLogIn(email, password)


### PR DESCRIPTION
Sync events are not logged when `RealmLog.level` is set. Any level previously defined is ignored, except if it is defined via the deprecated `AppConfiguration.Builder.log`.

The reason the level is ignored is because whenever an App or Realm configuration is set the log level is set to a default level of `WARN`.

This PR fixes the issue by setting the default level to the `RealmLog.level`, this way, if the user does not define any level via the deprecated method, we will set the level to whatever was already defined.