### PR TITLE
Delete local references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 * Fix craches caused by posting to a released scheduler. (Issue [#1543](https://github.com/realm/realm-kotlin/issues/1543))
-* [Sync] Fix crash while syncing data when LogLevel was set to `Trace` or `All`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560))
+* [Sync] Fix crash when syncing data if the log level was set to `LogLevel.TRACE` or `LogLevel.ALL`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 * Fix craches caused by posting to a released scheduler. (Issue [#1543](https://github.com/realm/realm-kotlin/issues/1543))
 * Fix NPE when applying query aggregators on classes annotated with `@PersistedName`. (Issue [1569](https://github.com/realm/realm-kotlin/pull/1569))
-* [Sync] Fix crash when syncing data if the log level was set to `LogLevel.TRACE` or `LogLevel.ALL`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560))
+* [Sync] Fix crash when syncing data if the log level was set to `LogLevel.TRACE` or `LogLevel.ALL`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560)) 
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.12.1 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None
+
+### Fixed
+* [Sync] Fix crash while syncing data when LogLevel was set to `Trace` or `All`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560))
+
+### Compatibility
+* File format: Generates Realms with file format v23.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* This release is compatible with the following Kotlin releases:
+  * Kotlin 1.8.0 and above. The K2 compiler is not supported yet.
+  * Ktor 2.1.2 and above.
+  * Coroutines 1.7.0 and above.
+  * AtomicFu 0.18.3 and above.
+  * The new memory model only. See https://github.com/realm/realm-kotlin#kotlin-memory-model-and-coroutine-compatibility
+* Minimum Kbson 0.3.0.
+* Minimum Gradle version: 6.8.3.
+* Minimum Android Gradle Plugin version: 4.1.3.
+* Minimum Android SDK: 16.
+
+
 ## 1.12.0 (2023-11-02)
 
 This release upgrades the Sync metadata in a way that is not compatible with older versions. To downgrade a Sync app from this version, you'll need to manually delete the metadata folder located at `$[SYNC-ROOT-DIRECTORY]/mongodb-realm/[APP-ID]/server-utility/metadata/`. This will log out all users.
@@ -22,7 +48,6 @@ This release upgrades the Sync metadata in a way that is not compatible with old
 * [Sync] If calling a function on App Services that resulted in a redirect, it would only redirect for 
 GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
 * [Sync] If calling a function on App Services that resulted in a redirect, it would only redirect for GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
-* [Sync] Fix crash while syncing data when LogLevel was set to `Trace` or `All`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 * None.
 
 ### Enhancements
-* None
+* None.
 
 ### Fixed
 * Fix craches caused by posting to a released scheduler. (Issue [#1543](https://github.com/realm/realm-kotlin/issues/1543))
 * Fix NPE when applying query aggregators on classes annotated with `@PersistedName`. (Issue [1569](https://github.com/realm/realm-kotlin/pull/1569))
-* [Sync] Fix crash when syncing data if the log level was set to `LogLevel.TRACE` or `LogLevel.ALL`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560)) 
+* [Sync] Fix crash when syncing data if the log level was set to `LogLevel.TRACE` or `LogLevel.ALL`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This release upgrades the Sync metadata in a way that is not compatible with old
 * [Sync] If calling a function on App Services that resulted in a redirect, it would only redirect for 
 GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
 * [Sync] If calling a function on App Services that resulted in a redirect, it would only redirect for GET requests. (Issue [#1517](https://github.com/realm/realm-kotlin/pull/1517))
+* [Sync] Fix crash while syncing data when LogLevel was set to `Trace` or `All`. (Issue [#1560](https://github.com/realm/realm-kotlin/pull/1560))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -139,7 +139,7 @@ bool migration_callback(void *userdata, realm_t *old_realm, realm_t *new_realm,
     static JavaClass java_callback_class(env, "io/realm/kotlin/internal/interop/MigrationCallback");
     static JavaMethod java_callback_method(env, java_callback_class, "migrate",
                                            "(Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;Lio/realm/kotlin/internal/interop/NativePointer;)V");
-    // These realm/schema pointers are only valid for the duraction of the
+    // These realm/schema pointers are only valid for the duration of the
     // migration so don't let ownership follow the NativePointer-objects
     env->PushLocalFrame(3);
     env->CallVoidMethod(static_cast<jobject>(userdata), java_callback_method,
@@ -147,9 +147,9 @@ bool migration_callback(void *userdata, realm_t *old_realm, realm_t *new_realm,
                         wrap_pointer(env, reinterpret_cast<jlong>(new_realm), false),
                         wrap_pointer(env, reinterpret_cast<jlong>(schema))
     );
-    jni_check_exception(env, true);
+    bool failed = jni_check_exception(env, true);
     env->PopLocalFrame(NULL);
-    return jni_check_exception(env);
+    return failed;
 }
 
 // TODO OPTIMIZE Abstract pattern for all notification registrations for collections that receives

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -38,13 +38,16 @@ inline jboolean jni_check_exception(JNIEnv *jenv = get_env(), bool registrable_c
     // FIXME https://github.com/realm/realm-kotlin/issues/665 This function is catching and swallowing
     //  the exception. This behavior could leave the SDK in an illegal state.
     if (jenv->ExceptionCheck()) {
-        // Print the exception stacktrace in stderr.
-        jenv->ExceptionDescribe();
-        jthrowable exception = jenv->ExceptionOccurred();
-        jenv->ExceptionClear();
-        // setting the user code error is only propagated on certain callbacks.
-        if (registrable_callback_error)
+        if (registrable_callback_error) {
+            // setting the user code error is only propagated on certain callbacks.
+            jthrowable exception = jenv->ExceptionOccurred();
+            jenv->ExceptionClear();
             realm_register_user_code_callback_error(jenv->NewGlobalRef(exception));
+        } else {
+            // Print the exception stacktrace in stderr.
+            jenv->ExceptionDescribe();
+            jenv->ExceptionClear();
+        }
         return false;
     }
     return true;

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -35,7 +35,11 @@ jobject wrap_pointer(JNIEnv* jenv, jlong pointer, jboolean managed = false) {
 }
 
 inline jboolean jni_check_exception(JNIEnv *jenv = get_env(), bool registrable_callback_error = false) {
+    // FIXME https://github.com/realm/realm-kotlin/issues/665 This function is catching and swallowing
+    //  the exception. This behavior could leave the SDK in an illegal state.
     if (jenv->ExceptionCheck()) {
+        // Print the exception stacktrace in stderr.
+        jenv->ExceptionDescribe();
         jthrowable exception = jenv->ExceptionOccurred();
         jenv->ExceptionClear();
         // setting the user code error is only propagated on certain callbacks.
@@ -49,7 +53,6 @@ inline jboolean jni_check_exception(JNIEnv *jenv = get_env(), bool registrable_c
 inline void push_local_frame(JNIEnv *jenv, jint frame_size) {
     if (jenv->PushLocalFrame(frame_size) != 0) {
         jni_check_exception(jenv);
-        jenv->ExceptionDescribe();
         throw std::runtime_error("Failed pushing a local frame with size " + std::to_string(frame_size));
     }
 }

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -951,8 +951,6 @@ before_client_reset(void* userdata, realm_t* before_realm) {
     env->PushLocalFrame(1);
     jobject before_pointer = wrap_pointer(env, reinterpret_cast<jlong>(before_realm), false);
     env->CallVoidMethod(static_cast<jobject>(userdata), java_before_callback_function, before_pointer);
-    jni_check_exception(env);
-    env->PopLocalFrame(NULL);
 
     bool result = true;
     if (env->ExceptionCheck()) {
@@ -961,6 +959,7 @@ before_client_reset(void* userdata, realm_t* before_realm) {
         system_out_println(env, message_template.append(exception_message));
         result = false;
     }
+    env->PopLocalFrame(NULL);
     return result;
 }
 
@@ -981,8 +980,6 @@ after_client_reset(void* userdata, realm_t* before_realm,
 
     jobject after_pointer = wrap_pointer(env, reinterpret_cast<jlong>(after_realm_ptr), false);
     env->CallVoidMethod(static_cast<jobject>(userdata), java_after_callback_function, before_pointer, after_pointer, did_recover);
-    jni_check_exception(env);
-    env->PopLocalFrame(NULL);
     realm_close(after_realm_ptr);
     bool result = true;
     if (env->ExceptionCheck()) {
@@ -991,6 +988,7 @@ after_client_reset(void* userdata, realm_t* before_realm,
         system_out_println(env, message_template.append(exception_message));
         result = false;
     }
+    env->PopLocalFrame(NULL);
     return result;
 }
 


### PR DESCRIPTION
There were some instances where a sync app would crash after enabling log-level `Trace` or `All`.

The cause is that objects instantiated in JNI were not reclaimed and could cause an Out Of Memory exception or a local reference table overflow.

This PR attempts to release any local instances by using the local frames.

Testing was done locally.