### PR TITLE
Fix redirects only working for GET requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* [Sync] If calling a function on App Services that resulted in a redirect, it would only redirect for GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/HttpClientCache.kt
@@ -2,6 +2,7 @@ package io.realm.kotlin.mongodb.internal
 
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpRedirect
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -34,7 +35,9 @@ internal fun createClient(timeoutMs: Long, customLogger: Logger?): HttpClient {
             }
         }
 
-        followRedirects = true
+        install(HttpRedirect) {
+            checkHttpMethod = false
+        }
     }
 }
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/HttpClientCache.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/HttpClientCache.kt
@@ -35,6 +35,8 @@ internal fun createClient(timeoutMs: Long, customLogger: Logger?): HttpClient {
             }
         }
 
+        // We should allow redirects for all types, not just GET and HEAD
+        // See https://github.com/ktorio/ktor/issues/1793
         install(HttpRedirect) {
             checkHttpMethod = false
         }

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/HttpClient.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/util/HttpClient.kt
@@ -18,6 +18,7 @@ package io.realm.kotlin.test.mongodb.util
 
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpRedirect
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.Logger
@@ -65,7 +66,11 @@ fun defaultClient(name: String, debug: Boolean, block: HttpClientConfig<*>.() ->
             }
         }
 
-        followRedirects = true
+        // We should allow redirects for all types, not just GET and HEAD
+        // See https://github.com/ktorio/ktor/issues/1793
+        install(HttpRedirect) {
+            checkHttpMethod = false
+        }
 
         // TODO connectionPool?
         this.apply(block)


### PR DESCRIPTION
Discovered this while testing a Windows build against a production server.

Our local dev server does not cause redirects, so I don't think there is a way to add a test for this. The fix was verified manually on both JVM and Darwin.