### PR TITLE
Fix `numberOfActiveVersions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.11.2 (YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixed
+* `Realm.getNumberOfActiveVersions` now returns the actual number of active versions. (Core issue [#6960](https://github.com/realm/realm-core/pull/6960))
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.8.0 and above. The K2 compiler is not supported yet.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.7.0 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Kbson 0.3.0.
+* Minimum Gradle version: 6.8.3.
+* Minimum Android Gradle Plugin version: 4.1.3.
+* Minimum Android SDK: 16.
+
+### Internal
+* Updated to Realm Core 13.20.0, commit a3717e492ec606e42995169cf706a82fc1cd0698.
+
+
 ## 1.11.1 (2023-09-07)
 
 ### Enhancements


### PR DESCRIPTION
`getNumberOfActiveVersions` did not return the actual number of active versions but the difference between the earliest and latest opened versions.

With this PR we include the core fix for this issue, `getNumberOfActiveVersions` would return the actual number of active versions.