### PR TITLE
Add script to fix H1s on Dokka-generated docs

### DIFF
--- a/tools/fix-h1s.sh
+++ b/tools/fix-h1s.sh
@@ -1,7 +1,18 @@
 #!/bin/bash -ex
 
+usage() {
+cat <<EOF
+Usage: $0 <root-dokka-dir>
+EOF
+}
+
+if [ "$#" -ne 1 ] ; then
+  usage
+  exit 1
+fi
+
 # Assume Dokka has been run
-pushd "`dirname "$0"`"/../docs/html
+pushd $1
 
 # Make the output SEO friendly by converting the "h2" title to the proper "h1".
 # For Dokka, this is only an issue on the index page (apparently).

--- a/tools/fix-h1s.sh
+++ b/tools/fix-h1s.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+
+# Assume Dokka has been run
+pushd "`dirname "$0"`"/../docs/html
+
+# Make the output SEO friendly by converting the "h2" title to the proper "h1".
+# For Dokka, this is only an issue on the index page (apparently).
+sed -i -e 's|<h2\(.*\)</h2>|<h1\1</h1>|' index.html
+find . -iname "*.html-e" | xargs rm
+
+popd

--- a/tools/publish_release.sh
+++ b/tools/publish_release.sh
@@ -108,6 +108,7 @@ create_javadoc() {
   echo "Creating JavaDoc/KDoc..."
   cd $REALM_KOTLIN_PATH/packages
   ./gradlew dokkaHtmlMultiModule --info --stacktrace --no-daemon
+  ../tools/fix-h1s.sh
   cd $HERE
 }
 

--- a/tools/publish_release.sh
+++ b/tools/publish_release.sh
@@ -108,7 +108,7 @@ create_javadoc() {
   echo "Creating JavaDoc/KDoc..."
   cd $REALM_KOTLIN_PATH/packages
   ./gradlew dokkaHtmlMultiModule --info --stacktrace --no-daemon
-  ../tools/fix-h1s.sh
+  ../tools/fix-h1s.sh build/dokka/htmlMultiModule
   cd $HERE
 }
 


### PR DESCRIPTION
This is an SEO team request to make sure all pages have an H1.

For more info see https://jira.mongodb.org/browse/DOCSP-31274

This has not been fully tested due to my lack of environment that can successfully build the Dokka files. Please validate.