### PR TITLE
Cleanup resources better during Client Reset and closing Realms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@
 * Realm will no longer set the JVM bytecode to 1.8 when applying the Realm plugin. ([#1513](https://github.com/realm/realm-kotlin/issues/1513))
 
 ### Fixed
+* `Realm.close()` is now idempotent.
 * [Sync] Manual client reset on Windows would not trigger correctly when run inside `onManualResetFallback`. (Issue [#1515](https://github.com/realm/realm-kotlin/pull/1515))  
-* [Sync] If calling a function on App Services that resulted in a redirect, it would only redirect for GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
+* [Sync] `ClientResetRequiredException.executeClientReset()` now returns a boolean indicating if the manual reset fully succeded or not. (Issue [#1515](https://github.com/realm/realm-kotlin/pull/1515))  
+* [Sync] If calling a function on App Services that resulted in a redirect, it would only redirect for 
+GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* [Sync] Manual client reset on Windows would not trigger correctly when run inside `onManualResetFallback`. (Issue [#1515](https://github.com/realm/realm-kotlin/pull/1515))  
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,6 +1,6 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2023-09-21
+MONGODB_REALM_SERVER=2023-09-22
 
 # `BAAS` and `BAAS-UI` projects commit hashes matching MONGODB_REALM_SERVER image version
 # note that the MONGODB_REALM_SERVER image is a nightly build, find the matching commits

--- a/dependencies.list
+++ b/dependencies.list
@@ -7,5 +7,5 @@ MONGODB_REALM_SERVER=2023-09-07
 # for that date within the following repositories:
 # https://github.com/10gen/baas/
 # https://github.com/10gen/baas-ui/
-REALM_BAAS_GIT_HASH=fc070ea7e874f58eb5b4f7a9d344fa7cdd755817
-REALM_BAAS_UI_GIT_HASH=ca722f5bb7a7485404a68874991ba8e50787ea9a
+REALM_BAAS_GIT_HASH=0b7562d0401d72c909369030dc29332542614ba3
+REALM_BAAS_UI_GIT_HASH=24baee4eb0e9736969a00a7bfac849565bca17f4

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,11 +1,11 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2023-09-07
+MONGODB_REALM_SERVER=2023-09-13
 
 # `BAAS` and `BAAS-UI` projects commit hashes matching MONGODB_REALM_SERVER image version
 # note that the MONGODB_REALM_SERVER image is a nightly build, find the matching commits
 # for that date within the following repositories:
 # https://github.com/10gen/baas/
 # https://github.com/10gen/baas-ui/
-REALM_BAAS_GIT_HASH=fc070ea7e874f58eb5b4f7a9d344fa7cdd755817
-REALM_BAAS_UI_GIT_HASH=ca722f5bb7a7485404a68874991ba8e50787ea9a
+REALM_BAAS_GIT_HASH=3e370f9ee73c00efe2486ce5cd91d8fceb841cd6
+REALM_BAAS_UI_GIT_HASH=20942c088737568eefd446536d6d681053365336

--- a/dependencies.list
+++ b/dependencies.list
@@ -7,5 +7,5 @@ MONGODB_REALM_SERVER=2023-09-13
 # for that date within the following repositories:
 # https://github.com/10gen/baas/
 # https://github.com/10gen/baas-ui/
-REALM_BAAS_GIT_HASH=3e370f9ee73c00efe2486ce5cd91d8fceb841cd6
-REALM_BAAS_UI_GIT_HASH=20942c088737568eefd446536d6d681053365336
+REALM_BAAS_GIT_HASH=fc070ea7e874f58eb5b4f7a9d344fa7cdd755817
+REALM_BAAS_UI_GIT_HASH=ca722f5bb7a7485404a68874991ba8e50787ea9a

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,6 +1,6 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2023-09-07
+MONGODB_REALM_SERVER=2023-09-21
 
 # `BAAS` and `BAAS-UI` projects commit hashes matching MONGODB_REALM_SERVER image version
 # note that the MONGODB_REALM_SERVER image is a nightly build, find the matching commits

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,6 +1,6 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2023-09-13
+MONGODB_REALM_SERVER=2023-09-07
 
 # `BAAS` and `BAAS-UI` projects commit hashes matching MONGODB_REALM_SERVER image version
 # note that the MONGODB_REALM_SERVER image is a nightly build, find the matching commits

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -2544,6 +2544,8 @@ actual object RealmInterop {
                 } catch (e: Throwable) {
                     println(e.message)
                     false
+                } finally {
+                    realm_wrapper.realm_close(afterRealmPtr)
                 }
             },
             StableRef.create(afterHandler).asCPointer(),

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -906,7 +906,7 @@ after_client_reset(void* userdata, realm_t* before_realm,
     realm_t* after_realm_ptr = realm_from_thread_safe_reference(after_realm, &scheduler);
     auto after_pointer = wrap_pointer(env, reinterpret_cast<jlong>(after_realm_ptr), false);
     env->CallVoidMethod(static_cast<jobject>(userdata), java_after_callback_function, before_pointer, after_pointer, did_recover);
-
+    realm_close(after_realm_ptr);
     if (env->ExceptionCheck()) {
         std::string exception_message = get_exception_message(env);
         std::string message_template = "An error has occurred in the 'onAfter' callback: ";

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
@@ -46,7 +46,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.reflect.KClass
 
@@ -55,8 +54,6 @@ import kotlin.reflect.KClass
 public class RealmImpl private constructor(
     configuration: InternalConfiguration,
 ) : BaseRealmImpl(configuration), Realm, InternalTypedRealm, Flowable<RealmChange<Realm>> {
-
-    private val realmPointerMutex = Mutex()
 
     public val notificationScheduler: LiveRealmContext =
         configuration.notificationDispatcherFactory.createLiveRealmContext()
@@ -85,6 +82,7 @@ public class RealmImpl private constructor(
 
     private var _realmReference: AtomicRef<FrozenRealmReference?> = atomic(null)
     private val realmReferenceLock = SynchronizableObject()
+    private val isClosed = atomic(false)
 
     /**
      * The current Realm reference that points to the underlying frozen C++ SharedRealm.
@@ -262,6 +260,12 @@ public class RealmImpl private constructor(
         return VersionInfo(mainVersions, notifier.versions(), writer.versions())
     }
 
+    override fun isClosed(): Boolean {
+        // We cannot rely on `realmReference()` here. If something happens during open, this might
+        // not be available and will throw, so we need to track closed state separately.
+        return isClosed.value
+    }
+
     override fun close() {
         // TODO Reconsider this constraint. We have the primitives to check is we are on the
         //  writer thread and just close the realm in writer.close()
@@ -270,18 +274,17 @@ public class RealmImpl private constructor(
             if (isClosed()) {
                 return
             }
+            isClosed.value = true
             runBlocking {
-                realmPointerMutex.withLock {
-                    writer.close()
-                    realmScope.cancel()
-                    notifier.close()
-                    versionTracker.close()
-                    @OptIn(ExperimentalStdlibApi::class)
-                    syncContext.value?.close()
-                    // The local realmReference is pointing to a realm reference managed by either the
-                    // version tracker, writer or notifier, so it is already closed
-                    super.close()
-                }
+                writer.close()
+                realmScope.cancel()
+                notifier.close()
+                versionTracker.close()
+                @OptIn(ExperimentalStdlibApi::class)
+                syncContext.value?.close()
+                // The local realmReference is pointing to a realm reference managed by either the
+                // version tracker, writer or notifier, so it is already closed
+                super.close()
             }
             if (!realmStateFlow.tryEmit(State.CLOSED)) {
                 log.warn("Cannot signal internal close")

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmImpl.kt
@@ -103,7 +103,8 @@ public class RealmImpl private constructor(
 
     // Injection point for synchronized Realms. This property should only be used to hold state
     // required by synchronized realms. See `SyncedRealmContext` for more details.
-    public var syncContext: AtomicRef<Any?> = atomic(null)
+    @OptIn(ExperimentalStdlibApi::class)
+    public var syncContext: AtomicRef<AutoCloseable?> = atomic(null)
 
     init {
         @Suppress("TooGenericExceptionCaught")
@@ -271,6 +272,8 @@ public class RealmImpl private constructor(
                 realmScope.cancel()
                 notifier.close()
                 versionTracker.close()
+                @OptIn(ExperimentalStdlibApi::class)
+                syncContext.value?.close()
                 // The local realmReference is pointing to a realm reference managed by either the
                 // version tracker, writer or notifier, so it is already closed
                 super.close()

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/ClientResetRequiredException.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/ClientResetRequiredException.kt
@@ -56,9 +56,10 @@ public class ClientResetRequiredException constructor(
      * associated to the session in which this error is generated **must be closed**. Not doing so
      * might result in unexpected file system errors.
      *
+     * @return `true` if the Client Reset succeeded, `false` if not.
      * @throws IllegalStateException if not all instances have been closed.
      */
-    public fun executeClientReset() {
-        RealmInterop.realm_sync_immediately_run_file_actions(appPointer, originalFilePath)
+    public fun executeClientReset(): Boolean {
+        return RealmInterop.realm_sync_immediately_run_file_actions(appPointer, originalFilePath)
     }
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncConfigurationImpl.kt
@@ -36,6 +36,7 @@ import io.realm.kotlin.internal.interop.SyncErrorCallback
 import io.realm.kotlin.internal.interop.sync.SyncError
 import io.realm.kotlin.internal.interop.sync.SyncSessionResyncMode
 import io.realm.kotlin.internal.platform.fileExists
+import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.mongodb.exceptions.ClientResetRequiredException
 import io.realm.kotlin.mongodb.exceptions.DownloadingRealmTimeOutException
 import io.realm.kotlin.mongodb.subscriptions
@@ -52,8 +53,11 @@ import io.realm.kotlin.mongodb.sync.SyncSession
 import kotlinx.atomicfu.AtomicBoolean
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.mongodb.kbson.BsonValue
@@ -194,10 +198,33 @@ internal class SyncConfigurationImpl(
             SyncErrorCallback { pointer: RealmSyncSessionPointer, error: SyncError ->
                 val session = SyncSessionImpl(pointer)
                 val syncError = convertSyncError(error)
-
-                // Notify before/after callbacks too if error is client reset
                 if (error.isClientResetRequested) {
-                    initializerHelper.onSyncError(session, frozenAppPointer, error)
+                    // If a Client Reset happened, we only get here if `onManualResetFallback` needs
+                    // to be called. This means there is a high likelihood that users will want to
+                    // call ClientResetRequiredException.executeClientReset() inside the callback.
+                    //
+                    // In order to do that, they will need to close the Realm first.
+                    //
+                    // On POSIX this will work fine, but on Windows this will fail as the
+                    // C++ session still holds a DBPointer preventing the release of the file during
+                    // the callback.
+                    //
+                    // So, in order to prevent errors on Windows, we are running the Kotlin callback
+                    // on a separate worker thread. This will allow Core to finish its callback so
+                    // when we close the Realm from the worker thread, the underlying
+                    // session can also be fully freed.
+                    //
+                    // Given that we do not make any promises regarding which thread the callback
+                    // is running on. This should be fine.
+                    @OptIn(DelicateCoroutinesApi::class)
+                    try {
+                        GlobalScope.launch {
+                            initializerHelper.onSyncError(session, frozenAppPointer, error)
+                        }
+                    } catch (ex: Exception) {
+                        @Suppress("invisible_member")
+                        RealmLog.error("Error thrown and ignored in `onManualResetFallback`: $ex")
+                    }
                 } else {
                     userErrorHandler.onError(session, syncError)
                 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncSessionImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncSessionImpl.kt
@@ -247,6 +247,10 @@ internal open class SyncSessionImpl(
         }
     }
 
+    fun close() {
+        nativePointer.release()
+    }
+
     internal companion object {
         internal fun stateFrom(coreState: CoreSyncSessionState): SyncSession.State {
             return when (coreState) {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
@@ -87,6 +87,7 @@ internal fun <T, R : BaseRealm> executeInSyncContext(realm: R, block: (context: 
     }
 }
 
+@OptIn(ExperimentalStdlibApi::class)
 private fun <T : BaseRealm> initSyncContextIfNeeded(realm: T): SyncedRealmContext<T> {
     // INVARIANT: `syncContext` is only ever set once, and never to `null`.
     // This code works around the fact that `Mutex`'s can only be locked inside suspend functions on

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
@@ -59,7 +59,7 @@ internal class SyncedRealmContext<T : BaseRealm>(realm: T) : AutoCloseable {
 
     override fun close() {
         if (sessionDelegate.isInitialized()) {
-            (session as SyncSessionImpl).nativePointer.release()
+            (session as SyncSessionImpl).close()
         }
     }
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
@@ -32,7 +32,8 @@ import io.realm.kotlin.mongodb.sync.SyncSession
  * In order to work around the bootstrap problem, all public API entry points that access this
  * class must do so through the [executeInSyncContext] closure.
  */
-internal class SyncedRealmContext<T : BaseRealm>(realm: T) {
+@OptIn(ExperimentalStdlibApi::class)
+internal class SyncedRealmContext<T : BaseRealm>(realm: T): AutoCloseable {
     // TODO For now this can only be a RealmImpl, which is required by the SyncSessionImpl
     //  When we introduce a public DynamicRealm, this can also be a `DynamicRealmImpl`
     //  And we probably need to modify the SyncSessionImpl to take either of these two.
@@ -40,17 +41,26 @@ internal class SyncedRealmContext<T : BaseRealm>(realm: T) {
     internal val config: SyncConfiguration = baseRealm.configuration as SyncConfiguration
     // Note: Session and Subscriptions only need a valid dbPointer when being created, after that, they
     // have their own lifecycle and can be cached.
-    internal val session: SyncSession by lazy {
+    private val sessionDelegate: Lazy<SyncSessionImpl> = lazy {
         SyncSessionImpl(
             baseRealm,
             RealmInterop.realm_sync_session_get(baseRealm.realmReference.dbPointer)
         )
     }
-    internal val subscriptions: SubscriptionSet<T> by lazy {
+    internal val session: SyncSession by sessionDelegate
+
+    private val subscriptionsDelegate: Lazy<SubscriptionSetImpl<T>> = lazy {
         SubscriptionSetImpl(
             realm,
             RealmInterop.realm_sync_get_latest_subscriptionset(baseRealm.realmReference.dbPointer)
         )
+    }
+    internal val subscriptions: SubscriptionSet<T> by subscriptionsDelegate
+
+    override fun close() {
+        if (sessionDelegate.isInitialized()) {
+            (session as SyncSessionImpl).nativePointer.release()
+        }
     }
 }
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SyncedRealmContext.kt
@@ -33,7 +33,7 @@ import io.realm.kotlin.mongodb.sync.SyncSession
  * class must do so through the [executeInSyncContext] closure.
  */
 @OptIn(ExperimentalStdlibApi::class)
-internal class SyncedRealmContext<T : BaseRealm>(realm: T): AutoCloseable {
+internal class SyncedRealmContext<T : BaseRealm>(realm: T) : AutoCloseable {
     // TODO For now this can only be a RealmImpl, which is required by the SyncSessionImpl
     //  When we introduce a public DynamicRealm, this can also be a `DynamicRealmImpl`
     //  And we probably need to modify the SyncSessionImpl to take either of these two.

--- a/packages/test-base/src/androidMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/androidMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -21,7 +21,6 @@ import android.os.SystemClock
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.attribute.PosixFilePermission
 import kotlin.io.path.absolutePathString
 import kotlin.time.Duration
 

--- a/packages/test-base/src/androidMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/androidMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -30,14 +30,8 @@ actual object PlatformUtils {
     actual fun createTempDir(prefix: String, readOnly: Boolean): String {
         val dir: Path = Files.createTempDirectory("$prefix-android_tests")
         if (readOnly) {
-            Files.setPosixFilePermissions(
-                dir,
-                setOf(
-                    PosixFilePermission.GROUP_READ,
-                    PosixFilePermission.OTHERS_READ,
-                    PosixFilePermission.OWNER_READ
-                )
-            )
+            // Use the File API as it works across Windows and POSIX.
+            dir.toFile().setReadOnly()
         }
         return dir.absolutePathString()
     }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmTests.kt
@@ -430,6 +430,14 @@ class RealmTests {
     }
 
     @Test
+    fun close_idempotent() {
+        realm.close()
+        assertTrue(realm.isClosed())
+        realm.close()
+        assertTrue(realm.isClosed())
+    }
+
+    @Test
     @Suppress("LongMethod")
     fun deleteRealm() {
         val fileSystem = FileSystem.SYSTEM

--- a/packages/test-sync/build.gradle.kts
+++ b/packages/test-sync/build.gradle.kts
@@ -287,27 +287,35 @@ kotlin {
 // - 'syncTestUrl` defines the root URL for the App Services server. Default is `http://localhost:9090`
 // - 'syncTestAppNamePrefix' is added a differentiator for all apps created by tests. This makes
 //   it possible for builds in parallel to run against the same test server. Default is `test-app`.
+fun getPropertyValue(propertyName: String): String? {
+    println("Finding $propertyName")
+    if (project.hasProperty(propertyName)) {
+        println("Found ${project.property(propertyName)}")
+        return project.property(propertyName) as String
+    }
+   return System.getenv(propertyName)
+}
 buildkonfig {
     packageName = "io.realm.kotlin.test.mongodb"
     objectName = "SyncServerConfig"
     defaultConfigs {
-        buildConfigField(Type.STRING, "url", properties["syncTestUrl"]!! as String)
-        buildConfigField(Type.STRING, "appPrefix", properties["syncTestAppNamePrefix"]!! as String)
-        if (properties.containsKey("syncTestLoginEmail") && properties.containsKey("syncTestLoginPassword")) {
-            buildConfigField(Type.STRING, "email", properties["syncTestLoginEmail"]!! as String)
-            buildConfigField(Type.STRING, "password", properties["syncTestLoginPassword"]!! as String)
+        buildConfigField(Type.STRING, "url", getPropertyValue("syncTestUrl"))
+        buildConfigField(Type.STRING, "appPrefix", getPropertyValue("syncTestAppNamePrefix"))
+        if (project.hasProperty("syncTestLoginEmail") && project.hasProperty("syncTestLoginPassword")) {
+            buildConfigField(Type.STRING, "email", getPropertyValue("syncTestLoginEmail"))
+            buildConfigField(Type.STRING, "password", getPropertyValue("syncTestLoginPassword"))
         } else {
             buildConfigField(Type.STRING, "email", "")
             buildConfigField(Type.STRING, "password", "")
         }
-        if (properties.containsKey("syncTestLoginPublicApiKey") && properties.containsKey("syncTestLoginPrivateApiKey")) {
-            buildConfigField(Type.STRING, "publicApiKey", properties["syncTestLoginPublicApiKey"]!! as String)
-            buildConfigField(Type.STRING, "privateApiKey", properties["syncTestLoginPrivateApiKey"]!! as String)
+        if (project.hasProperty("syncTestLoginPublicApiKey") && project.hasProperty("syncTestLoginPrivateApiKey")) {
+            buildConfigField(Type.STRING, "publicApiKey", getPropertyValue("syncTestLoginPublicApiKey"))
+            buildConfigField(Type.STRING, "privateApiKey", getPropertyValue("syncTestLoginPrivateApiKey"))
         } else {
             buildConfigField(Type.STRING, "publicApiKey", "")
             buildConfigField(Type.STRING, "privateApiKey", "")
         }
-        buildConfigField(Type.STRING, "clusterName", properties["syncTestClusterName"] as String? ?: "")
+        buildConfigField(Type.STRING, "clusterName", getPropertyValue("syncTestClusterName") ?: "")
     }
 }
 

--- a/packages/test-sync/build.gradle.kts
+++ b/packages/test-sync/build.gradle.kts
@@ -290,7 +290,7 @@ fun getPropertyValue(propertyName: String): String? {
     if (project.hasProperty(propertyName)) {
         return project.property(propertyName) as String
     }
-   return System.getenv(propertyName)
+    return System.getenv(propertyName)
 }
 buildkonfig {
     packageName = "io.realm.kotlin.test.mongodb"

--- a/packages/test-sync/build.gradle.kts
+++ b/packages/test-sync/build.gradle.kts
@@ -288,9 +288,7 @@ kotlin {
 // - 'syncTestAppNamePrefix' is added a differentiator for all apps created by tests. This makes
 //   it possible for builds in parallel to run against the same test server. Default is `test-app`.
 fun getPropertyValue(propertyName: String): String? {
-    println("Finding $propertyName")
     if (project.hasProperty(propertyName)) {
-        println("Found ${project.property(propertyName)}")
         return project.property(propertyName) as String
     }
    return System.getenv(propertyName)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
@@ -19,6 +19,7 @@ package io.realm.kotlin.test.mongodb.common
 
 import io.realm.kotlin.internal.platform.PATH_SEPARATOR
 import io.realm.kotlin.internal.platform.appFilesDirectory
+import io.realm.kotlin.internal.platform.isWindows
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.log.RealmLog
@@ -151,9 +152,13 @@ class AppConfigurationTests {
 
     @Test
     fun syncRootDirectory_writeProtectedDir() {
-        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
-        val dir = PlatformUtils.createTempDir(readOnly = true)
-        assertFailsWith<IllegalArgumentException> { builder.syncRootDirectory(dir) }
+        // It looks like we cannot create a readOnly directory on Windows, so ignore this test
+        // there for now.
+        if (!isWindows()) {
+            val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
+            val dir = PlatformUtils.createTempDir(readOnly = true)
+            assertFailsWith<IllegalArgumentException> { builder.syncRootDirectory(dir) }
+        }
     }
 
     // When creating the full path for a synced Realm, we will always append `/mongodb-realm` to

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
@@ -18,7 +18,6 @@
 package io.realm.kotlin.test.mongodb.common
 
 import io.realm.kotlin.internal.platform.appFilesDirectory
-import io.realm.kotlin.internal.platform.isWindows
 import io.realm.kotlin.internal.platform.pathOf
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.log.LogLevel
@@ -152,13 +151,9 @@ class AppConfigurationTests {
 
     @Test
     fun syncRootDirectory_writeProtectedDir() {
-        // It looks like we cannot create a readOnly directory on Windows, so ignore this test
-        // there for now.
-        if (!isWindows()) {
-            val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
-            val dir = PlatformUtils.createTempDir(readOnly = true)
-            assertFailsWith<IllegalArgumentException> { builder.syncRootDirectory(dir) }
-        }
+        val builder: AppConfiguration.Builder = AppConfiguration.Builder(APP_ID)
+        val dir = PlatformUtils.createTempDir(readOnly = true)
+        assertFailsWith<IllegalArgumentException> { builder.syncRootDirectory(dir) }
     }
 
     // When creating the full path for a synced Realm, we will always append `/mongodb-realm` to

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AsymmetricSyncTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AsymmetricSyncTests.kt
@@ -104,12 +104,7 @@ class AsymmetricSyncTests {
         }
         config = SyncConfiguration.Builder(
             user,
-            schema = setOf(
-                Measurement::class,
-                Device::class,
-                BackupDevice::class,
-                DeviceParent::class
-            )
+            schema = FLX_SYNC_SCHEMA
         ).initialSubscriptions {
             it.query<DeviceParent>().subscribe()
         }.build()
@@ -299,11 +294,7 @@ class AsymmetricSyncTests {
     fun asymmetricSchema() = runBlocking {
         config = SyncConfiguration.Builder(
             app.login(Credentials.anonymous()),
-            schema = setOf(
-                AsymmetricA::class,
-                EmbeddedB::class,
-                StandardC::class,
-            )
+            schema = FLX_SYNC_SCHEMA
         ).build()
         Realm.open(config).use {
             it.write {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
@@ -58,7 +58,6 @@ import kotlin.time.Duration.Companion.seconds
  */
 class FlexibleSyncIntegrationTests {
 
-    private val defaultSchema = setOf(FlexParentObject::class, FlexChildObject::class, FlexEmbeddedObject::class)
     private lateinit var app: TestApp
 
     @BeforeTest
@@ -83,7 +82,7 @@ class FlexibleSyncIntegrationTests {
 
         // Upload data from user 1
         val user1 = app.createUserAndLogIn(TestHelper.randomEmail(), "123456")
-        val config1 = SyncConfiguration.create(user1, defaultSchema)
+        val config1 = SyncConfiguration.create(user1, FLX_SYNC_SCHEMA)
         Realm.open(config1).use { realm1 ->
             val subs = realm1.subscriptions.update {
                 add(realm1.query<FlexParentObject>("section = $0", randomSection))
@@ -98,7 +97,7 @@ class FlexibleSyncIntegrationTests {
 
         // Download data from user 2
         val user2 = app.createUserAndLogIn(TestHelper.randomEmail(), "123456")
-        val config2 = SyncConfiguration.Builder(user2, defaultSchema)
+        val config2 = SyncConfiguration.Builder(user2, FLX_SYNC_SCHEMA)
             .initialSubscriptions { realm ->
                 add(
                     realm.query<FlexParentObject>(
@@ -119,7 +118,7 @@ class FlexibleSyncIntegrationTests {
     @Test
     fun writeFailsIfNoSubscription() = runBlocking {
         val user = app.createUserAndLogIn(TestHelper.randomEmail(), "123456")
-        val config = SyncConfiguration.Builder(user, defaultSchema)
+        val config = SyncConfiguration.Builder(user, FLX_SYNC_SCHEMA)
             .build()
 
         Realm.open(config).use { realm ->
@@ -137,7 +136,7 @@ class FlexibleSyncIntegrationTests {
         val randomSection = Random.nextInt() // Generate random section to allow replays of unit tests
 
         val user = app.createUserAndLogIn(TestHelper.randomEmail(), "123456")
-        val config = SyncConfiguration.Builder(user, defaultSchema).build()
+        val config = SyncConfiguration.Builder(user, FLX_SYNC_SCHEMA).build()
         Realm.open(config).use { realm ->
             realm.subscriptions.update {
                 val query = realm.query<FlexParentObject>()
@@ -162,7 +161,7 @@ class FlexibleSyncIntegrationTests {
 
     @Test
     fun initialSubscriptions_timeOut() {
-        val config = SyncConfiguration.Builder(app.currentUser!!, defaultSchema)
+        val config = SyncConfiguration.Builder(app.currentUser!!, FLX_SYNC_SCHEMA)
             .initialSubscriptions { realm ->
                 repeat(10) {
                     add(realm.query<FlexParentObject>("section = $0", it))
@@ -185,7 +184,7 @@ class FlexibleSyncIntegrationTests {
 
         // Prepare some user data
         val user1 = app.createUserAndLogin()
-        val config1 = SyncConfiguration.create(user1, defaultSchema)
+        val config1 = SyncConfiguration.create(user1, FLX_SYNC_SCHEMA)
         Realm.open(config1).use { realm ->
             realm.subscriptions.update {
                 add(realm.query<FlexParentObject>("section = $0", randomSection))
@@ -207,7 +206,7 @@ class FlexibleSyncIntegrationTests {
         // User 2 opens a Realm twice
         val counter = atomic(0)
         val user2 = app.createUserAndLogin()
-        val config2 = SyncConfiguration.Builder(user2, defaultSchema)
+        val config2 = SyncConfiguration.Builder(user2, FLX_SYNC_SCHEMA)
             .initialSubscriptions(rerunOnOpen = true) { realm ->
                 add(
                     realm.query<FlexParentObject>(
@@ -235,7 +234,7 @@ class FlexibleSyncIntegrationTests {
 
         // Upload data from user 1
         val user1 = app.createUserAndLogIn(TestHelper.randomEmail(), "123456")
-        val config1 = SyncConfiguration.create(user1, defaultSchema)
+        val config1 = SyncConfiguration.create(user1, FLX_SYNC_SCHEMA)
         Realm.open(config1).use { realm1 ->
             val subs = realm1.subscriptions.update {
                 add(realm1.query<FlexParentObject>("section = $0", randomSection))
@@ -273,7 +272,7 @@ class FlexibleSyncIntegrationTests {
 
         // Download data from user 2
         val user2 = app.createUserAndLogIn(TestHelper.randomEmail(), "123456")
-        val config2 = SyncConfiguration.Builder(user2, defaultSchema)
+        val config2 = SyncConfiguration.Builder(user2, FLX_SYNC_SCHEMA)
             .initialSubscriptions { realm ->
                 add(
                     realm.query<FlexParentObject>(
@@ -304,7 +303,7 @@ class FlexibleSyncIntegrationTests {
 
         val channel = Channel<CompensatingWriteException>(1)
 
-        val config1 = SyncConfiguration.Builder(user1, defaultSchema)
+        val config1 = SyncConfiguration.Builder(user1, FLX_SYNC_SCHEMA)
             .errorHandler { _: SyncSession, syncException: SyncException ->
                 runBlocking {
                     channel.send(syncException as CompensatingWriteException)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
@@ -22,7 +22,6 @@ import io.realm.kotlin.entities.sync.flx.FlexEmbeddedObject
 import io.realm.kotlin.entities.sync.flx.FlexParentObject
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.internal.platform.runBlocking
-import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.mongodb.exceptions.CompensatingWriteException
 import io.realm.kotlin.mongodb.exceptions.DownloadingRealmTimeOutException
 import io.realm.kotlin.mongodb.exceptions.SyncException

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
@@ -145,7 +145,7 @@ class FlexibleSyncIntegrationTests {
                     .query("(name = 'red' OR name = 'blue')")
                 add(query, "sub")
             }
-            assertTrue(realm.subscriptions.waitForSynchronization(120.seconds))
+            assertTrue(realm.subscriptions.waitForSynchronization(240.seconds))
             realm.write {
                 copyToRealm(FlexParentObject(randomSection).apply { name = "red" })
                 copyToRealm(FlexParentObject(randomSection).apply { name = "blue" })

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
@@ -64,7 +64,7 @@ class FlexibleSyncIntegrationTests {
 
     @BeforeTest
     fun setup() {
-        app = TestApp(this::class.simpleName, appName = TEST_APP_FLEX, logLevel = LogLevel.ALL)
+        app = TestApp(this::class.simpleName, appName = TEST_APP_FLEX)
         val (email, password) = TestHelper.randomEmail() to "password1234"
         runBlocking {
             app.createUserAndLogIn(email, password)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/MutableSubscriptionSetTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/MutableSubscriptionSetTests.kt
@@ -64,7 +64,7 @@ class MutableSubscriptionSetTests {
         }
         config = SyncConfiguration.Builder(
             user,
-            schema = setOf(FlexParentObject::class, FlexChildObject::class, FlexEmbeddedObject::class)
+            schema = FLX_SYNC_SCHEMA
         )
             .build()
         realm = Realm.open(config)
@@ -284,7 +284,7 @@ class MutableSubscriptionSetTests {
         // Not part of schema
         realm.subscriptions.update {
             assertFailsWith<IllegalArgumentException> {
-                removeAll(io.realm.kotlin.entities.sync.ParentPk::class)
+                removeAll(io.realm.kotlin.entities.Sample::class)
             }
         }
 

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/ProgressListenerTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/ProgressListenerTests.kt
@@ -61,8 +61,6 @@ import kotlin.time.Duration.Companion.seconds
 private const val TEST_SIZE = 500
 private val TIMEOUT = 30.seconds
 
-private val schema = setOf(SyncObjectWithAllTypes::class)
-
 class ProgressListenerTests {
 
     private lateinit var app: TestApp
@@ -242,7 +240,7 @@ class ProgressListenerTests {
     fun throwsOnFlexibleSync() = runBlocking {
         TestApp("throwsOnFlexibleSync", TEST_APP_FLEX).use {
             val user = app.createUserAndLogIn()
-            val configuration: SyncConfiguration = SyncConfiguration.create(user, schema)
+            val configuration: SyncConfiguration = SyncConfiguration.create(user, FLX_SYNC_SCHEMA)
             Realm.open(configuration).use { realm ->
                 assertFailsWithMessage<UnsupportedOperationException>(
                     "Progress listeners are not supported for Flexible Sync"
@@ -306,7 +304,7 @@ class ProgressListenerTests {
         user: User,
         partitionValue: String = getTestPartitionValue()
     ): SyncConfiguration {
-        return SyncConfiguration.Builder(user, partitionValue, schema)
+        return SyncConfiguration.Builder(user, partitionValue, io.realm.kotlin.test.mongodb.common.PARTITION_SYNC_SCHEMA)
             .build()
     }
 

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/Schema.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/Schema.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.kotlin.test.mongodb.common
+
+import io.realm.kotlin.entities.sync.ChildPk
+import io.realm.kotlin.entities.sync.ObjectIdPk
+import io.realm.kotlin.entities.sync.ParentPk
+import io.realm.kotlin.entities.sync.SyncObjectWithAllTypes
+import io.realm.kotlin.entities.sync.SyncPerson
+import io.realm.kotlin.entities.sync.flx.FlexChildObject
+import io.realm.kotlin.entities.sync.flx.FlexEmbeddedObject
+import io.realm.kotlin.entities.sync.flx.FlexParentObject
+
+private val ASYMMETRIC_CLASSES = setOf(
+    AsymmetricSyncTests.AsymmetricA::class,
+    AsymmetricSyncTests.EmbeddedB::class,
+    AsymmetricSyncTests.StandardC::class,
+    Measurement::class,
+)
+
+private val DEFAULT_CLASSES = setOf(
+    BackupDevice::class,
+    ChildPk::class,
+    Device::class,
+    DeviceParent::class,
+    FlexChildObject::class,
+    FlexEmbeddedObject::class,
+    FlexParentObject::class,
+    ObjectIdPk::class,
+    ParentPk::class,
+    SyncObjectWithAllTypes::class,
+    SyncPerson::class
+)
+
+val FLX_SYNC_SCHEMA = DEFAULT_CLASSES + ASYMMETRIC_CLASSES
+val PARTITION_SYNC_SCHEMA = DEFAULT_CLASSES

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SubscriptionExtensionsTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SubscriptionExtensionsTests.kt
@@ -17,8 +17,6 @@
 package io.realm.kotlin.test.mongodb.common
 
 import io.realm.kotlin.Realm
-import io.realm.kotlin.entities.sync.flx.FlexChildObject
-import io.realm.kotlin.entities.sync.flx.FlexEmbeddedObject
 import io.realm.kotlin.entities.sync.flx.FlexParentObject
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.internal.platform.runBlocking
@@ -45,7 +43,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.text.Typography.section
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -67,7 +64,7 @@ class SubscriptionExtensionsTests {
         }
         val config = SyncConfiguration.Builder(
             user,
-            schema = setOf(FlexParentObject::class, FlexChildObject::class, FlexEmbeddedObject::class)
+            schema = FLX_SYNC_SCHEMA
         )
             .build()
         realm = Realm.open(config)
@@ -136,7 +133,7 @@ class SubscriptionExtensionsTests {
         val user1 = app.createUserAndLogIn(email, password)
         val config = SyncConfiguration.Builder(
             user1,
-            schema = setOf(FlexParentObject::class, FlexChildObject::class, FlexEmbeddedObject::class)
+            schema = FLX_SYNC_SCHEMA
         ).initialSubscriptions { realm: Realm ->
             realm.query<FlexParentObject>("section = $0", section).subscribe()
         }.build()
@@ -394,7 +391,7 @@ class SubscriptionExtensionsTests {
 
     private suspend fun uploadServerData(sectionId: Int, noOfObjects: Int) {
         val user = app.createUserAndLogin()
-        val config = SyncConfiguration.Builder(user, setOf(FlexParentObject::class, FlexChildObject::class, FlexEmbeddedObject::class))
+        val config = SyncConfiguration.Builder(user, FLX_SYNC_SCHEMA)
             .initialSubscriptions {
                 it.query<FlexParentObject>().subscribe()
             }

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SubscriptionSetTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SubscriptionSetTests.kt
@@ -64,7 +64,7 @@ class SubscriptionSetTests {
         }
         val config = SyncConfiguration.Builder(
             user,
-            schema = setOf(FlexParentObject::class, FlexChildObject::class, FlexEmbeddedObject::class)
+            schema = FLX_SYNC_SCHEMA
         )
             .build()
         realm = Realm.open(config)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SubscriptionTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SubscriptionTests.kt
@@ -62,7 +62,7 @@ class SubscriptionTests {
         }
         val config = SyncConfiguration.Builder(
             user,
-            schema = setOf(ParentPk::class, ChildPk::class)
+            schema = FLX_SYNC_SCHEMA
         )
             .build()
         realm = Realm.open(config)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
@@ -681,13 +681,15 @@ class SyncClientResetIntegrationTests {
         }).build()
 
         runBlocking {
-            testRealm = Realm.open(config)
-            with(testRealm!!.syncSession) {
-                downloadAllServerChanges(defaultTimeout)
-                app.triggerClientReset(syncMode, this, user.id)
-                // Twice until the deprecated method is removed
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+            Realm.open(config).use { realm ->
+                testRealm = realm
+                with(realm.syncSession) {
+                    downloadAllServerChanges(defaultTimeout)
+                    app.triggerClientReset(syncMode, this, user.id)
+                    // Twice until the deprecated method is removed
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+                }
             }
         }
     }
@@ -994,19 +996,20 @@ class SyncClientResetIntegrationTests {
         ).build()
 
         runBlocking {
-            val realm = Realm.open(config)
-            with(realm.syncSession) {
-                downloadAllServerChanges(defaultTimeout)
-                app.triggerClientReset(syncMode, this, user.id)
-                val exception = channel.receiveOrFail()
-                val originalFilePath = assertNotNull(exception.originalFilePath)
-                val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
-                realm.close()
-                assertTrue(fileExists(originalFilePath))
-                assertFalse(fileExists(recoveryFilePath))
-                assertTrue(exception.executeClientReset())
-                assertFalse(fileExists(originalFilePath))
-                assertTrue(fileExists(recoveryFilePath))
+            Realm.open(config).use { realm ->
+                with(realm.syncSession) {
+                    downloadAllServerChanges(defaultTimeout)
+                    app.triggerClientReset(syncMode, this, user.id)
+                    val exception = channel.receiveOrFail()
+                    val originalFilePath = assertNotNull(exception.originalFilePath)
+                    val recoveryFilePath = assertNotNull(exception.recoveryFilePath)
+                    realm.close()
+                    assertTrue(fileExists(originalFilePath))
+                    assertFalse(fileExists(recoveryFilePath))
+                    assertTrue(exception.executeClientReset())
+                    assertFalse(fileExists(originalFilePath))
+                    assertTrue(fileExists(recoveryFilePath))
+                }
             }
         }
     }
@@ -1239,11 +1242,13 @@ class SyncClientResetIntegrationTests {
         }).build()
 
         runBlocking {
-            testRealm = Realm.open(config)
-            with(testRealm!!.syncSession) {
-                downloadAllServerChanges(defaultTimeout)
-                app.triggerClientReset(syncMode, this, user.id)
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+            Realm.open(config).use { realm ->
+                testRealm = realm
+                with(realm.syncSession) {
+                    downloadAllServerChanges(defaultTimeout)
+                    app.triggerClientReset(syncMode, this, user.id)
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+                }
             }
         }
     }
@@ -1440,11 +1445,13 @@ class SyncClientResetIntegrationTests {
         }).build()
 
         runBlocking {
-            testRealm = Realm.open(config)
-            with(testRealm!!.syncSession) {
-                downloadAllServerChanges(defaultTimeout)
-                app.triggerClientReset(syncMode, this, user.id)
-                assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+            Realm.open(config).use { realm ->
+                testRealm = realm
+                with(realm.syncSession) {
+                    downloadAllServerChanges(defaultTimeout)
+                    app.triggerClientReset(syncMode, this, user.id)
+                    assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
+                }
             }
         }
     }

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
@@ -1204,6 +1204,7 @@ class SyncClientResetIntegrationTests {
         val channel = Channel<ClientResetEvents>(2)
         val config = builder.syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
+                @Suppress("TooGenericExceptionThrown")
                 throw RuntimeException("Trigger onManualResetFallback")
             }
 
@@ -1400,6 +1401,7 @@ class SyncClientResetIntegrationTests {
         val channel = Channel<ClientResetEvents>(2)
         val config = builder.syncClientResetStrategy(object : RecoverOrDiscardUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
+                @Suppress("TooGenericExceptionThrown")
                 throw RuntimeException("Trigger onManualResetFallback")
             }
 

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
@@ -21,8 +21,6 @@ import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.entities.sync.SyncPerson
-import io.realm.kotlin.entities.sync.flx.FlexChildObject
-import io.realm.kotlin.entities.sync.flx.FlexEmbeddedObject
 import io.realm.kotlin.entities.sync.flx.FlexParentObject
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.internal.interop.ErrorCode
@@ -161,11 +159,7 @@ class SyncClientResetIntegrationTests {
                 configBuilderGenerator = { user ->
                     return@TestEnvironment SyncConfiguration.Builder(
                         user,
-                        setOf(
-                            FlexParentObject::class,
-                            FlexChildObject::class,
-                            FlexEmbeddedObject::class
-                        )
+                        FLX_SYNC_SCHEMA
                     ).initialSubscriptions { realm ->
                         realm.query<FlexParentObject>(
                             "section = $0 AND name = $1",
@@ -220,7 +214,7 @@ class SyncClientResetIntegrationTests {
                 return@TestEnvironment SyncConfiguration.Builder(
                     user,
                     TestHelper.randomPartitionValue(),
-                    schema = setOf(SyncPerson::class)
+                    schema = PARTITION_SYNC_SCHEMA
                 )
             },
             insertElement = { realm: Realm ->

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientTests.kt
@@ -56,7 +56,7 @@ class SyncClientTests {
     // There is no way to test reconnect automatically, so just verify that code path does not crash.
     @Test
     fun reconnect() {
-        val config = SyncConfiguration.create(user, schema = setOf())
+        val config = SyncConfiguration.create(user, schema = FLX_SYNC_SCHEMA)
         Realm.open(config).use {
             app.sync.reconnect()
         }
@@ -69,7 +69,7 @@ class SyncClientTests {
 
     @Test
     fun hasSyncSessions() {
-        val config = SyncConfiguration.create(user, schema = setOf())
+        val config = SyncConfiguration.create(user, schema = FLX_SYNC_SCHEMA)
         Realm.open(config).use {
             assertTrue(app.sync.hasSyncSessions)
         }
@@ -82,8 +82,8 @@ class SyncClientTests {
 
     @Test
     fun waitForSessionsToTerminate() {
-        val config1 = SyncConfiguration.Builder(user, schema = setOf()).build()
-        val config2 = SyncConfiguration.Builder(user, schema = setOf()).name("other.realm").build()
+        val config1 = SyncConfiguration.Builder(user, schema = FLX_SYNC_SCHEMA).build()
+        val config2 = SyncConfiguration.Builder(user, schema = FLX_SYNC_SCHEMA).name("other.realm").build()
 
         Realm.open(config1).use {
             assertTrue(app.sync.hasSyncSessions)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
@@ -105,7 +105,7 @@ class SyncConfigTests {
         val logger = createDefaultSystemLogger("TEST", LogLevel.DEBUG)
         val customLoggers = listOf(logger)
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).also { builder ->
@@ -124,7 +124,7 @@ class SyncConfigTests {
         }
         val user = createTestUser()
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).also { builder ->
@@ -137,7 +137,7 @@ class SyncConfigTests {
     fun errorHandler_default() {
         val user = createTestUser()
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).build()
@@ -150,7 +150,7 @@ class SyncConfigTests {
     fun compactOnLaunch_default() {
         val user = createTestUser()
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).build()
@@ -164,7 +164,7 @@ class SyncConfigTests {
         val user = createTestUser()
         val callback = CompactOnLaunchCallback { _, _ -> false }
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         )
@@ -186,7 +186,7 @@ class SyncConfigTests {
             )
         }
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = PARTITION_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         )
@@ -249,7 +249,7 @@ class SyncConfigTests {
             }
         }
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).syncClientResetStrategy(strategy)
@@ -277,7 +277,7 @@ class SyncConfigTests {
             }
         }
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).syncClientResetStrategy(strategy)
@@ -309,7 +309,7 @@ class SyncConfigTests {
             }
         }
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).syncClientResetStrategy(strategy)
@@ -321,7 +321,7 @@ class SyncConfigTests {
     fun equals_sameObject() {
         val user = createTestUser()
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).build()
@@ -374,7 +374,7 @@ class SyncConfigTests {
     fun equals_syncSpecificFields() {
         val user = createTestUser()
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).build()
@@ -532,7 +532,7 @@ class SyncConfigTests {
     fun encryption() {
         val user = createTestUser()
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).also { builder ->
@@ -759,7 +759,7 @@ class SyncConfigTests {
     fun getPartitionValue() {
         val user = createTestUser()
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).build()
@@ -1243,7 +1243,7 @@ class SyncConfigTests {
         }
 
         SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).build()

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncSessionTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncSessionTests.kt
@@ -258,13 +258,13 @@ class SyncSessionTests {
         val config1 = SyncConfiguration.Builder(
             user1,
             partitionValue,
-            schema = setOf(ParentPk::class, ChildPk::class)
+            schema = FLX_SYNC_SCHEMA
         ).name("user1.realm")
             .build()
         val config2 = SyncConfiguration.Builder(
             user2,
             partitionValue,
-            schema = setOf(ParentPk::class, ChildPk::class)
+            schema = FLX_SYNC_SCHEMA
         ).name("user2.realm")
             .build()
 
@@ -320,7 +320,7 @@ class SyncSessionTests {
         val user = app.createUserAndLogIn(email, password)
         val channel = Channel<SyncSession>(1)
         val config = SyncConfiguration.Builder(
-            schema = setOf(ParentPk::class, ChildPk::class),
+            schema = PARTITION_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).errorHandler { session, _ ->
@@ -382,7 +382,7 @@ class SyncSessionTests {
     @Test
     fun syncingObjectIdFromMongoDB() = runBlocking {
         val adminApi = app.asTestApp
-        val config = SyncConfiguration.Builder(user, partitionValue, schema = setOf(ObjectIdPk::class)).build()
+        val config = SyncConfiguration.Builder(user, partitionValue, schema = PARTITION_SYNC_SCHEMA).build()
         Realm.open(config).use { realm ->
             val json: JsonObject = adminApi.insertDocument(
                 ObjectIdPk::class.simpleName!!,
@@ -427,7 +427,7 @@ class SyncSessionTests {
             val config = SyncConfiguration.Builder(
                 user,
                 partitionValue,
-                schema = setOf(ObjectIdPk::class)
+                schema = PARTITION_SYNC_SCHEMA
             )
                 .build()
             Realm.open(config).use { realm ->
@@ -473,6 +473,7 @@ class SyncSessionTests {
         }
     }
 
+    @Ignore // TODO Find another way to test with with developer mode v2
     @Test
     fun getConfiguration_inErrorHandlerThrows() = runBlocking {
         // Open and close a realm with a schema.
@@ -480,7 +481,7 @@ class SyncSessionTests {
         val (email, password) = TestHelper.randomEmail() to "password1234"
         val user = app.createUserAndLogIn(email, password)
         val config1 = SyncConfiguration.Builder(
-            schema = setOf(ChildPk::class),
+            schema = FLX_SYNC_SCHEMA,
             user = user,
             partitionValue = partitionValue
         ).name("test1.realm").build()

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/nonlatin/NonLatinTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/nonlatin/NonLatinTests.kt
@@ -8,6 +8,7 @@ import io.realm.kotlin.mongodb.User
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
+import io.realm.kotlin.test.mongodb.common.PARTITION_SYNC_SCHEMA
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
@@ -54,7 +55,7 @@ class NonLatinTests {
     @Test
     fun readNullCharacterFromMongoDB() = runBlocking {
         val adminApi = app.asTestApp
-        val config = SyncConfiguration.Builder(user, partitionValue, schema = setOf(ObjectIdPk::class)).build()
+        val config = SyncConfiguration.Builder(user, partitionValue, schema = PARTITION_SYNC_SCHEMA).build()
         Realm.open(config).use { realm ->
             val json: JsonObject = adminApi.insertDocument(
                 ObjectIdPk::class.simpleName!!,


### PR DESCRIPTION
This PR fixes some problems I discovered on Windows.

- During Client Reset we were not closing a realm instance correctly, which will prevent the Realm file from being deleted later. This fixed most of our Client Reset Tests on Windows, which all timed out during tearDown.
- Manually closing the SyncSession Pointer when closing the Realm make shutdown more predictable. Before this, it was GC dependant.
- I switched to a more accurate pattern for testing client resets rather than us "faking" it.
- I haven't added a changelog entry since we are still leaking something during a manual client reset. I'm still trying to hunt that one down.