### PR TITLE
Fixing compiler crash when using 1.9.20 with Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* Fix compiler crash caused by a change in Kotlin 1.9.20 ((toIrConst moved under common IrUtils)[https://github.com/JetBrains/kotlin/commit/ca8db7d0b83f6dfd6afcea7a5fe7556d38f325d8]). (Issue [#1566](https://github.com/realm/realm-kotlin/issues/1566))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.
@@ -36,7 +36,7 @@
 * None.
 
 ### Fixed
-* Fix craches caused by posting to a released scheduler. (Issue [#1543](https://github.com/realm/realm-kotlin/issues/1543))
+* Fix crashes caused by posting to a released scheduler. (Issue [#1543](https://github.com/realm/realm-kotlin/issues/1543))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -128,7 +128,7 @@ object Versions {
     // When updating the Kotlin version, also remember to update /examples/min-android-sample/build.gradle.kts
     const val kotlin = "1.8.21" // https://github.com/JetBrains/kotlin and https://kotlinlang.org/docs/releases.html#release-details
     const val kotlinJvmTarget = "1.8" // Which JVM bytecode version is kotlin compiled to.
-    const val latestKotlin = "1.9.20-Beta" // https://kotlinlang.org/docs/eap.html#build-details
+    const val latestKotlin = "1.9.20" // https://kotlinlang.org/docs/eap.html#build-details
     const val kotlinCompileTesting = "1.5.0" // https://github.com/tschuchortdev/kotlin-compile-testing
     const val ktlint = "0.45.2" // https://github.com/pinterest/ktlint
     const val ktor = "2.1.2" // https://github.com/ktorio/ktor

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/SyncLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/SyncLoweringExtension.kt
@@ -31,8 +31,8 @@ import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetObjectValueImpl
-import org.jetbrains.kotlin.ir.interpreter.toIrConstOrNull
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl
 import org.jetbrains.kotlin.ir.util.companionObject
@@ -147,10 +147,11 @@ private class SyncLowering(private val pluginContext: IrPluginContext, private v
                     }
                     putValueArgument(
                         expression.valueArgumentsCount,
-                        bundleId.toIrConstOrNull(
+                        IrConstImpl.string(
+                            startOffset,
+                            endOffset,
                             pluginContext.irBuiltIns.stringType,
-                            expression.startOffset,
-                            expression.endOffset,
+                            bundleId
                         )
                     )
                 }


### PR DESCRIPTION
Fixes #1566  toIrConst moved under common IrUtils in Kotlin 1.9.20 https://github.com/JetBrains/kotlin/commit/ca8db7d0b83f6dfd6afcea7a5fe7556d38f325d8 

`bundleId` is a string so we can work around using `toIrConstOrNull` by using `IrConstImpl.string` 