### PR TITLE
Fix test around releasing intermediate versions

### DIFF
--- a/packages/test-base/src/androidInstrumentedTest/kotlin/io/realm/kotlin/test/android/MemoryTests.kt
+++ b/packages/test-base/src/androidInstrumentedTest/kotlin/io/realm/kotlin/test/android/MemoryTests.kt
@@ -149,14 +149,15 @@ class MemoryTests {
 
             // Perform various writes and deletes and garbage collect the references to allow core to
             // release the underlying versions
+            val referenceHolder = mutableListOf<MemoryTest>()
             for (i in 1..3) {
-                val referenceHolder = mutableListOf<MemoryTest>()
-                realm.writeBlocking {
-                    for (i in 1..10) {
+                for (i in 1..10) {
+                    val y: MemoryTest = realm.writeBlocking {
                         copyToRealm(MemoryTest()).apply {
                             stringField = oneMBstring
-                        }.also { referenceHolder.add(it) }
+                        }
                     }
+                    referenceHolder.add(y)
                 }
                 realm.writeBlocking {
                     delete(query<MemoryTest>("stringField != 'INITIAL'"))


### PR DESCRIPTION
The old version of test was erroneously storing references to live objects, thus wouldn't ever hold on to any frozen versions beside the initial object. The test was actually ok, but it is now easier to play around with not clearing the references as it is just a matter of commenting out `referenceHolder.clear()` to make the test fail.  