### PR TITLE
Remove Realm Plugin setting the bytecode target to 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* Realm will now longer set the JVM bytecode to 1.8 when applying the Realm plugin. (Issue [#XXXX]())
+* Realm will no longer set the JVM bytecode to 1.8 when applying the Realm plugin. ([#1513](https://github.com/realm/realm-kotlin/issues/1513))
 
 ### Fixed
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Enhancements
-* None.
+* Realm will now longer set the JVM bytecode to 1.8 when applying the Realm plugin. (Issue [#XXXX]())
 
 ### Fixed
 * None.

--- a/benchmarks/androidApp/build.gradle.kts
+++ b/benchmarks/androidApp/build.gradle.kts
@@ -8,12 +8,12 @@ android {
     compileSdk = Versions.Android.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = Versions.sourceCompatibilityVersion
+        targetCompatibility = Versions.targetCompatibilityVersion
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = Versions.kotlinJvmTarget
     }
 
     defaultConfig {

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -32,7 +32,7 @@ allprojects {
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = Versions.jvmTarget
+        kotlinOptions.jvmTarget = Versions.kotlinJvmTarget
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,6 +29,11 @@ gradlePlugin {
     }
 }
 
+java {
+    sourceCompatibility = Versions.sourceCompatibilityVersion
+    targetCompatibility = Versions.targetCompatibilityVersion
+}
+
 repositories {
     google()
     gradlePluginPortal()

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -127,9 +127,7 @@ object Versions {
     const val kbson = "0.3.0" // https://github.com/mongodb/kbson
     // When updating the Kotlin version, also remember to update /examples/min-android-sample/build.gradle.kts
     const val kotlin = "1.8.21" // https://github.com/JetBrains/kotlin and https://kotlinlang.org/docs/releases.html#release-details
-    const val latestKotlin = "1.9.20-Beta" // https://kotlinlang.org/docs/eap.html#build-details
     const val kotlinJvmTarget = "1.8" // Which JVM bytecode version is kotlin compiled to.
-    const val latestKotlin = "1.9.0" // https://kotlinlang.org/docs/eap.html#build-details
     const val latestKotlin = "1.9.20-Beta" // https://kotlinlang.org/docs/eap.html#build-details
     const val kotlinCompileTesting = "1.5.0" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlint = "0.45.2" // https://github.com/pinterest/ktlint

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import org.gradle.api.JavaVersion
 
 /**
  * Enum describing operating systems we can build on.
@@ -124,20 +124,22 @@ object Versions {
     const val jmh = "1.34" // https://github.com/openjdk/jmh
     const val jmhPlugin = "0.6.6" // https://github.com/melix/jmh-gradle-plugin
     const val junit = "4.13.2" // https://mvnrepository.com/artifact/junit/junit
-    const val jvmTarget = "1.8"
+    const val kbson = "0.3.0" // https://github.com/mongodb/kbson
     // When updating the Kotlin version, also remember to update /examples/min-android-sample/build.gradle.kts
     const val kotlin = "1.8.21" // https://github.com/JetBrains/kotlin and https://kotlinlang.org/docs/releases.html#release-details
+    const val kotlinJvmTarget = "1.8" // Which JVM bytecode version is kotlin compiled to.
     const val latestKotlin = "1.9.0" // https://kotlinlang.org/docs/eap.html#build-details
     const val kotlinCompileTesting = "1.5.0" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlint = "0.45.2" // https://github.com/pinterest/ktlint
     const val ktor = "2.1.2" // https://github.com/ktorio/ktor
+    const val multidex = "2.0.1" // https://developer.android.com/jetpack/androidx/releases/multidex
     const val nexusPublishPlugin = "1.1.0" // https://github.com/gradle-nexus/publish-plugin
     const val okio = "3.2.0" // https://square.github.io/okio/#releases
     const val relinker = "1.4.5" // https://github.com/KeepSafe/ReLinker
     const val serialization = "1.4.0" // https://kotlinlang.org/docs/releases.html#release-details
     const val shadowJar =  "6.1.0" // https://mvnrepository.com/artifact/com.github.johnrengelman.shadow/com.github.johnrengelman.shadow.gradle.plugin?repo=gradle-plugins
-    const val multidex = "2.0.1" // https://developer.android.com/jetpack/androidx/releases/multidex
-    const val kbson = "0.3.0" // https://github.com/mongodb/kbson
+    val sourceCompatibilityVersion = JavaVersion.VERSION_1_8 // Language level of any Java source code.
+    val targetCompatibilityVersion = JavaVersion.VERSION_1_8 // Version of generated JVM bytecode from Java files.
 }
 
 // Could be actual Dependency objects

--- a/buildSrc/src/main/kotlin/realm-lint.gradle.kts
+++ b/buildSrc/src/main/kotlin/realm-lint.gradle.kts
@@ -57,6 +57,7 @@ allprojects {
 
         description = "Check Kotlin code style."
         classpath = ktlint
+        jvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED")
         mainClass.set("com.pinterest.ktlint.Main")
         args = listOf(
             "src/**/*.kt",
@@ -74,6 +75,7 @@ allprojects {
 
         description = "Fix Kotlin code style deviations."
         classpath = ktlint
+        jvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED")
         mainClass.set("com.pinterest.ktlint.Main")
         args = listOf(
             "-F",

--- a/examples/kmm-sample/androidApp/build.gradle.kts
+++ b/examples/kmm-sample/androidApp/build.gradle.kts
@@ -64,7 +64,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = Versions.sourceCompatibilityVersion
+        targetCompatibility = Versions.targetCompatibilityVersion
     }
 }

--- a/examples/kmm-sample/compose-desktop/build.gradle.kts
+++ b/examples/kmm-sample/compose-desktop/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = Versions.jvmTarget
+    kotlinOptions.jvmTarget = Versions.kotlinJvmTarget
 }
 
 application {

--- a/examples/realm-java-compatibility/app/build.gradle
+++ b/examples/realm-java-compatibility/app/build.gradle
@@ -43,11 +43,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility Versions.sourceCompatibilityVersion
+        targetCompatibility Versions.targetCompatibilityVersion
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = Versions.kotlinJvmTarget
     }
 }
 

--- a/integration-tests/gradle-plugin-test/single-platform/build.gradle.kts
+++ b/integration-tests/gradle-plugin-test/single-platform/build.gradle.kts
@@ -40,11 +40,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = Versions.sourceCompatibilityVersion
+        targetCompatibility = Versions.targetCompatibilityVersion
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = Versions.kotlinJvmTarget
     }
 }
 

--- a/packages/build.gradle.kts
+++ b/packages/build.gradle.kts
@@ -27,8 +27,9 @@ allprojects {
     version = Realm.version
     group = Realm.group
 
+    // Define JVM bytecode target for all Kotlin targets
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = "${Versions.jvmTarget}"
+        kotlinOptions.jvmTarget = "${Versions.kotlinJvmTarget}"
     }
 }
 

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -113,11 +113,7 @@ val nativeLibraryIncludesIosSimulatorArm64Release =
     includeBinaries(releaseLibs.map { "$absoluteCorePath/build-simulator-arm64/lib/$it" })
 
 kotlin {
-    jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = Versions.kotlinJvmTarget
-        }
-    }
+    jvm()
     android("android") {
         publishLibraryVariants("release")
     }

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -115,7 +115,7 @@ val nativeLibraryIncludesIosSimulatorArm64Release =
 kotlin {
     jvm {
         compilations.all {
-            kotlinOptions.jvmTarget = Versions.jvmTarget
+            kotlinOptions.jvmTarget = Versions.kotlinJvmTarget
         }
     }
     android("android") {
@@ -344,12 +344,10 @@ android {
             path = project.file("src/jvm/CMakeLists.txt")
         }
     }
-    // To avoid
-    // Failed to transform kotlinx-coroutines-core-jvm-1.5.0-native-mt.jar ...
-    // The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
+
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = Versions.sourceCompatibilityVersion
+        targetCompatibility = Versions.targetCompatibilityVersion
     }
 }
 

--- a/packages/gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/build.gradle.kts
@@ -82,8 +82,8 @@ publishing {
 java {
     withSourcesJar()
     withJavadocJar()
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = Versions.sourceCompatibilityVersion
+    targetCompatibility = Versions.targetCompatibilityVersion
 }
 
 // Make version information available at runtime

--- a/packages/gradle-plugin/src/main/kotlin/io/realm/kotlin/gradle/RealmPlugin.kt
+++ b/packages/gradle-plugin/src/main/kotlin/io/realm/kotlin/gradle/RealmPlugin.kt
@@ -79,24 +79,11 @@ open class RealmPlugin : Plugin<Project> {
         // Stand alone Android projects have not initialized kotlin plugin when applying this, so
         // postpone dependency injection till after evaluation.
         project.afterEvaluate {
-            val kotlin: Any? = project.extensions.findByName("kotlin")
             // TODO AUTO-SETUP To ease configuration we could/should inject dependencies to our
             //  library, but await better insight into when/what to inject and supply appropriate
             //  opt-out options through our own extension?
             //  Dependencies should probably be added by source set and not by target, as
             //  kotlin.sourceSets.getByName("commonMain").dependencies (or "main" for Android), but
-            when (kotlin) {
-                is KotlinSingleTargetExtension<*> -> {
-                    updateKotlinOption(kotlin.target)
-                }
-                is KotlinMultiplatformExtension -> {
-                    kotlin.targets.all { target -> updateKotlinOption(target) }
-                }
-                else -> {
-                    // TODO AUTO-SETUP Should we report errors? Probably an oversighted case
-                    // TODO("Cannot 'realm-kotlin' library dependency to ${if (kotlin != null) kotlin::class.qualifiedName else "null"}")
-                }
-            }
 
             // Create the analytics during configuration because it needs access to the project
             // in order to gather project relevant information in afterEvaluate. Currently
@@ -109,18 +96,6 @@ open class RealmPlugin : Plugin<Project> {
                 // Work-around for https://github.com/gradle/gradle/issues/18821
                 // Since this only happens in multi-module projects, this should be fine as
                 // the build will still be registered by the first module that starts the service.
-            }
-        }
-    }
-
-    private fun updateKotlinOption(target: KotlinTarget) {
-        target.compilations.all { compilation ->
-            // Setup correct compiler options
-            // FIXME AUTO-SETUP Are these to dangerous to apply under the hood?
-            when (val options = compilation.kotlinOptions) {
-                is KotlinJvmOptions -> {
-                    options.jvmTarget = "1.8"
-                }
             }
         }
     }

--- a/packages/gradle-plugin/src/main/kotlin/io/realm/kotlin/gradle/RealmPlugin.kt
+++ b/packages/gradle-plugin/src/main/kotlin/io/realm/kotlin/gradle/RealmPlugin.kt
@@ -27,10 +27,6 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Provider
 import org.gradle.build.event.BuildEventsListenerRegistry
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinSingleTargetExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import javax.inject.Inject
 
 @Suppress("unused")

--- a/packages/jni-swig-stub/build.gradle.kts
+++ b/packages/jni-swig-stub/build.gradle.kts
@@ -32,11 +32,6 @@ java {
     }
 }
 
-configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 tasks.create("realmWrapperJvm") {
     doLast {
         // If task is actually triggered (not up to date) then we should clean up the old stuff
@@ -70,8 +65,8 @@ realmPublish {
 java {
     withSourcesJar()
     withJavadocJar()
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = Versions.sourceCompatibilityVersion
+    targetCompatibility = Versions.targetCompatibilityVersion
 }
 
 publishing {

--- a/packages/library-base/build.gradle.kts
+++ b/packages/library-base/build.gradle.kts
@@ -161,12 +161,9 @@ android {
             consumerProguardFiles("proguard-rules-consumer-common.pro")
         }
     }
-    // To avoid
-    // Failed to transform kotlinx-coroutines-core-jvm-1.5.0-native-mt.jar ...
-    // The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = Versions.sourceCompatibilityVersion
+        targetCompatibility = Versions.targetCompatibilityVersion
     }
     // Skip BuildConfig generation as it overlaps with io.realm.kotlin.BuildConfig from realm-java
     buildFeatures {

--- a/packages/library-sync/build.gradle.kts
+++ b/packages/library-sync/build.gradle.kts
@@ -157,12 +157,9 @@ android {
             consumerProguardFiles("proguard-rules-consumer-common.pro")
         }
     }
-    // To avoid
-    // Failed to transform kotlinx-coroutines-core-jvm-1.5.0-native-mt.jar ...
-    // The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = Versions.sourceCompatibilityVersion
+        targetCompatibility = Versions.targetCompatibilityVersion
     }
     // Skip BuildConfig generation as it overlaps with io.realm.kotlin.BuildConfig from realm-java
     buildFeatures {

--- a/packages/plugin-compiler-shaded/build.gradle.kts
+++ b/packages/plugin-compiler-shaded/build.gradle.kts
@@ -55,8 +55,8 @@ realmPublish {
 java {
     withSourcesJar()
     withJavadocJar()
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = Versions.sourceCompatibilityVersion
+    targetCompatibility = Versions.targetCompatibilityVersion
 }
 
 publishing {

--- a/packages/plugin-compiler/build.gradle.kts
+++ b/packages/plugin-compiler/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "${Versions.jvmTarget}"
         freeCompilerArgs = listOf("-Xjvm-default=all-compatibility")
     }
 }
@@ -69,6 +68,6 @@ publishing {
 java {
     withSourcesJar()
     withJavadocJar()
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = Versions.sourceCompatibilityVersion
+    targetCompatibility = Versions.targetCompatibilityVersion
 }

--- a/packages/test-base/build.gradle.kts
+++ b/packages/test-base/build.gradle.kts
@@ -103,10 +103,6 @@ kotlin {
             }
         }
     }
-
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).all {
-        kotlinOptions.jvmTarget = Versions.jvmTarget
-    }
 }
 
 // Android configuration
@@ -150,8 +146,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = Versions.sourceCompatibilityVersion
+        targetCompatibility = Versions.targetCompatibilityVersion
     }
 
     // Remove overlapping resources after adding "org.jetbrains.kotlinx:kotlinx-coroutines-test" to

--- a/packages/test-sync/build.gradle.kts
+++ b/packages/test-sync/build.gradle.kts
@@ -122,7 +122,6 @@ kotlin {
     }
     // JVM specific KotlinCompilation tasks
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).all {
-        kotlinOptions.jvmTarget = Versions.jvmTarget
         kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
 }
@@ -161,8 +160,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = Versions.sourceCompatibilityVersion
+        targetCompatibility = Versions.targetCompatibilityVersion
     }
 
     // Remove overlapping resources after adding "org.jetbrains.kotlinx:kotlinx-coroutines-test" to


### PR DESCRIPTION
From Kotlin 1.8.0 the minimum supported Java target is 1.8. This means there is no longer any reason we are setting this in our Realm Plugin. In fact, it might silently modify the behavior of people's compiled code if they are not setting the jvmTarget themselves: https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target

I tested this with various combinations of  Java (11 and 17)  and `build.gradle` settings and it doesn't seem to cause build failures.

At the same time, I also unified how we are setting the Kotlin and Java bytecode versions, so they can now all be controlled through our buildSrc Config file.

Regarding the target version, I kept it at 1.8 since we don't know what version of the JVM people are running on the desktop.  On Android the minimum the 11, but it didn't seem worth it to try to differentiate the two.

Since we are running Java 11 as a minimum on our developer machines and CI, we could probably set the `sourceCompatibility` to 11 as well, but the confusion didn't seem worth it. Also, we don't really have any Java sources to speak of anyway.