### PR TITLE
Remove dependency on KAPT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * None.
 
 ### Enhancements
-* Realm will no longer set the JVM bytecode to 1.8 when applying the Realm plugin. ([#1513](https://github.com/realm/realm-kotlin/issues/1513))
+* Realm will no longer set the JVM bytecode to 1.8 when applying the Realm plugin. (Issue [#1513](https://github.com/realm/realm-kotlin/issues/1513))
+* The Realm Gradle Plugin no longer has a dependency on KAPT. (Issue [#1513](https://github.com/realm/realm-kotlin/issues/1513))
 
 ### Fixed
 * `Realm.close()` is now idempotent.

--- a/packages/gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/build.gradle.kts
@@ -17,7 +17,6 @@ import kotlin.text.toBoolean
 
 plugins {
     kotlin("jvm")
-    kotlin("kapt")
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version Versions.gradlePluginPublishPlugin
     id("realm-publisher")


### PR DESCRIPTION
Closes #1513 

Fixes the error in #1513, but it will just move the error to another. Most likely 

```
> 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlinAndroid' task (current target is 17) jvm target compatibility should be set to the same Java version.
  Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```

