### PR TITLE
Remove all deprecated APIs from the compiler plugin.

### DIFF
--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -103,7 +103,6 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
-import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -544,7 +543,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
                             if (!(isValidTargetType || isValidGenericType)) {
                                 val targetPropertyName = getLinkingObjectPropertyName(declaration.backingField!!)
                                 logError(
-                                    "Error in backlinks field '${declaration.name}' - target property '$targetPropertyName' does not reference '${sourceType.toIrBasedKotlinType().getKotlinTypeFqName(true)}'.",
+                                    "Error in backlinks field '${declaration.name}' - target property '$targetPropertyName' does not reference '${sourceType.toIrBasedKotlinType().getKotlinTypeFqNameCompat(true)}'.",
                                     declaration.locationOf()
                                 )
                             }
@@ -1102,7 +1101,7 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
         val genericPropertyType: PropertyType? = getPropertyTypeFromKotlinType(collectionGenericType)
         return if (genericPropertyType == null) {
             logError(
-                "Unsupported type for ${collectionType.description}: '${collectionGenericType.getKotlinTypeFqName(true)
+                "Unsupported type for ${collectionType.description}: '${collectionGenericType.getKotlinTypeFqNameCompat(true)
                 }'",
                 declaration.locationOf()
             )

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/AccessorModifierIrGeneration.kt
@@ -13,28 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(FirIncompatiblePluginAPI::class)
 
 package io.realm.kotlin.compiler
 
-import io.realm.kotlin.compiler.FqNames.ASYMMETRIC_OBJECT_INTERFACE
-import io.realm.kotlin.compiler.FqNames.EMBEDDED_OBJECT_INTERFACE
-import io.realm.kotlin.compiler.FqNames.IGNORE_ANNOTATION
-import io.realm.kotlin.compiler.FqNames.KBSON_DECIMAL128
-import io.realm.kotlin.compiler.FqNames.KBSON_OBJECT_ID
-import io.realm.kotlin.compiler.FqNames.REALM_ANY
-import io.realm.kotlin.compiler.FqNames.REALM_BACKLINKS
-import io.realm.kotlin.compiler.FqNames.REALM_DICTIONARY
-import io.realm.kotlin.compiler.FqNames.REALM_EMBEDDED_BACKLINKS
-import io.realm.kotlin.compiler.FqNames.REALM_INSTANT
-import io.realm.kotlin.compiler.FqNames.REALM_LIST
-import io.realm.kotlin.compiler.FqNames.REALM_MUTABLE_INTEGER
-import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_HELPER
-import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_ID
-import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_INTERFACE
-import io.realm.kotlin.compiler.FqNames.REALM_SET
-import io.realm.kotlin.compiler.FqNames.REALM_UUID
-import io.realm.kotlin.compiler.FqNames.TRANSIENT_ANNOTATION
+import io.realm.kotlin.compiler.ClassIds.ASYMMETRIC_OBJECT_INTERFACE
+import io.realm.kotlin.compiler.ClassIds.EMBEDDED_OBJECT_INTERFACE
+import io.realm.kotlin.compiler.ClassIds.IGNORE_ANNOTATION
+import io.realm.kotlin.compiler.ClassIds.KBSON_DECIMAL128
+import io.realm.kotlin.compiler.ClassIds.KBSON_OBJECT_ID
+import io.realm.kotlin.compiler.ClassIds.REALM_ANY
+import io.realm.kotlin.compiler.ClassIds.REALM_BACKLINKS
+import io.realm.kotlin.compiler.ClassIds.REALM_DICTIONARY
+import io.realm.kotlin.compiler.ClassIds.REALM_EMBEDDED_BACKLINKS
+import io.realm.kotlin.compiler.ClassIds.REALM_INSTANT
+import io.realm.kotlin.compiler.ClassIds.REALM_LIST
+import io.realm.kotlin.compiler.ClassIds.REALM_MUTABLE_INTEGER
+import io.realm.kotlin.compiler.ClassIds.REALM_OBJECT_HELPER
+import io.realm.kotlin.compiler.ClassIds.REALM_OBJECT_ID
+import io.realm.kotlin.compiler.ClassIds.REALM_OBJECT_INTERFACE
+import io.realm.kotlin.compiler.ClassIds.REALM_SET
+import io.realm.kotlin.compiler.ClassIds.REALM_UUID
+import io.realm.kotlin.compiler.ClassIds.TRANSIENT_ANNOTATION
 import io.realm.kotlin.compiler.Names.OBJECT_REFERENCE
 import io.realm.kotlin.compiler.Names.REALM_ACCESSOR_HELPER_GET_BOOLEAN
 import io.realm.kotlin.compiler.Names.REALM_ACCESSOR_HELPER_GET_BYTE_ARRAY
@@ -59,7 +58,6 @@ import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_SET_LIST
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_SET_OBJECT
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_HELPER_SET_SET
 import io.realm.kotlin.compiler.Names.REALM_SYNTHETIC_PROPERTY_PREFIX
-import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
@@ -102,13 +100,14 @@ import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.types.makeNotNull
 import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName
+import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.descriptorUtil.classId
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.StarProjectionImpl
@@ -191,25 +190,25 @@ class AccessorModifierIrGeneration(private val pluginContext: IrPluginContext) {
 
     // Top level SDK->Core converters
     private val byteToLong: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.byteToLong")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("byteToLong"))).first().owner
     private val charToLong: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.charToLong")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("charToLong"))).first().owner
     private val shortToLong: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.shortToLong")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("shortToLong"))).first().owner
     private val intToLong: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.intToLong")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("intToLong"))).first().owner
 
     // Top level Core->SDK converters
     private val longToByte: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.longToByte")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("longToByte"))).first().owner
     private val longToChar: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.longToChar")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("longToChar"))).first().owner
     private val longToShort: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.longToShort")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("longToShort"))).first().owner
     private val longToInt: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.longToInt")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("longToInt"))).first().owner
     private val objectIdToRealmObjectId: IrSimpleFunction =
-        pluginContext.referenceFunctions(FqName("io.realm.kotlin.internal.objectIdToRealmObjectId")).first().owner
+        pluginContext.referenceFunctions(CallableId(FqName("io.realm.kotlin.internal"), Name.identifier("objectIdToRealmObjectId"))).first().owner
 
     private lateinit var objectReferenceProperty: IrProperty
     private lateinit var objectReferenceType: IrType

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
@@ -16,9 +16,9 @@
 
 package io.realm.kotlin.compiler
 
-import io.realm.kotlin.compiler.FqNames.CLASS_APP_CONFIGURATION
 import io.realm.kotlin.compiler.FqNames.PACKAGE_MONGODB
 import io.realm.kotlin.compiler.FqNames.PACKAGE_MONGODB_INTERNAL
+import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -86,69 +86,78 @@ internal object Names {
 }
 
 internal object FqNames {
-    // TODO we can replace with RealmObject::class.java.canonicalName if we make the runtime_api available as a compile time only dependency for the compiler-plugin
-    val REALM_NATIVE_POINTER = FqName("io.realm.kotlin.internal.interop.NativePointer")
-    val REALM_OBJECT_INTERNAL_INTERFACE = FqName("io.realm.kotlin.internal.RealmObjectInternal")
-
-    val REALM_MODEL_COMPANION = FqName("io.realm.kotlin.internal.RealmObjectCompanion")
-    val REALM_OBJECT_HELPER = FqName("io.realm.kotlin.internal.RealmObjectHelper")
-    val REALM_CLASS_IMPL = FqName("io.realm.kotlin.internal.schema.RealmClassImpl")
-    val OBJECT_REFERENCE_CLASS = FqName("io.realm.kotlin.internal.RealmObjectReference")
-
-    val BASE_REALM_OBJECT_INTERFACE = ClassId(FqName("io.realm.kotlin.types"), FqName("BaseRealmObject"), false)
-    val REALM_OBJECT_INTERFACE = ClassId(FqName("io.realm.kotlin.types"), FqName("RealmObject"), false)
-    val TYPED_REALM_OBJECT_INTERFACE = FqName("io.realm.kotlin.types.TypedRealmObject")
-    val EMBEDDED_OBJECT_INTERFACE = ClassId(FqName("io.realm.kotlin.types"), FqName("EmbeddedRealmObject"), false)
-    val ASYMMETRIC_OBJECT_INTERFACE = ClassId(FqName("io.realm.kotlin.types"), FqName("AsymmetricRealmObject"), false)
-
-    // External visible interface of Realm objects
-    val KOTLIN_COLLECTIONS_SET = FqName("kotlin.collections.Set")
-    val KOTLIN_COLLECTIONS_LIST = FqName("kotlin.collections.List")
-    val KOTLIN_COLLECTIONS_LISTOF = FqName("kotlin.collections.listOf")
-    val KOTLIN_COLLECTIONS_MAP = FqName("kotlin.collections.Map")
-    val KOTLIN_COLLECTIONS_MAPOF = FqName("kotlin.collections.mapOf")
-    val KOTLIN_REFLECT_KMUTABLEPROPERTY1 = FqName("kotlin.reflect.KMutableProperty1")
-    val KOTLIN_REFLECT_KPROPERTY1 = FqName("kotlin.reflect.KProperty1")
-    val KOTLIN_PAIR = FqName("kotlin.Pair")
-
-    // Schema related types
-    val CLASS_INFO = FqName("io.realm.kotlin.internal.interop.ClassInfo")
-    val PROPERTY_INFO = FqName("io.realm.kotlin.internal.interop.PropertyInfo")
-    val PROPERTY_TYPE = FqName("io.realm.kotlin.internal.interop.PropertyType")
-    val COLLECTION_TYPE = FqName("io.realm.kotlin.internal.interop.CollectionType")
-    val PRIMARY_KEY_ANNOTATION = FqName("io.realm.kotlin.types.annotations.PrimaryKey")
-    val INDEX_ANNOTATION = FqName("io.realm.kotlin.types.annotations.Index")
-    val FULLTEXT_ANNOTATION = FqName("io.realm.kotlin.types.annotations.FullText")
-    val IGNORE_ANNOTATION = FqName("io.realm.kotlin.types.annotations.Ignore")
-    val PERSISTED_NAME_ANNOTATION = FqName("io.realm.kotlin.types.annotations.PersistedName")
-    val TRANSIENT_ANNOTATION = FqName("kotlin.jvm.Transient")
-    val MODEL_OBJECT_ANNOTATION = FqName("io.realm.kotlin.internal.platform.ModelObject")
-    val PROPERTY_INFO_CREATE = FqName("io.realm.kotlin.internal.schema.createPropertyInfo")
-    val CLASS_KIND_TYPE = FqName("io.realm.kotlin.schema.RealmClassKind")
-
-    // Realm data types
-    val REALM_LIST = FqName("io.realm.kotlin.types.RealmList")
-    val REALM_SET = FqName("io.realm.kotlin.types.RealmSet")
-    val REALM_DICTIONARY = FqName("io.realm.kotlin.types.RealmDictionary")
-    val REALM_INSTANT = FqName("io.realm.kotlin.types.RealmInstant")
-    val REALM_BACKLINKS = FqName("io.realm.kotlin.types.BacklinksDelegate")
-    val REALM_EMBEDDED_BACKLINKS = FqName("io.realm.kotlin.types.EmbeddedBacklinksDelegate")
-    val REALM_OBJECT_ID = FqName("io.realm.kotlin.types.ObjectId")
-    val KBSON_OBJECT_ID = FqName("org.mongodb.kbson.BsonObjectId")
-    val KBSON_DECIMAL128 = FqName("org.mongodb.kbson.BsonDecimal128")
-    val REALM_UUID = FqName("io.realm.kotlin.types.RealmUUID")
-    val REALM_MUTABLE_INTEGER = FqName("io.realm.kotlin.types.MutableRealmInt")
-    val REALM_ANY = FqName("io.realm.kotlin.types.RealmAny")
-
+    val PACKAGE_ANNOTATIONS = FqName("io.realm.kotlin.types.annotations")
+    val PACKAGE_KOTLIN_COLLECTIONS = FqName("kotlin.collections")
+    val PACKAGE_KOTLIN_REFLECT = FqName("kotlin.reflect")
+    val PACKAGE_TYPES = FqName("io.realm.kotlin.types")
+    val PACKAGE_REALM_INTEROP = FqName("io.realm.kotlin.internal.interop")
+    val PACKAGE_REALM_INTERNAL = FqName("io.realm.kotlin.internal")
     val PACKAGE_MONGODB = FqName("io.realm.kotlin.mongodb")
     val PACKAGE_MONGODB_INTERNAL = FqName("io.realm.kotlin.mongodb.internal")
-    val CLASS_APP_CONFIGURATION = FqName("io.realm.kotlin.mongodb.AppConfiguration")
 }
 
 object ClassIds {
+
+    // TODO we can replace with RealmObject::class.java.canonicalName if we make the runtime_api available as a compile time only dependency for the compiler-plugin
+    val REALM_NATIVE_POINTER = FqName("io.realm.kotlin.internal.interop.NativePointer")
+    val REALM_OBJECT_INTERNAL_INTERFACE = ClassId(FqName("io.realm.kotlin.internal"), Name.identifier("RealmObjectInternal"))
+
+    val REALM_MODEL_COMPANION = ClassId(FqNames.PACKAGE_REALM_INTERNAL, Name.identifier("RealmObjectCompanion"))
+    val REALM_OBJECT_HELPER = ClassId(FqNames.PACKAGE_REALM_INTERNAL, Name.identifier("RealmObjectHelper"))
+    val REALM_CLASS_IMPL = ClassId(FqName("io.realm.kotlin.internal.schema"), Name.identifier("RealmClassImpl"))
+    val OBJECT_REFERENCE_CLASS = ClassId(FqNames.PACKAGE_REALM_INTERNAL, Name.identifier("RealmObjectReference"))
+
+    val BASE_REALM_OBJECT_INTERFACE = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("BaseRealmObject"))
+    val REALM_OBJECT_INTERFACE = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmObject"))
+    val TYPED_REALM_OBJECT_INTERFACE = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("TypedRealmObject"))
+    val EMBEDDED_OBJECT_INTERFACE = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("EmbeddedRealmObject"))
+    val ASYMMETRIC_OBJECT_INTERFACE = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("AsymmetricRealmObject"))
+
+    val CLASS_APP_CONFIGURATION = ClassId(FqName("io.realm.kotlin.mongodb"), Name.identifier("AppConfiguration"))
+
+    // External visible interface of Realm objects
+    val KOTLIN_COLLECTIONS_SET = ClassId(FqNames.PACKAGE_KOTLIN_COLLECTIONS, Name.identifier("Set"))
+    val KOTLIN_COLLECTIONS_LIST = ClassId(FqNames.PACKAGE_KOTLIN_COLLECTIONS, Name.identifier("List"))
+    val KOTLIN_COLLECTIONS_LISTOF = CallableId(FqNames.PACKAGE_KOTLIN_COLLECTIONS, Name.identifier("listOf"))
+    val KOTLIN_COLLECTIONS_MAP = ClassId(FqNames.PACKAGE_KOTLIN_COLLECTIONS, Name.identifier("Map"))
+    val KOTLIN_COLLECTIONS_MAPOF = CallableId(FqNames.PACKAGE_KOTLIN_COLLECTIONS, Name.identifier("mapOf"))
+    val KOTLIN_REFLECT_KMUTABLEPROPERTY1 = ClassId(FqNames.PACKAGE_KOTLIN_REFLECT, Name.identifier("KMutableProperty1"))
+    val KOTLIN_REFLECT_KPROPERTY1 = ClassId(FqNames.PACKAGE_KOTLIN_REFLECT, Name.identifier("KProperty1"))
+    val KOTLIN_PAIR = ClassId(FqName("kotlin"), Name.identifier("Pair"))
+
+    // Schema related types
+    val CLASS_INFO = ClassId(FqNames.PACKAGE_REALM_INTEROP, Name.identifier("ClassInfo"))
+    val PROPERTY_INFO = ClassId(FqNames.PACKAGE_REALM_INTEROP, Name.identifier("PropertyInfo"))
+    val PROPERTY_TYPE = ClassId(FqNames.PACKAGE_REALM_INTEROP, Name.identifier("PropertyType"))
+    val COLLECTION_TYPE = ClassId(FqNames.PACKAGE_REALM_INTEROP, Name.identifier("CollectionType"))
+    val PRIMARY_KEY_ANNOTATION = ClassId(FqNames.PACKAGE_ANNOTATIONS, Name.identifier("PrimaryKey"))
+    val INDEX_ANNOTATION = ClassId(FqNames.PACKAGE_ANNOTATIONS, Name.identifier("Index"))
+    val FULLTEXT_ANNOTATION = ClassId(FqNames.PACKAGE_ANNOTATIONS, Name.identifier("FullText"))
+    val IGNORE_ANNOTATION = ClassId(FqNames.PACKAGE_ANNOTATIONS, Name.identifier("Ignore"))
+    val PERSISTED_NAME_ANNOTATION = ClassId(FqNames.PACKAGE_ANNOTATIONS, Name.identifier("PersistedName"))
+    val TRANSIENT_ANNOTATION = ClassId(FqName("kotlin.jvm"), Name.identifier("Transient"))
+    val MODEL_OBJECT_ANNOTATION = ClassId(FqName("io.realm.kotlin.internal.platform"), Name.identifier("ModelObject"))
+    val PROPERTY_INFO_CREATE = CallableId(FqName("io.realm.kotlin.internal.schema"), Name.identifier("createPropertyInfo"))
+    val CLASS_KIND_TYPE = ClassId(FqName("io.realm.kotlin.schema"), Name.identifier("RealmClassKind"))
+
+    // Realm data types
+    val REALM_LIST = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmList"))
+    val REALM_SET = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmSet"))
+    val REALM_DICTIONARY = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmDictionary"))
+    val REALM_INSTANT = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmInstant"))
+    val REALM_BACKLINKS = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("BacklinksDelegate"))
+    val REALM_EMBEDDED_BACKLINKS = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("EmbeddedBacklinksDelegate"))
+    val REALM_OBJECT_ID = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("ObjectId"))
+    val KBSON_OBJECT_ID = ClassId(FqName("org.mongodb.kbson"), Name.identifier("BsonObjectId"))
+    val KBSON_DECIMAL128 = ClassId(FqName("org.mongodb.kbson"), Name.identifier("BsonDecimal128"))
+    val REALM_UUID = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmUUID"))
+    val REALM_MUTABLE_INTEGER = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("MutableRealmInt"))
+    val REALM_ANY = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmAny"))
+
+    // Sync types
     val APP = ClassId(PACKAGE_MONGODB, Name.identifier("App"))
     val APP_IMPL = ClassId(PACKAGE_MONGODB_INTERNAL, Name.identifier("AppImpl"))
     val APP_CONFIGURATION = ClassId(PACKAGE_MONGODB, Name.identifier("AppConfiguration"))
     val APP_CONFIGURATION_IMPL = ClassId(PACKAGE_MONGODB_INTERNAL, Name.identifier("AppConfigurationImpl"))
-    val APP_CONFIGURATION_BUILDER = ClassId(CLASS_APP_CONFIGURATION, Name.identifier("Builder"))
+    val APP_CONFIGURATION_BUILDER = ClassId(FqName("io.realm.kotlin.mongodb.AppConfiguration"), FqName("Builder"), true)
 }

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
@@ -87,6 +87,7 @@ internal object Names {
 
 internal object FqNames {
     val PACKAGE_ANNOTATIONS = FqName("io.realm.kotlin.types.annotations")
+    val PACKAGE_KBSON = FqName("org.mongodb.kbson")
     val PACKAGE_KOTLIN_COLLECTIONS = FqName("kotlin.collections")
     val PACKAGE_KOTLIN_REFLECT = FqName("kotlin.reflect")
     val PACKAGE_TYPES = FqName("io.realm.kotlin.types")
@@ -100,7 +101,7 @@ object ClassIds {
 
     // TODO we can replace with RealmObject::class.java.canonicalName if we make the runtime_api available as a compile time only dependency for the compiler-plugin
     val REALM_NATIVE_POINTER = FqName("io.realm.kotlin.internal.interop.NativePointer")
-    val REALM_OBJECT_INTERNAL_INTERFACE = ClassId(FqName("io.realm.kotlin.internal"), Name.identifier("RealmObjectInternal"))
+    val REALM_OBJECT_INTERNAL_INTERFACE = ClassId(FqNames.PACKAGE_REALM_INTERNAL, Name.identifier("RealmObjectInternal"))
 
     val REALM_MODEL_COMPANION = ClassId(FqNames.PACKAGE_REALM_INTERNAL, Name.identifier("RealmObjectCompanion"))
     val REALM_OBJECT_HELPER = ClassId(FqNames.PACKAGE_REALM_INTERNAL, Name.identifier("RealmObjectHelper"))
@@ -113,7 +114,7 @@ object ClassIds {
     val EMBEDDED_OBJECT_INTERFACE = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("EmbeddedRealmObject"))
     val ASYMMETRIC_OBJECT_INTERFACE = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("AsymmetricRealmObject"))
 
-    val CLASS_APP_CONFIGURATION = ClassId(FqName("io.realm.kotlin.mongodb"), Name.identifier("AppConfiguration"))
+    val CLASS_APP_CONFIGURATION = ClassId(FqNames.PACKAGE_MONGODB, Name.identifier("AppConfiguration"))
 
     // External visible interface of Realm objects
     val KOTLIN_COLLECTIONS_SET = ClassId(FqNames.PACKAGE_KOTLIN_COLLECTIONS, Name.identifier("Set"))
@@ -148,8 +149,8 @@ object ClassIds {
     val REALM_BACKLINKS = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("BacklinksDelegate"))
     val REALM_EMBEDDED_BACKLINKS = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("EmbeddedBacklinksDelegate"))
     val REALM_OBJECT_ID = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("ObjectId"))
-    val KBSON_OBJECT_ID = ClassId(FqName("org.mongodb.kbson"), Name.identifier("BsonObjectId"))
-    val KBSON_DECIMAL128 = ClassId(FqName("org.mongodb.kbson"), Name.identifier("BsonDecimal128"))
+    val KBSON_OBJECT_ID = ClassId(FqNames.PACKAGE_KBSON, Name.identifier("BsonObjectId"))
+    val KBSON_DECIMAL128 = ClassId(FqNames.PACKAGE_KBSON, Name.identifier("BsonDecimal128"))
     val REALM_UUID = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmUUID"))
     val REALM_MUTABLE_INTEGER = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("MutableRealmInt"))
     val REALM_ANY = ClassId(FqNames.PACKAGE_TYPES, Name.identifier("RealmAny"))

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
@@ -95,11 +95,11 @@ internal object FqNames {
     val REALM_CLASS_IMPL = FqName("io.realm.kotlin.internal.schema.RealmClassImpl")
     val OBJECT_REFERENCE_CLASS = FqName("io.realm.kotlin.internal.RealmObjectReference")
 
-    val BASE_REALM_OBJECT_INTERFACE = FqName("io.realm.kotlin.types.BaseRealmObject")
-    val REALM_OBJECT_INTERFACE = FqName("io.realm.kotlin.types.RealmObject")
+    val BASE_REALM_OBJECT_INTERFACE = ClassId(FqName("io.realm.kotlin.types"), FqName("BaseRealmObject"), false)
+    val REALM_OBJECT_INTERFACE = ClassId(FqName("io.realm.kotlin.types"), FqName("RealmObject"), false)
     val TYPED_REALM_OBJECT_INTERFACE = FqName("io.realm.kotlin.types.TypedRealmObject")
-    val EMBEDDED_OBJECT_INTERFACE = FqName("io.realm.kotlin.types.EmbeddedRealmObject")
-    val ASYMMETRIC_OBJECT_INTERFACE = FqName("io.realm.kotlin.types.AsymmetricRealmObject")
+    val EMBEDDED_OBJECT_INTERFACE = ClassId(FqName("io.realm.kotlin.types"), FqName("EmbeddedRealmObject"), false)
+    val ASYMMETRIC_OBJECT_INTERFACE = ClassId(FqName("io.realm.kotlin.types"), FqName("AsymmetricRealmObject"), false)
 
     // External visible interface of Realm objects
     val KOTLIN_COLLECTIONS_SET = FqName("kotlin.collections.Set")

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -16,9 +16,9 @@
 
 package io.realm.kotlin.compiler
 
-import io.realm.kotlin.compiler.FqNames.MODEL_OBJECT_ANNOTATION
-import io.realm.kotlin.compiler.FqNames.REALM_MODEL_COMPANION
-import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_INTERNAL_INTERFACE
+import io.realm.kotlin.compiler.ClassIds.MODEL_OBJECT_ANNOTATION
+import io.realm.kotlin.compiler.ClassIds.REALM_MODEL_COMPANION
+import io.realm.kotlin.compiler.ClassIds.REALM_OBJECT_INTERNAL_INTERFACE
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -13,32 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(FirIncompatiblePluginAPI::class)
 
 package io.realm.kotlin.compiler
 
-import io.realm.kotlin.compiler.FqNames.CLASS_INFO
-import io.realm.kotlin.compiler.FqNames.CLASS_KIND_TYPE
-import io.realm.kotlin.compiler.FqNames.COLLECTION_TYPE
-import io.realm.kotlin.compiler.FqNames.FULLTEXT_ANNOTATION
-import io.realm.kotlin.compiler.FqNames.INDEX_ANNOTATION
-import io.realm.kotlin.compiler.FqNames.KBSON_OBJECT_ID
-import io.realm.kotlin.compiler.FqNames.KOTLIN_COLLECTIONS_MAP
-import io.realm.kotlin.compiler.FqNames.KOTLIN_COLLECTIONS_MAPOF
-import io.realm.kotlin.compiler.FqNames.KOTLIN_PAIR
-import io.realm.kotlin.compiler.FqNames.OBJECT_REFERENCE_CLASS
-import io.realm.kotlin.compiler.FqNames.PRIMARY_KEY_ANNOTATION
-import io.realm.kotlin.compiler.FqNames.PROPERTY_INFO
-import io.realm.kotlin.compiler.FqNames.PROPERTY_INFO_CREATE
-import io.realm.kotlin.compiler.FqNames.PROPERTY_TYPE
-import io.realm.kotlin.compiler.FqNames.REALM_ANY
-import io.realm.kotlin.compiler.FqNames.REALM_INSTANT
-import io.realm.kotlin.compiler.FqNames.REALM_MODEL_COMPANION
-import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_ID
-import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_INTERFACE
-import io.realm.kotlin.compiler.FqNames.REALM_OBJECT_INTERNAL_INTERFACE
-import io.realm.kotlin.compiler.FqNames.REALM_UUID
-import io.realm.kotlin.compiler.FqNames.TYPED_REALM_OBJECT_INTERFACE
+import io.realm.kotlin.compiler.ClassIds.CLASS_INFO
+import io.realm.kotlin.compiler.ClassIds.CLASS_KIND_TYPE
+import io.realm.kotlin.compiler.ClassIds.COLLECTION_TYPE
+import io.realm.kotlin.compiler.ClassIds.FULLTEXT_ANNOTATION
+import io.realm.kotlin.compiler.ClassIds.INDEX_ANNOTATION
+import io.realm.kotlin.compiler.ClassIds.KBSON_OBJECT_ID
+import io.realm.kotlin.compiler.ClassIds.KOTLIN_COLLECTIONS_MAP
+import io.realm.kotlin.compiler.ClassIds.KOTLIN_COLLECTIONS_MAPOF
+import io.realm.kotlin.compiler.ClassIds.KOTLIN_PAIR
+import io.realm.kotlin.compiler.ClassIds.OBJECT_REFERENCE_CLASS
+import io.realm.kotlin.compiler.ClassIds.PRIMARY_KEY_ANNOTATION
+import io.realm.kotlin.compiler.ClassIds.PROPERTY_INFO
+import io.realm.kotlin.compiler.ClassIds.PROPERTY_INFO_CREATE
+import io.realm.kotlin.compiler.ClassIds.PROPERTY_TYPE
+import io.realm.kotlin.compiler.ClassIds.REALM_ANY
+import io.realm.kotlin.compiler.ClassIds.REALM_INSTANT
+import io.realm.kotlin.compiler.ClassIds.REALM_MODEL_COMPANION
+import io.realm.kotlin.compiler.ClassIds.REALM_OBJECT_ID
+import io.realm.kotlin.compiler.ClassIds.REALM_OBJECT_INTERFACE
+import io.realm.kotlin.compiler.ClassIds.REALM_OBJECT_INTERNAL_INTERFACE
+import io.realm.kotlin.compiler.ClassIds.REALM_UUID
+import io.realm.kotlin.compiler.ClassIds.TYPED_REALM_OBJECT_INTERFACE
 import io.realm.kotlin.compiler.Names.CLASS_INFO_CREATE
 import io.realm.kotlin.compiler.Names.OBJECT_REFERENCE
 import io.realm.kotlin.compiler.Names.PROPERTY_COLLECTION_TYPE_DICTIONARY
@@ -55,7 +54,6 @@ import io.realm.kotlin.compiler.Names.REALM_OBJECT_COMPANION_NEW_INSTANCE_METHOD
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_COMPANION_PRIMARY_KEY_MEMBER
 import io.realm.kotlin.compiler.Names.REALM_OBJECT_COMPANION_SCHEMA_METHOD
 import io.realm.kotlin.compiler.Names.SET
-import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
@@ -155,10 +153,10 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
     private val realmAnyType: IrType = pluginContext.lookupClassOrThrow(REALM_ANY).defaultType
 
     private val kMutableProperty1Class: IrClass =
-        pluginContext.lookupClassOrThrow(FqNames.KOTLIN_REFLECT_KMUTABLEPROPERTY1)
+        pluginContext.lookupClassOrThrow(ClassIds.KOTLIN_REFLECT_KMUTABLEPROPERTY1)
 
     private val kProperty1Class: IrClass =
-        pluginContext.lookupClassOrThrow(FqNames.KOTLIN_REFLECT_KPROPERTY1)
+        pluginContext.lookupClassOrThrow(ClassIds.KOTLIN_REFLECT_KPROPERTY1)
 
     private val mapClass: IrClass = pluginContext.lookupClassOrThrow(KOTLIN_COLLECTIONS_MAP)
     private val pairClass: IrClass = pluginContext.lookupClassOrThrow(KOTLIN_PAIR)
@@ -190,8 +188,8 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
         realmObjectMutablePropertyType
     )
 
-    val realmClassImpl = pluginContext.lookupClassOrThrow(FqNames.REALM_CLASS_IMPL)
-    private val realmClassCtor = pluginContext.lookupConstructorInClass(FqNames.REALM_CLASS_IMPL) {
+    val realmClassImpl = pluginContext.lookupClassOrThrow(ClassIds.REALM_CLASS_IMPL)
+    private val realmClassCtor = pluginContext.lookupConstructorInClass(ClassIds.REALM_CLASS_IMPL) {
         it.owner.valueParameters.size == 2
     }
 

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/SyncLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/SyncLoweringExtension.kt
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
-import org.jetbrains.kotlin.ir.backend.js.utils.valueArguments
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationContainer
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -130,7 +129,7 @@ private class SyncLowering(private val pluginContext: IrPluginContext, private v
 
     val transformer = object : IrElementTransformerVoid() {
         override fun visitCall(expression: IrCall): IrExpression {
-            replacements.get(expression.symbol)?.let { (target, dispatchReceiverFunction) ->
+            replacements[expression.symbol]?.let { (target, dispatchReceiverFunction) ->
                 return IrCallImpl(
                     startOffset = expression.startOffset,
                     endOffset = expression.endOffset,
@@ -142,7 +141,8 @@ private class SyncLowering(private val pluginContext: IrPluginContext, private v
                     superQualifierSymbol = null
                 ).apply {
                     dispatchReceiver = dispatchReceiverFunction(expression)
-                    expression.valueArguments.forEachIndexed { index, irExpression ->
+                    val valueArguments = List(expression.valueArgumentsCount) { expression.getValueArgument(it) }
+                    valueArguments.forEachIndexed { index, irExpression ->
                         putValueArgument(index, irExpression,)
                     }
                     putValueArgument(

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/CollectionTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/CollectionTests.kt
@@ -114,7 +114,7 @@ abstract class CollectionTests(
             )
         )
         assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        assertTrue(result.messages.contains("Unsupported type for ${collectionType.description}: 'A'"))
+        assertTrue(result.messages.contains("Unsupported type for ${collectionType.description}: 'A'"), result.messages)
     }
 
     // ------------------------------------------------


### PR DESCRIPTION
This PR reworks the compiler plugin, so it no longer uses deprecated APIs. This should move us closer to K2 support, but I'm keeping support out of this for now.

- All APIs using descriptors have been changed to IR-based APIs.
- All APIs marked with `@FirIncompatiblePluginAPI` has been reworked.
- Both of the two above required changing from using `FqNames` to `ClassId` and `CallableId`.

Regarding testing. Our library is built and tested with Kotlin 1.8.21. We do have a minimal sample project being built with 1.8.20, but I'll see if all tests run on 1.8.20 as well, just to be sure we are not breaking backwards compatibility.