### PR TITLE
Fix new temp dirs not different on native

### DIFF
--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/utils/PlatformUtilsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/utils/PlatformUtilsTests.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.kotlin.test.common.utils
+
+import io.realm.kotlin.internal.platform.directoryExists
+import io.realm.kotlin.test.platform.PlatformUtils
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class PlatformUtilsTests {
+    @Test
+    fun createTempDir_createDifferentDirs() {
+        val testDir1 = PlatformUtils.createTempDir("test-dir")
+        val testDir2 = PlatformUtils.createTempDir("test-dir")
+
+        assertTrue(directoryExists(testDir1))
+        assertTrue(directoryExists(testDir2))
+
+        assertNotEquals(testDir1, testDir2)
+    }
+
+    @Test
+    fun createTempDir_deleteDifferentDirs() {
+        val testDir = PlatformUtils.createTempDir("test-dir")
+        assertTrue(directoryExists(testDir))
+        PlatformUtils.deleteTempDir(testDir)
+        assertFalse(directoryExists(testDir))
+    }
+}

--- a/packages/test-base/src/nativeDarwin/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/nativeDarwin/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -16,6 +16,7 @@
 
 package io.realm.kotlin.test.platform
 
+import io.realm.kotlin.test.util.Utils
 import kotlinx.cinterop.ULongVar
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.cValue
@@ -35,7 +36,8 @@ import kotlin.time.Duration
 actual object PlatformUtils {
     actual fun createTempDir(prefix: String, readOnly: Boolean): String {
         // X is a special char which will be replace by mkdtemp template
-        val mask = prefix.replace('X', 'Z', ignoreCase = true)
+        val suffix = "-${Utils.createRandomString(4)}"
+        val mask = prefix.plus(suffix).replace('X', 'Z', ignoreCase = true)
         val path = "${platform.Foundation.NSTemporaryDirectory()}$mask"
         platform.posix.mkdtemp(path.cstr)
         if (readOnly) {


### PR DESCRIPTION
Creating two temporary directories in native with the same prefix value via `PlatformUtils.createTempDir` would result in the same directory, JVM would result in different directories.

This incongruence might cause issues while writing test cases.