### PR TITLE
Fix missing scheduler on Linux and Windows (JVM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.11.1 (YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixed
+* Opening a Realm would crash with `No built-in scheduler implementation for this platform` on Linux (JVM) and Windows. (Issue [#1502](https://github.com/realm/realm-kotlin/issues/1502), since 1.11.0)
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.8.0 and above. The K2 compiler is not supported yet.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.7.0 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Kbson 0.3.0.
+* Minimum Gradle version: 6.8.3.
+* Minimum Android Gradle Plugin version: 4.1.3.
+* Minimum Android SDK: 16.
+
+### Internal
+* None.
+
+
 ## 1.11.0 (2023-09-01)
 
 ### Breaking Changes

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -182,7 +182,7 @@ actual object RealmInterop {
     }
 
     actual fun realm_create_scheduler(): RealmSchedulerPointer =
-        LongPointerWrapper(realmc.realm_scheduler_make_default())
+        LongPointerWrapper(realmc.realm_create_generic_scheduler())
 
     actual fun realm_create_scheduler(dispatcher: CoroutineDispatcher): RealmSchedulerPointer =
         LongPointerWrapper(realmc.realm_create_scheduler(JVMScheduler(dispatcher)))

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -1051,5 +1051,5 @@ realm_sync_thread_error(realm_userdata_t userdata, const char* error) {
 
 realm_scheduler_t*
 realm_create_generic_scheduler() {
-    return new realm_scheduler_t{realm::util::Scheduler::make_generic()};
+    return new realm_scheduler_t { realm::util::Scheduler::make_dummy() };
 }

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -1048,3 +1048,8 @@ realm_sync_thread_error(realm_userdata_t userdata, const char* error) {
     env->CallVoidMethod(static_cast<jobject>(userdata), java_callback_method, to_jstring(env, msg));
     jni_check_exception(env);
 }
+
+realm_scheduler_t*
+realm_create_generic_scheduler() {
+    return new realm_scheduler_t{realm::util::Scheduler::make_generic()};
+}

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -134,4 +134,7 @@ realm_sync_thread_destroyed(realm_userdata_t userdata);
 void
 realm_sync_thread_error(realm_userdata_t userdata, const char* error);
 
+realm_scheduler_t*
+realm_create_generic_scheduler();
+
 #endif //TEST_REALM_API_HELPERS_H

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/FullText.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/FullText.kt
@@ -16,10 +16,11 @@ package io.realm.kotlin.types.annotations
  *
  * The full-text index currently support this set of features:
  *
- * - Only token or word search, e.g. `bio TEXT 'computer dancing'` will find all objects that
+ * - Token or word search, e.g. `bio TEXT 'computer dancing'` will find all objects that
  *   contains the words `computer` and `dancing` in their `bio` property.
  * - Tokens are diacritics- and case-insensitive, e.g.`bio TEXT 'cafe dancing'` and
  *   `bio TEXT 'café DANCING'` will return the same set of matches.
+ * - Token prefix search can be done using `*`, like `bio TEXT comp*`.
  * - Ignoring results with certain tokens are done using `-`, e.g. `bio TEXT 'computer -dancing'`
  *   will find all objects that contain `computer` but not `dancing`.
  * - Tokens are defined by a simple tokenizer that uses the following rules:
@@ -29,7 +30,7 @@ package io.realm.kotlin.types.annotations
  *
  * Note the following constraints before using full-text search:
  *
- * - Token prefix or suffix search like `bio TEXT 'comp* *cing'` is not supported.
+ * - Token suffix search like `bio TEXT '*cing'` is not supported.
  * - Only ASCII and Latin-1 alphanumerical chars are included in the index (most western languages).
  * - Only boolean match is supported, i.e. "found" or "not found". It is not possible to sort
  *   results by "relevance" .

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/VersionTrackingTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/VersionTrackingTests.kt
@@ -81,7 +81,11 @@ class VersionTrackingTests {
         realm.activeVersions().run {
             assertEquals(1, all.size)
             assertEquals(1, allTracked.size)
-            assertNull(notifier)
+            // The notifier might or might not had time to run
+            notifier?.let {
+                assertEquals(2, it.current.version)
+                assertEquals(0, it.active.size)
+            }
             assertNull(writer)
         }
     }


### PR DESCRIPTION
Closes #1502 

This PR aligns the behavior of schedulers across all platforms. Previously Darwin was using their custom run-loop, which was why it worked there while Linux and Windows failed.

The fix has been verified on Github Actions: https://github.com/realm/realm-kotlin/actions/runs/6098168339