### PR TITLE
Bump core to version 13.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
 * Minimum Android SDK: 16.
 
 ### Internal
-* Updated to Realm Core 13.23.0, commit f8604b9fd3d2982008a1d3f5ff35e52ee9098d5b.
+* Updated to Realm Core 13.23.1, commit c569bec4d04da84030d94f376437bc4efda3686b.
 
 
 ## 1.11.1 (2023-09-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.12.0-SNAPSHOT (YYYY-MM-DD)
 
-To downgrade a Sync app from this version, you'll need to manually delete the metadata folder located at `$[SYNC-ROOT-DIRECTORY]/mongodb-realm/[APP-ID]/server-utility/metadata/`.
+This release upgrades the Sync metadata in a way that is not compatible with older versions. To downgrade a Sync app from this version, you'll need to manually delete the metadata folder located at `$[SYNC-ROOT-DIRECTORY]/mongodb-realm/[APP-ID]/server-utility/metadata/`. This will log out all users.
 
 ### Breaking Changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
 * Minimum Android SDK: 16.
 
 ### Internal
-* None.
+* Updated to Realm Core 13.23.0, commit f8604b9fd3d2982008a1d3f5ff35e52ee9098d5b.
 
 
 ## 1.11.1 (2023-09-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.12.0-SNAPSHOT (YYYY-MM-DD)
 
+To downgrade a Sync app from this version, you'll need to manually delete the metadata folder located at `$[SYNC-ROOT-DIRECTORY]/mongodb-realm/[APP-ID]/server-utility/metadata/`.
+
 ### Breaking Changes
 * None.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
 * Minimum Android SDK: 16.
 
 ### Internal
-* Updated to Realm Core 13.23.1, commit c569bec4d04da84030d94f376437bc4efda3686b.
+* Updated to Realm Core 13.23.1, commit 3618b2e9d679cd2880be8df17b79d4cc6d71ff76.
 
 
 ## 1.11.1 (2023-09-07)

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,11 +1,11 @@
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2023-09-22
+MONGODB_REALM_SERVER=2023-10-10
 
 # `BAAS` and `BAAS-UI` projects commit hashes matching MONGODB_REALM_SERVER image version
 # note that the MONGODB_REALM_SERVER image is a nightly build, find the matching commits
 # for that date within the following repositories:
 # https://github.com/10gen/baas/
 # https://github.com/10gen/baas-ui/
-REALM_BAAS_GIT_HASH=0b7562d0401d72c909369030dc29332542614ba3
-REALM_BAAS_UI_GIT_HASH=24baee4eb0e9736969a00a7bfac849565bca17f4
+REALM_BAAS_GIT_HASH=8246fc548763eb908b8090df864e9924e3330a0d
+REALM_BAAS_UI_GIT_HASH=8a1843be2bf24f2faa705c5470a5bdd8d954f7ea

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -534,7 +534,6 @@ expect object RealmInterop {
     // User
     fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity>
     fun realm_user_get_identity(user: RealmUserPointer): String
-    fun realm_user_get_auth_provider(user: RealmUserPointer): AuthProvider
     fun realm_user_get_access_token(user: RealmUserPointer): String
     fun realm_user_get_refresh_token(user: RealmUserPointer): String
     fun realm_user_get_device_id(user: RealmUserPointer): String

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1114,10 +1114,6 @@ actual object RealmInterop {
         return realmc.realm_user_get_identity(user.cptr())
     }
 
-    actual fun realm_user_get_auth_provider(user: RealmUserPointer): AuthProvider {
-        return AuthProvider.of(realmc.realm_user_get_auth_provider(user.cptr()))
-    }
-
     actual fun realm_user_get_access_token(user: RealmUserPointer): String {
         return realmc.realm_user_get_access_token(user.cptr())
     }

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -2287,10 +2287,6 @@ actual object RealmInterop {
         return realm_wrapper.realm_user_get_identity(user.cptr()).safeKString("identity")
     }
 
-    actual fun realm_user_get_auth_provider(user: RealmUserPointer): AuthProvider {
-        return AuthProvider.of(realm_wrapper.realm_user_get_auth_provider(user.cptr()))
-    }
-
     actual fun realm_user_is_logged_in(user: RealmUserPointer): Boolean {
         return realm_wrapper.realm_user_is_logged_in(user.cptr())
     }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
@@ -83,7 +83,7 @@ public interface User {
      * Returns the provider type used to log the user in.
      * If a user logs out, the authentication provider last used to log the user in will still be returned.
      */
-    @Deprecated("Property not stable, users might have multiple providers.", ReplaceWith("identities"))
+    @Deprecated("Users might have multiple providers. This will return the provider of the first identity of the user", ReplaceWith("identities"))
     public val provider: AuthenticationProvider
 
     /**

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/User.kt
@@ -83,6 +83,7 @@ public interface User {
      * Returns the provider type used to log the user in.
      * If a user logs out, the authentication provider last used to log the user in will still be returned.
      */
+    @Deprecated("Property not stable, users might have multiple providers.", ReplaceWith("identities"))
     public val provider: AuthenticationProvider
 
     /**

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/UserImpl.kt
@@ -49,7 +49,7 @@ public class UserImpl(
     override val loggedIn: Boolean
         get() = RealmInterop.realm_user_is_logged_in(nativePointer)
     override val provider: AuthenticationProvider
-        get() = AuthenticationProviderImpl.fromId(RealmInterop.realm_user_get_auth_provider(nativePointer))
+        get() = identities.first().provider
     override val accessToken: String
         get() = RealmInterop.realm_user_get_access_token(nativePointer)
     override val refreshToken: String

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
@@ -23,7 +23,6 @@ import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.internal.ConfigurationImpl
 import io.realm.kotlin.internal.ContextLogger
 import io.realm.kotlin.internal.ObjectIdImpl
-import io.realm.kotlin.internal.REALM_FILE_EXTENSION
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.SchemaMode
 import io.realm.kotlin.internal.platform.PATH_SEPARATOR
@@ -606,12 +605,7 @@ public interface SyncConfiguration : Configuration {
                 )
             }
 
-            // Remove .realm extension if user has overridden filename manually
-            return if (name != null) {
-                absolutePath.removeSuffix(REALM_FILE_EXTENSION)
-            } else {
-                absolutePath
-            }
+            return absolutePath
         }
     }
 

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmTests.kt
@@ -441,7 +441,7 @@ class RealmTests {
     @Suppress("LongMethod")
     fun deleteRealm() {
         val fileSystem = FileSystem.SYSTEM
-        val testDir = PlatformUtils.createTempDir("test_dir")
+        val testDir = PlatformUtils.createTempDir()
         val testDirPath = testDir.toPath()
         assertTrue(fileSystem.exists(testDirPath))
 
@@ -510,7 +510,7 @@ class RealmTests {
     @Test
     fun deleteRealm_fileDoesNotExists() {
         val fileSystem = FileSystem.SYSTEM
-        val testDir = PlatformUtils.createTempDir("test_dir")
+        val testDir = PlatformUtils.createTempDir()
         val configuration = RealmConfiguration.Builder(schema = setOf(Parent::class, Child::class))
             .directory(testDir)
             .build()

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
@@ -391,7 +391,7 @@ class AppTests {
             Realm.open(syncConfig).close()
 
             // Create a configuration pointing to the metadata Realm for that app
-            val lastSetSchemaVersion = 6L
+            val lastSetSchemaVersion = 7L
             val metadataDir = "${app.configuration.syncRootDirectory}/mongodb-realm/${app.configuration.appId}/server-utility/metadata/"
             val config = RealmConfiguration
                 .Builder(setOf())

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
@@ -331,7 +331,7 @@ class FlexibleSyncIntegrationTests {
 
             val exception: CompensatingWriteException = channel.receiveOrFail()
 
-            assertTrue(exception.message!!.startsWith("[Sync][CompensatingWrite(1033)] Client attempted a write that is outside of permissions or query filters; it has been reverted Logs:"), exception.message)
+            assertTrue(exception.message!!.startsWith("[Sync][CompensatingWrite(1033)] Client attempted a write that is not allowed; it has been reverted Logs:"), exception.message)
             assertEquals(1, exception.writes.size)
 
             exception.writes[0].run {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
@@ -133,6 +133,7 @@ class SyncClientResetIntegrationTests {
 
                 block(syncMode, app, user, configBuilderGenerator(user))
             } finally {
+                logChannel.close()
                 app.close()
             }
         }
@@ -442,10 +443,11 @@ class SyncClientResetIntegrationTests {
 
                 // Validate Realm instance has been correctly updated
                 assertEquals(0, objectChannel.receiveOrFail().list.size)
-
+                objectChannel.close()
                 job.cancel()
             }
         }
+        channel.close()
     }
 
     @Test
@@ -540,10 +542,11 @@ class SyncClientResetIntegrationTests {
 
                 // Validate Realm instance has been correctly updated
                 assertEquals(1, objectChannel.receiveOrFail().list.size)
-
+                objectChannel.close()
                 job.cancel()
             }
         }
+        channel.close()
     }
 
     @Test
@@ -615,6 +618,7 @@ class SyncClientResetIntegrationTests {
                 }
             }
         }
+        channel.close()
     }
 
     @Test
@@ -690,6 +694,7 @@ class SyncClientResetIntegrationTests {
                 }
             }
         }
+        channel.close()
     }
 
     @Test
@@ -763,6 +768,8 @@ class SyncClientResetIntegrationTests {
                 assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
             }
         }
+
+        channel.close()
     }
 
     @Test
@@ -850,6 +857,7 @@ class SyncClientResetIntegrationTests {
                 assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
             }
         }
+        channel.close()
     }
 
     // ---------------------------------------------------------------------------------------
@@ -958,6 +966,7 @@ class SyncClientResetIntegrationTests {
                 }
             }
         }
+        channel.close()
     }
 
     @Test
@@ -1010,6 +1019,7 @@ class SyncClientResetIntegrationTests {
                 }
             }
         }
+        channel.close()
     }
 
     // ---------------------------------------------------------------------------------------
@@ -1070,6 +1080,7 @@ class SyncClientResetIntegrationTests {
                 assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receiveOrFail())
             }
         }
+        channel.close()
     }
 
     @Test
@@ -1121,6 +1132,7 @@ class SyncClientResetIntegrationTests {
                 assertTrue(exception.message!!.contains("Simulate Client Reset"))
             }
         }
+        channel.close()
     }
 
     @Test
@@ -1179,6 +1191,7 @@ class SyncClientResetIntegrationTests {
                 assertEquals(ClientResetEvents.ON_MANUAL_RESET_FALLBACK, channel.receiveOrFail())
             }
         }
+        channel.close()
     }
 
     @Test
@@ -1249,6 +1262,7 @@ class SyncClientResetIntegrationTests {
                 }
             }
         }
+        channel.close()
     }
 
     // ---------------------------------------------------------------------------------------
@@ -1311,6 +1325,7 @@ class SyncClientResetIntegrationTests {
                 assertEquals(ClientResetEvents.ON_AFTER_RECOVERY, channel.receiveOrFail())
             }
         }
+        channel.close()
     }
 
     @Test
@@ -1378,6 +1393,7 @@ class SyncClientResetIntegrationTests {
                 assertEquals(ClientResetEvents.ON_AFTER_DISCARD, channel.receiveOrFail())
             }
         }
+        channel.close()
     }
 
     @Test
@@ -1452,5 +1468,6 @@ class SyncClientResetIntegrationTests {
                 }
             }
         }
+        channel.close()
     }
 }

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
@@ -531,7 +531,11 @@ class SyncClientResetIntegrationTests {
                 assertEquals(ClientResetEvents.ON_BEFORE_RESET, channel.receiveOrFail())
                 assertEquals(ClientResetEvents.ON_AFTER_RESET, channel.receiveOrFail())
 
-                // TODO We must not need this. Force updating the instance pointer.
+                // Object count down to 0 just after the reset
+                assertEquals(0, objectChannel.receiveOrFail().list.size)
+
+                // TODO https://github.com/realm/realm-core/issues/7065
+                // We must not need this. Force updating the instance pointer.
                 realm.write { }
 
                 // Validate Realm instance has been correctly updated

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
@@ -1261,8 +1261,8 @@ class SyncConfigTests {
         val config: SyncConfiguration = SyncConfiguration.Builder(user, partitionValue, setOf())
             .name(fileName)
             .build()
-        val suffix = pathOf("", "mongodb-realm", user.app.configuration.appId, user.id, fileName)
+        val suffix = pathOf("", "mongodb-realm", user.app.configuration.appId, user.id, "$fileName.realm")
         assertTrue(config.path.endsWith(suffix), "${config.path} failed.")
-        assertEquals(fileName, config.name, "${config.name} failed.")
+        assertEquals("$fileName.realm", config.name, "${config.name} failed.")
     }
 }

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncConfigTests.kt
@@ -1261,8 +1261,11 @@ class SyncConfigTests {
         val config: SyncConfiguration = SyncConfiguration.Builder(user, partitionValue, setOf())
             .name(fileName)
             .build()
-        val suffix = pathOf("", "mongodb-realm", user.app.configuration.appId, user.id, "$fileName.realm")
+
+        val expectedFilename = if (fileName.endsWith(".realm")) fileName else "$fileName.realm"
+
+        val suffix = pathOf("", "mongodb-realm", user.app.configuration.appId, user.id, expectedFilename)
         assertTrue(config.path.endsWith(suffix), "${config.path} failed.")
-        assertEquals("$fileName.realm", config.name, "${config.name} failed.")
+        assertEquals(expectedFilename, config.name, "${config.name} failed.")
     }
 }


### PR DESCRIPTION
Bumps core to version 13.23.0.

Core has removed `realm_user_get_auth_provider`, in reaction to this we have annotated `User.provider` as deprecated and now returns the first element auth provider at `User.identities`.