### PR TITLE
Allow aggregators on properties annotated with @PersistedName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Fix craches caused by posting to a released scheduler. (Issue [#1543](https://github.com/realm/realm-kotlin/issues/1543))
+* Fix NPE when applying query aggregators on classes annotated with `@PersistedName`. (Issue [1569](https://github.com/realm/realm-kotlin/pull/1569))
 
 ### Compatibility
 * File format: Generates Realms with file format v23.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/query/ObjectQuery.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/query/ObjectQuery.kt
@@ -54,7 +54,7 @@ internal class ObjectQuery<E : BaseRealmObject> constructor(
         RealmInterop.realm_query_find_all(queryPointer)
     }
 
-    private val classMetadata: ClassMetadata? = realmReference.schemaMetadata[clazz.simpleName!!]
+    private val classMetadata: ClassMetadata? = realmReference.schemaMetadata[classKey]
 
     internal constructor(
         realmReference: RealmReference,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/schema/CachedClassKeyMap.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/schema/CachedClassKeyMap.kt
@@ -24,6 +24,7 @@ import io.realm.kotlin.internal.interop.PropertyKey
 import io.realm.kotlin.internal.interop.PropertyType
 import io.realm.kotlin.internal.interop.RealmInterop
 import io.realm.kotlin.internal.interop.RealmPointer
+import io.realm.kotlin.internal.interop.SCHEMA_NO_VALUE
 import io.realm.kotlin.types.BaseRealmObject
 import io.realm.kotlin.types.TypedRealmObject
 import kotlin.reflect.KClass
@@ -64,6 +65,7 @@ public interface ClassMetadata {
 
 public interface PropertyMetadata {
     public val name: String
+    public val publicName: String
     public val key: PropertyKey
     public val collectionType: CollectionType
     public val type: PropertyType
@@ -154,7 +156,7 @@ public class CachedClassMetadata(
         primaryKeyProperty = properties.firstOrNull { it.isPrimaryKey }
         isEmbeddedRealmObject = classInfo.isEmbedded
 
-        nameMap = properties.associateBy { it.name }
+        nameMap = properties.associateBy { it.name } + properties.filterNot { it.publicName == SCHEMA_NO_VALUE }.associateBy { it.publicName }
         keyMap = properties.associateBy { it.key }
         propertyMap = properties.associateBy { it.accessor }
     }
@@ -169,6 +171,7 @@ public class CachedPropertyMetadata(
     override val accessor: KProperty1<BaseRealmObject, Any?>? = null
 ) : PropertyMetadata {
     override val name: String = propertyInfo.name
+    override val publicName: String = propertyInfo.publicName
     override val key: PropertyKey = propertyInfo.key
     override val collectionType: CollectionType = propertyInfo.collectionType
     override val type: PropertyType = propertyInfo.type

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/PersistedNameTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/PersistedNameTests.kt
@@ -27,6 +27,9 @@ import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.realmSetOf
 import io.realm.kotlin.internal.asDynamicRealm
 import io.realm.kotlin.migration.AutomaticSchemaMigration
+import io.realm.kotlin.query.max
+import io.realm.kotlin.query.min
+import io.realm.kotlin.query.sum
 import io.realm.kotlin.schema.RealmStorageType
 import io.realm.kotlin.test.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
@@ -74,6 +77,54 @@ class PersistedNameTests {
             realm.close()
         }
         PlatformUtils.deleteTempDir(tmpDir)
+    }
+
+    // --------------------------------------------------
+    // Aggregators
+    // --------------------------------------------------
+
+    @Test
+    fun aggregators_byPublicName() {
+        realm.writeBlocking {
+            copyToRealm(PersistedNameSample())
+        }
+
+        assertEquals(
+            expected = 10,
+            actual = realm.query<PersistedNameSample>().sum<Int>("publicNameIntField").find()
+        )
+
+        assertEquals(
+            expected = 10,
+            actual = realm.query<PersistedNameSample>().max<Int>("publicNameIntField").find()
+        )
+
+        assertEquals(
+            expected = 10,
+            actual = realm.query<PersistedNameSample>().min<Int>("publicNameIntField").find()
+        )
+    }
+
+    @Test
+    fun aggregators_byPersistedName() {
+        realm.writeBlocking {
+            copyToRealm(PersistedNameSample())
+        }
+
+        assertEquals(
+            expected = 10,
+            actual = realm.query<PersistedNameSample>().sum<Int>("persistedNameIntField").find()
+        )
+
+        assertEquals(
+            expected = 10,
+            actual = realm.query<PersistedNameSample>().max<Int>("persistedNameIntField").find()
+        )
+
+        assertEquals(
+            expected = 10,
+            actual = realm.query<PersistedNameSample>().min<Int>("persistedNameIntField").find()
+        )
     }
 
     // --------------------------------------------------
@@ -479,6 +530,9 @@ class PersistedNameSample : RealmObject {
     // the underlying schema due to being equal to the persisted name.
     @PersistedName("sameName2")
     var sameName2 = "Realm"
+
+    @PersistedName("persistedNameIntField")
+    var publicNameIntField: Int = 10
 }
 
 class PersistedNameParentSample(var id: Int) : RealmObject {


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/1555

Aggregators on properties annotated with @PersistedName triggered an NPE. The cause was that we used the public names to retrieve the schema metadata when they were only accessible via the persisted one.

This PR fixes the issue by retrieving the object schema via the classkey, and then allowing retrieving properties via both persisted and public names.