### PR TITLE
Fix darwin native leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * `Realm.getNumberOfActiveVersions` now returns the actual number of active versions. (Core issue [#6960](https://github.com/realm/realm-core/pull/6960))
+* Fix a memory leak on the Darwin native platform, see PR for more information. (Issue [#1530](https://github.com/realm/realm-kotlin/pull/1530))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * `Realm.getNumberOfActiveVersions` now returns the actual number of active versions. (Core issue [#6960](https://github.com/realm/realm-core/pull/6960))
-* Fix a memory leak on the Darwin native platform, see PR for more information. (Issue [#1530](https://github.com/realm/realm-kotlin/pull/1530))
+* Fixed memory leak on Darwin caused by a reference cycle between resources and the GC cleaner. (Issue [#1530](https://github.com/realm/realm-kotlin/pull/1530))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -111,7 +111,6 @@ import realm_wrapper.realm_property_info_t
 import realm_wrapper.realm_query_arg_t
 import realm_wrapper.realm_release
 import realm_wrapper.realm_results_t
-import realm_wrapper.realm_scheduler_notify_func_t
 import realm_wrapper.realm_scheduler_t
 import realm_wrapper.realm_set_t
 import realm_wrapper.realm_string_t
@@ -160,11 +159,22 @@ private fun <T : CPointed> checkedPointerResult(pointer: CPointer<T>?): CPointer
     if (pointer == null) throwOnError(); return pointer
 }
 
-// FIXME API-INTERNAL Consider making NativePointer/CPointerWrapper generic to enforce typing
+/**
+ * Class with a pointer reference and its status. It breaks the reference cycle between CPointerWrapper
+ * and its GC cleaner, otherwise the cleaner would never be invoked.
+ *
+ * See leaking cleaner: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.native.ref/create-cleaner.html
+ */
+data class ReleasablePointer(
+    private val _ptr: CPointer<out CPointed>?,
+    val released: AtomicBoolean = atomic(false)
+) {
+    fun release() {
+        if (released.compareAndSet(expect = false, update = true)) {
+            realm_release(_ptr)
+        }
+    }
 
-class CPointerWrapper<T : CapiT>(ptr: CPointer<out CPointed>?, managed: Boolean = true) : NativePointer<T> {
-    private val released: AtomicBoolean = atomic(false)
-    private val _ptr = checkedPointerResult(ptr)
     val ptr: CPointer<out CPointed>?
         get() {
             return if (!released.value) {
@@ -173,23 +183,28 @@ class CPointerWrapper<T : CapiT>(ptr: CPointer<out CPointed>?, managed: Boolean 
                 throw POINTER_DELETED_ERROR
             }
         }
+}
+
+// FIXME API-INTERNAL Consider making NativePointer/CPointerWrapper generic to enforce typing
+class CPointerWrapper<T : CapiT>(ptr: CPointer<out CPointed>?, managed: Boolean = true) : NativePointer<T> {
+    val _ptr = ReleasablePointer(
+        checkedPointerResult(ptr)
+    )
+
+    val ptr: CPointer<out CPointed>? = _ptr.ptr
 
     @OptIn(ExperimentalStdlibApi::class)
     val cleaner = if (managed) {
         createCleaner(_ptr) {
-            if (released.compareAndSet(expect = false, update = true)) {
-                realm_release(ptr)
-            }
+            it.release()
         }
     } else null
 
     override fun release() {
-        if (released.compareAndSet(expect = false, update = true)) {
-            realm_release(_ptr)
-        }
+        _ptr.release()
     }
 
-    override fun isReleased(): Boolean = released.value
+    override fun isReleased(): Boolean = _ptr.released.value
 }
 
 // Convenience type cast
@@ -582,7 +597,7 @@ actual object RealmInterop {
             )
         ) ?: error("Couldn't create scheduler")
 
-        scheduler.set_scheduler(capi_scheduler)
+        scheduler.setScheduler(capi_scheduler)
 
         return CPointerWrapper<RealmSchedulerT>(capi_scheduler)
     }
@@ -3378,11 +3393,6 @@ actual object RealmInterop {
         }
     }
 
-    data class CoreCallback(
-        val callback: realm_scheduler_notify_func_t,
-        val callbackUserdata: CPointer<out CPointed>,
-    )
-
     interface Scheduler {
         fun notify()
     }
@@ -3391,15 +3401,11 @@ actual object RealmInterop {
         val threadId: ULong,
         dispatcher: CoroutineDispatcher
     ) : Scheduler {
-        val scope: CoroutineScope = CoroutineScope(dispatcher)
-        val ref: CPointer<out CPointed>
-        lateinit var scheduler: CPointer<realm_scheduler_t>
+        private val scope: CoroutineScope = CoroutineScope(dispatcher)
+        val ref: CPointer<out CPointed> = StableRef.create(this).asCPointer()
+        private lateinit var scheduler: CPointer<realm_scheduler_t>
 
-        init {
-            ref = StableRef.create(this).asCPointer()
-        }
-
-        fun set_scheduler(scheduler: CPointer<realm_scheduler_t>) {
+        fun setScheduler(scheduler: CPointer<realm_scheduler_t>) {
             this.scheduler = scheduler
         }
 

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/SynchronizableObjectDarwin.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/SynchronizableObjectDarwin.kt
@@ -32,9 +32,9 @@ actual class SynchronizableObject {
     private val mutex = nativeHeap.alloc<native_pthread_mutex_t>()
 
     @OptIn(ExperimentalStdlibApi::class)
-    private val cleaner = createCleaner(mutex) {
-        native_pthread_mutex_destroy(mutex.ptr)
-        nativeHeap.free(mutex)
+    private val cleaner = createCleaner(mutex) { capturedMutex ->
+        native_pthread_mutex_destroy(capturedMutex.ptr)
+        nativeHeap.free(capturedMutex)
     }
 
     init {


### PR DESCRIPTION
A reference cycle between `CPointerWrapper` and its cleaner was causing a leak were the GC was not reclaiming any native memory. 

This PR breaks the cycle by moving the `CPointerWrapper` and cleaner shared data into a new data class.

See [LeakingCleaner](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.native.ref/create-cleaner.html).