### PR TITLE
Add automatic resolution of embedded object constraints during migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements
 * Support for performing geospatial queries using the new classes: `GeoPoint`, `GeoCircle`, `GeoBox`, and `GeoPolygon`. See `GeoPoint` documentation on how to persist locations. (Issue [#1403](https://github.com/realm/realm-kotlin/pull/1403))
+* Support for automatic resolution of embedded object constraints during migration through `RealmConfiguration.Builder.migration(migration: AutomaticSchemaMigration, resolveEmbeddedObjectConstraints: Boolean)`. (Issue [#1464](https://github.com/realm/realm-kotlin/issues/1464)
 
 ### Fixed
 * None.

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -186,6 +186,7 @@ expect object RealmInterop {
     fun realm_config_get_encryption_key(config: RealmConfigurationPointer): ByteArray?
     fun realm_config_set_should_compact_on_launch_function(config: RealmConfigurationPointer, callback: CompactOnLaunchCallback)
     fun realm_config_set_migration_function(config: RealmConfigurationPointer, callback: MigrationCallback)
+    fun realm_config_set_automatic_backlink_handling(config: RealmConfigurationPointer, enabled: Boolean)
     fun realm_config_set_data_initialization_function(config: RealmConfigurationPointer, callback: DataInitializationCallback)
     fun realm_config_set_in_memory(config: RealmConfigurationPointer, inMemory: Boolean)
     fun realm_schema_validate(schema: RealmSchemaPointer, mode: SchemaValidationMode): Boolean

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -172,6 +172,10 @@ actual object RealmInterop {
         realmc.realm_config_set_migration_function(config.cptr(), callback)
     }
 
+    actual fun realm_config_set_automatic_backlink_handling(config: RealmConfigurationPointer, enabled: Boolean) {
+        realmc.realm_config_set_automatic_backlink_handling(config.cptr(), enabled)
+    }
+
     actual fun realm_config_set_data_initialization_function(config: RealmConfigurationPointer, callback: DataInitializationCallback) {
         realmc.realm_config_set_data_initialization_function(config.cptr(), callback)
     }

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -433,6 +433,15 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_config_set_automatic_backlink_handling(
+        config: RealmConfigurationPointer,
+        enabled: Boolean
+    ) {
+        realm_wrapper.realm_config_set_automatic_backlink_handling(
+            config.cptr(),
+            enabled,
+        )
+    }
     actual fun realm_config_set_migration_function(
         config: RealmConfigurationPointer,
         callback: MigrationCallback

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
@@ -125,7 +125,10 @@ public interface RealmConfiguration : Configuration {
          * @see RealmMigration
          * @see AutomaticSchemaMigration
          */
-        public fun migration( migration: AutomaticSchemaMigration, resolveEmbeddedObjectConstraints: Boolean = false ): Builder =
+        public fun migration(
+            migration: AutomaticSchemaMigration,
+            resolveEmbeddedObjectConstraints: Boolean = false
+        ): Builder =
             apply {
                 this.migration = migration
                 this.automaticEmbeddedObjectConstraintsResolution = resolveEmbeddedObjectConstraints

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
@@ -55,6 +55,7 @@ public interface RealmConfiguration : Configuration {
         private var directory: String = appFilesDirectory()
         private var deleteRealmIfMigrationNeeded: Boolean = false
         private var migration: RealmMigration? = null
+        private var automaticBacklinkHandling = false
 
         /**
          * Sets the path to the directory that contains the realm file. If the directory does not
@@ -108,6 +109,52 @@ public interface RealmConfiguration : Configuration {
          */
         public fun migration(migration: RealmMigration): Builder =
             apply { this.migration = migration }
+
+        // FIXME Rephrase docs from Realm Java
+        // FIXME Should this rather be an option on AutomaticSchemaMigration :thinking:
+        /**
+         * Converts the class to be embedded or not, while also providing automatic handling of objects
+         * that break some of the constraints for making the class embedded.
+         * <p>
+         * A class can only be marked as embedded if the following invariants are satisfied:
+         * <ul>
+         *     <li>
+         *         The class is not allowed to have a primary key defined.
+         *     </li>
+         *     <li>
+         *         All existing objects of this type, must have one and exactly one parent object
+         *         already pointing to it. If 0 or more than 1 object has a reference to an object
+         *         about to be marked embedded an {@link IllegalStateException} will be thrown.
+         *     </li>
+         * </ul>
+         * If some of these constraints are broken you can ask Realm to resolve them automatically using
+         * the @{code resolveEmbeddedClassConstraints} parameter. Setting this to @{code true} will
+         * do the following:
+         * <ul>
+         *     <li>
+         *         An object with 0 parents, i.e. no other objects have a reference to it, will be
+         *         deleted.
+         *     </li>
+         *     <li>
+         *         An object with more than 1 parent, i.e. 2 or more objects have a reference to it,
+         *         will be copied so each copy have exactly one parent.
+         *     </li>
+         *     <li>
+         *         Objects with a primary key defined will still throw an IllegalStateException and
+         *         cannot be converted.
+         *     </li>
+         * </ul>
+         * @param embedded If @{code true}, the class type will be turned into an embedded class, and
+         * must satisfy the constraints defined above. If @{code false}, the class will be turn into
+         * a normal class. An embeded class can always be turned into a non-embedded one.
+         * @param resolveEmbeddedClassConstraints whether or not to automatically fix broken constraints
+         * if @{code embedded} was set to true. See above for a full description of what that entails.
+         * @throws IllegalStateException if the class could not be converted because it broke some of
+         * the Embedded Objects invariants and these could not be resolved automatically.
+         * @see RealmClass#embedded()
+         */
+        public fun resolveEmbeddedObjectConstraintsOnMigration(enabled: Boolean): Builder =
+            apply { this.automaticBacklinkHandling = enabled }
 
         override fun name(name: String): Builder = apply {
             checkName(name)
@@ -163,6 +210,7 @@ public interface RealmConfiguration : Configuration {
                 deleteRealmIfMigrationNeeded,
                 compactOnLaunchCallback,
                 migration,
+                automaticBacklinkHandling,
                 initialDataCallback,
                 inMemory,
                 initialRealmFileConfiguration,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -47,7 +47,7 @@ import kotlin.reflect.KClass
 
 // TODO Public due to being accessed from `library-sync`
 @Suppress("LongParameterList")
-public open class ConfigurationImpl constructor(
+public open class ConfigurationImpl(
     directory: String,
     name: String,
     schema: Set<KClass<out BaseRealmObject>>,
@@ -60,6 +60,7 @@ public open class ConfigurationImpl constructor(
     private val userEncryptionKey: ByteArray?,
     compactOnLaunchCallback: CompactOnLaunchCallback?,
     private val userMigration: RealmMigration?,
+    automaticBacklinkHandling: Boolean,
     initialDataCallback: InitialDataCallback?,
     override val isFlexibleSyncConfiguration: Boolean,
     inMemory: Boolean,
@@ -218,6 +219,7 @@ public open class ConfigurationImpl constructor(
             migrationCallback?.let {
                 RealmInterop.realm_config_set_migration_function(nativeConfig, it)
             }
+            RealmInterop.realm_config_set_automatic_backlink_handling(nativeConfig, automaticBacklinkHandling)
 
             userEncryptionKey?.let { key: ByteArray ->
                 RealmInterop.realm_config_set_encryption_key(nativeConfig, key)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.KClass
 public const val REALM_FILE_EXTENSION: String = ".realm"
 
 @Suppress("LongParameterList")
-internal class RealmConfigurationImpl constructor(
+internal class RealmConfigurationImpl(
     directory: String,
     name: String,
     schema: Set<KClass<out BaseRealmObject>>,
@@ -43,6 +43,7 @@ internal class RealmConfigurationImpl constructor(
     override val deleteRealmIfMigrationNeeded: Boolean,
     compactOnLaunchCallback: CompactOnLaunchCallback?,
     migration: RealmMigration?,
+    automaticBacklinkHandling: Boolean,
     initialDataCallback: InitialDataCallback?,
     inMemory: Boolean,
     override val initialRealmFileConfiguration: InitialRealmFileConfiguration?,
@@ -63,6 +64,7 @@ internal class RealmConfigurationImpl constructor(
     encryptionKey,
     compactOnLaunchCallback,
     migration,
+    automaticBacklinkHandling,
     initialDataCallback,
     false,
     inMemory,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
@@ -568,6 +568,7 @@ public interface SyncConfiguration : Configuration {
                 encryptionKey,
                 compactOnLaunchCallback,
                 null, // migration is not relevant for sync,
+                automaticBacklinkHandling,
                 initialDataCallback,
                 partitionValue == null,
                 inMemory,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
@@ -568,7 +568,7 @@ public interface SyncConfiguration : Configuration {
                 encryptionKey,
                 compactOnLaunchCallback,
                 null, // migration is not relevant for sync,
-                automaticBacklinkHandling,
+                false, // automatic backlink handling is not relevant for sync
                 initialDataCallback,
                 partitionValue == null,
                 inMemory,

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/migration/embedded/after/EmbeddedMigrationChild.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/migration/embedded/after/EmbeddedMigrationChild.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.entities.migration.embedded.after
+
+import io.realm.kotlin.types.EmbeddedRealmObject
+
+class EmbeddedMigrationChild : EmbeddedRealmObject {
+    var id: String = "child"
+}

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/migration/embedded/after/EmbeddedMigrationParent.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/migration/embedded/after/EmbeddedMigrationParent.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.entities.migration.embedded.after
+
+import io.realm.kotlin.types.RealmObject
+
+class EmbeddedMigrationParent : RealmObject {
+    var id: String = "parent"
+    var child: EmbeddedMigrationChild? = null
+}

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/migration/embedded/before/EmbeddedMigrationChild.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/migration/embedded/before/EmbeddedMigrationChild.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.entities.migration.embedded.before
+
+import io.realm.kotlin.types.RealmObject
+
+class EmbeddedMigrationChild : RealmObject {
+    var id: String = "child"
+}

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/migration/embedded/before/EmbeddedMigrationParent.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/migration/embedded/before/EmbeddedMigrationParent.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.entities.migration.embedded.before
+
+import io.realm.kotlin.types.RealmObject
+
+class EmbeddedMigrationParent : RealmObject {
+    var id: String = "parent"
+    var child: EmbeddedMigrationChild? = null
+}

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/MigrationTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/MigrationTests.kt
@@ -21,9 +21,15 @@ import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.entities.Sample
 import io.realm.kotlin.entities.link.Child
 import io.realm.kotlin.entities.link.Parent
+import io.realm.kotlin.entities.migration.embedded.before.EmbeddedMigrationChild
+import io.realm.kotlin.entities.migration.embedded.before.EmbeddedMigrationParent
 import io.realm.kotlin.ext.query
+import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.migration.AutomaticSchemaMigration
 import io.realm.kotlin.query.find
+import io.realm.kotlin.test.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.use
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -176,6 +182,134 @@ class MigrationTests {
                     close()
                 }
             }
+    }
+
+    @Test
+    fun migrationThrowsOnViolatingEmbeddedObjectConstraints() = runBlocking<Unit> {
+        val initialConfiguration = RealmConfiguration.Builder(
+            schema = setOf(
+                io.realm.kotlin.entities.migration.embedded.before.EmbeddedMigrationParent::class,
+                io.realm.kotlin.entities.migration.embedded.before.EmbeddedMigrationChild::class
+            )
+        )
+            .directory(tmpDir)
+            .build()
+
+        Realm.open(initialConfiguration).use {
+            it.write {
+                copyToRealm(EmbeddedMigrationChild().apply { id = "orphaned-child" })
+            }
+        }
+
+        val migratedConfiguration = RealmConfiguration.Builder(
+            schema = setOf(
+                io.realm.kotlin.entities.migration.embedded.after.EmbeddedMigrationParent::class,
+                io.realm.kotlin.entities.migration.embedded.after.EmbeddedMigrationChild::class,
+            )
+        )
+            .directory(tmpDir)
+            .schemaVersion(1)
+            .migration(AutomaticSchemaMigration { })
+            .build()
+
+        assertFailsWithMessage<IllegalStateException>("Cannot convert 'EmbeddedMigrationChild' to embedded: at least one object has no incoming links and would be deleted.") {
+            Realm.open(migratedConfiguration).use { }
+        }
+    }
+
+    @Test
+    fun automaticBacklinkHandling_deleteOrphanedChildren() = runBlocking {
+        val initialConfiguration = RealmConfiguration.Builder(
+            schema = setOf(
+                io.realm.kotlin.entities.migration.embedded.before.EmbeddedMigrationParent::class,
+                io.realm.kotlin.entities.migration.embedded.before.EmbeddedMigrationChild::class
+            )
+        )
+            .directory(tmpDir)
+            .build()
+
+        Realm.open(initialConfiguration).use {
+            it.write {
+                copyToRealm(
+                    EmbeddedMigrationParent().apply {
+                        child = EmbeddedMigrationChild().apply { id = "child-with-parent" }
+                    }
+                )
+                copyToRealm(EmbeddedMigrationChild().apply { id = "orphaned-child" })
+            }
+        }
+
+        val migratedConfiguration = RealmConfiguration.Builder(
+            schema = setOf(
+                io.realm.kotlin.entities.migration.embedded.after.EmbeddedMigrationParent::class,
+                io.realm.kotlin.entities.migration.embedded.after.EmbeddedMigrationChild::class,
+            )
+        )
+            .directory(tmpDir)
+            .schemaVersion(1)
+            .resolveEmbeddedObjectConstraintsOnMigration(true)
+            .migration(AutomaticSchemaMigration { })
+            .build()
+
+        Realm.open(migratedConfiguration).use {
+            val childWithParent =
+                it.query<io.realm.kotlin.entities.migration.embedded.after.EmbeddedMigrationChild>()
+                    .find().single()
+            assertEquals("child-with-parent", childWithParent.id)
+        }
+    }
+
+    @Test
+    fun automaticBacklinkHandling_cloneDuplicateReferences() = runBlocking {
+        val initialConfiguration = RealmConfiguration.Builder(
+            schema = setOf(
+                io.realm.kotlin.entities.migration.embedded.before.EmbeddedMigrationParent::class,
+                io.realm.kotlin.entities.migration.embedded.before.EmbeddedMigrationChild::class
+            )
+        )
+            .directory(tmpDir)
+            .build()
+
+        Realm.open(
+            initialConfiguration
+        ).use {
+            it.write {
+                // Add two parents referencing the same child
+                val child = copyToRealm(EmbeddedMigrationChild().apply { id = "child-with-parent" })
+                copyToRealm(
+                    EmbeddedMigrationParent().apply {
+                        id = "mom1"
+                        this.child = child
+                    }
+                )
+                copyToRealm(
+                    EmbeddedMigrationParent().apply {
+                        id = "mom2"
+                        this.child = child
+                    }
+                )
+            }
+        }
+
+        val migratedConfiguration = RealmConfiguration.Builder(
+            schema = setOf(
+                io.realm.kotlin.entities.migration.embedded.after.EmbeddedMigrationParent::class,
+                io.realm.kotlin.entities.migration.embedded.after.EmbeddedMigrationChild::class,
+            )
+        )
+            .directory(tmpDir)
+            .schemaVersion(1)
+            .resolveEmbeddedObjectConstraintsOnMigration(true)
+            .migration(AutomaticSchemaMigration { })
+            .build()
+
+        Realm.open(migratedConfiguration).use {
+            assertEquals(
+                2,
+                it.query<io.realm.kotlin.entities.migration.embedded.after.EmbeddedMigrationChild>()
+                    .find().count()
+            )
+        }
     }
 
     // TODO add test for adding/remove columns when we have an API to open with an existing Realm.

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/MigrationTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/MigrationTests.kt
@@ -247,8 +247,7 @@ class MigrationTests {
         )
             .directory(tmpDir)
             .schemaVersion(1)
-            .resolveEmbeddedObjectConstraintsOnMigration(true)
-            .migration(AutomaticSchemaMigration { })
+            .migration(AutomaticSchemaMigration { }, resolveEmbeddedObjectConstraints = true)
             .build()
 
         Realm.open(migratedConfiguration).use {
@@ -299,8 +298,7 @@ class MigrationTests {
         )
             .directory(tmpDir)
             .schemaVersion(1)
-            .resolveEmbeddedObjectConstraintsOnMigration(true)
-            .migration(AutomaticSchemaMigration { })
+            .migration(AutomaticSchemaMigration { }, resolveEmbeddedObjectConstraints = true)
             .build()
 
         Realm.open(migratedConfiguration).use {


### PR DESCRIPTION
This adds configuration option to enable automatic handling of embedded object constraints during automatic migration through:

```
class RealmConfiguration {

    class Builder {
        /**
         * Sets the migration to handle schema updates with automatic migration of data.
         *
         * @param migration the [AutomaticSchemaMigration] instance to handle schema and data
         * migration in the event of a schema update.
         * @param resolveEmbeddedObjectConstraints a flag to indicate whether realm should resolve
         * embedded object constraints after migration. If this is `true` then all embedded objects
         * without a parent will be deleted and every embedded object with multiple references to it
         * will be duplicated so that every referencing object will hold its own copy of the
         * embedded object.
         *
         * @see RealmMigration
         * @see AutomaticSchemaMigration
         */
        public fun migration(
            migration: AutomaticSchemaMigration,
            resolveEmbeddedObjectConstraints: Boolean = false
        ): Builder =
            apply {
                this.migration = migration
                this.automaticEmbeddedObjectConstraintsResolution = resolveEmbeddedObjectConstraints
            }
    }
}
```

The above API was chosen in favor of adding additional properties/methods to the `AutomaticSchemaMigration` interface, as this would require users to instantiate it as anynomous instances and that seems very tedious compared to the standalone functional interface. Alternative it could also have been wrapped in a completely new type, but that just bloats the name space.  

Closes #1464 