### PR TITLE
Add support for multiplexing (enabled by default) and SyncTimeoutOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ### Enhancements
 * Support for experimental K2-compilation with `kotlin.experimental.tryK2=true`. (Issue [#1483](https://github.com/realm/realm-kotlin/issues/1483))
+* [Sync] Added support for multiplexing sync connections. When enabled (the default), a single
+  connection is used per sync user rather than one per synchronized Realm. This
+  reduces resource consumption when multiple Realms are opened and will
+  typically improve performance. The behavior can be controlled through [AppConfiguration.Builder.enableSessionMultiplexing]. (Issue [#XXXX]())  
+* [Sync] Various sync timeout options can now be configured through `AppConfiguration.Builder.syncTimeouts()`. (Issue [#971](https://github.com/realm/realm-kotlin/issues/971)).
 
 ### Fixed
 * None.

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -581,6 +581,12 @@ expect object RealmInterop {
         applicationInfo: String
     )
 
+    fun realm_sync_client_config_set_connect_timeout(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong)
+    fun realm_sync_client_config_set_connection_linger_time(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong)
+    fun realm_sync_client_config_set_ping_keepalive_period(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong)
+    fun realm_sync_client_config_set_pong_keepalive_timeout(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong)
+    fun realm_sync_client_config_set_fast_reconnect_limit(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong)
+
     fun realm_sync_config_new(
         user: RealmUserPointer,
         partition: String

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1301,6 +1301,26 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_sync_client_config_set_connect_timeout(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realmc.realm_sync_client_config_set_connect_timeout(syncClientConfig.cptr(), timeoutMs.toLong())
+    }
+
+    actual fun realm_sync_client_config_set_connection_linger_time(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realmc.realm_sync_client_config_set_connection_linger_time(syncClientConfig.cptr(), timeoutMs.toLong())
+    }
+
+    actual fun realm_sync_client_config_set_ping_keepalive_period(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realmc.realm_sync_client_config_set_ping_keepalive_period(syncClientConfig.cptr(), timeoutMs.toLong())
+    }
+
+    actual fun realm_sync_client_config_set_pong_keepalive_timeout(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realmc.realm_sync_client_config_set_pong_keepalive_timeout(syncClientConfig.cptr(), timeoutMs.toLong())
+    }
+
+    actual fun realm_sync_client_config_set_fast_reconnect_limit(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realmc.realm_sync_client_config_set_fast_reconnect_limit(syncClientConfig.cptr(), timeoutMs.toLong())
+    }
+
     actual fun realm_network_transport_new(networkTransport: NetworkTransport): RealmNetworkTransportPointer {
         return LongPointerWrapper(realmc.realm_network_transport_new(networkTransport))
     }

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -2444,6 +2444,26 @@ actual object RealmInterop {
         )
     }
 
+    actual fun realm_sync_client_config_set_connect_timeout(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realm_wrapper.realm_sync_client_config_set_connect_timeout(syncClientConfig.cptr(), timeoutMs)
+    }
+
+    actual fun realm_sync_client_config_set_connection_linger_time(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realm_wrapper.realm_sync_client_config_set_connection_linger_time(syncClientConfig.cptr(), timeoutMs)
+    }
+
+    actual fun realm_sync_client_config_set_ping_keepalive_period(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realm_wrapper.realm_sync_client_config_set_ping_keepalive_period(syncClientConfig.cptr(), timeoutMs)
+    }
+
+    actual fun realm_sync_client_config_set_pong_keepalive_timeout(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realm_wrapper.realm_sync_client_config_set_pong_keepalive_timeout(syncClientConfig.cptr(), timeoutMs)
+    }
+
+    actual fun realm_sync_client_config_set_fast_reconnect_limit(syncClientConfig: RealmSyncClientConfigurationPointer, timeoutMs: ULong) {
+        realm_wrapper.realm_sync_client_config_set_fast_reconnect_limit(syncClientConfig.cptr(), timeoutMs)
+    }
+
     actual fun realm_sync_config_set_error_handler(
         syncConfig: RealmSyncConfigurationPointer,
         errorHandler: SyncErrorCallback

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncTimeoutOptions.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncTimeoutOptions.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.kotlin.mongodb.sync
+
+import kotlin.time.Duration
+
+/**
+ * The configured timeouts for various aspects of the sync connection between synchronized realms
+ * and App Services.
+ */
+public data class SyncTimeoutOptions(
+
+    /**
+     * The maximum time to allow for a connection to become fully established. This includes
+     * the time to resolve the network address, the TCP connect operation, the SSL
+     * handshake, and the WebSocket handshake.
+     */
+    val connectTimeout: Duration,
+
+    /**
+     * If session multiplexing is enabled, how long to keep connections open while there are
+     * no active session.
+     */
+    val connectionLingerTime: Duration,
+
+    /**
+     * How long to wait between each ping message sent to the server. The client periodically
+     * sends ping messages to the server to check if the connection is still alive. Shorter
+     * periods make connection state change notifications more responsive at the cost of
+     * battery life (as the antenna will have to wake up more often).
+     */
+    val pingKeepalivePeriod: Duration,
+
+    /**
+     * How long to wait for the server to respond to a ping message. Shorter values make
+     * connection state change notifications more responsive, but increase the chance of
+     * spurious disconnections.
+     */
+    val pongKeepalivePeriod: Duration,
+
+    /**
+     * When a client first connects to the server, it downloads all data from the server
+     * before it begins to upload local changes. This typically reduces the total amount
+     * of merging needed and  gets the local client into a useful state faster. If a
+     * disconnect and reconnect happens within the time span of the fast reconnect limit,
+     * this is skipped and the session behaves as if it were continuously
+     * connected.
+     */
+    val fastReconnectLimit: Duration
+)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncTimeoutOptionsBuilder.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncTimeoutOptionsBuilder.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.kotlin.mongodb.sync
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Builder for configuring various timeouts related to the sync connection to the server.
+ *
+ * @see [io.realm.kotlin.mongodb.AppConfiguration.Builder.syncTimeouts]
+ */
+public class SyncTimeoutOptionsBuilder {
+
+    /**
+     * The maximum time to allow for a connection to become fully established. This includes
+     * the time to resolve the network address, the TCP connect operation, the SSL
+     * handshake, and the WebSocket handshake.
+     *
+     * Only values >= 1 second is allowed. Default is 2 minutes.
+     *
+     * @throws IllegalArgumentException if the duration is outside the allowed range.
+     */
+    public var connectTimeout: Duration = 2.minutes
+        set(value) {
+            if (value < 1.seconds) {
+                throw IllegalArgumentException("connectTimeout only support durations >= 1 second. This was: $value")
+            }
+            field = value
+        }
+
+    /**
+     * If session multiplexing is enabled, how long to keep connections open while there are
+     * no active session.
+     *
+     * Only durations > 0 seconds are allowed. Default is 30 seconds.
+     *
+     * @throws IllegalArgumentException if the duration is outside the allowed range.
+     * @see io.realm.kotlin.mongodb.AppConfiguration.Builder.enableSessionMultiplexing
+     */
+    public var connectionLingerTime: Duration = 30.seconds
+        set(value) {
+            if (value <= 0.milliseconds) {
+                throw IllegalArgumentException("connectionLingerTime must be a positive duration > 0. This was: $value")
+            }
+            field = value
+        }
+
+    /**
+     * How long to wait between each ping message sent to the server. The client periodically
+     * sends ping messages to the server to check if the connection is still alive. Shorter
+     * periods make connection state change notifications more responsive at the cost of
+     * battery life (as the antenna will have to wake up more often).
+     *
+     * Only durations > 5 seconds are allowed. Default is 1 minute.
+     *
+     * @throws IllegalArgumentException if the duration is outside the allowed range.
+     */
+    public var pingKeepalivePeriod: Duration = 1.minutes
+        set(value) {
+            if (value <= 5.seconds) {
+                throw IllegalArgumentException("pingKeepalivePeriod must be a positive duration > 5 seconds. This was: $value")
+            }
+            field = value
+        }
+
+    /**
+     * How long to wait for the server to respond to a ping message. Shorter values make
+     * connection state change notifications more responsive, but increase the chance of
+     * spurious disconnections.
+     *
+     * Only durations > 5 seconds are allowed. Default is 2 minutes.
+     *
+     * @throws IllegalArgumentException if the duration is outside the allowed range.
+     */
+    public var pongKeepalivePeriod: Duration = 2.minutes
+        set(value) {
+            if (value <= 5.seconds) {
+                throw IllegalArgumentException("pongKeepalivePeriod must be a positive duration > 5 seconds. This was: $value")
+            }
+            field = value
+        }
+
+    /**
+     * When a client first connects to the server, it downloads all data from the server
+     * before it begins to upload local changes. This typically reduces the total amount
+     * of merging needed and  gets the local client into a useful state faster. If a
+     * disconnect and reconnect happens within the time span of the fast reconnect limit,
+     * this is skipped and the session behaves as if it were continuously
+     * connected.
+     *
+     * Only durations > 1 second are allowed. Default is 1 minute.
+     *
+     * @throws IllegalArgumentException if the duration is outside the allowed range.
+     */
+    public var fastReconnectLimit: Duration = 1.minutes
+        set(value) {
+            if (value <= 1.seconds) {
+                throw IllegalArgumentException("fastReconnectLimit must be a positive duration > 1 second. This was: $value")
+            }
+            field = value
+        }
+
+    /**
+     * Construct the final [SyncTimeoutOptions] object.
+     */
+    internal fun build() = SyncTimeoutOptions(
+        connectTimeout = this.connectTimeout,
+        connectionLingerTime = this.connectionLingerTime,
+        pingKeepalivePeriod = this.pingKeepalivePeriod,
+        pongKeepalivePeriod = this.pongKeepalivePeriod,
+        fastReconnectLimit = this.fastReconnectLimit
+    )
+}

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
@@ -41,12 +41,15 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 private const val CUSTOM_HEADER_NAME = "Foo"
 private const val CUSTOM_HEADER_VALUE = "bar"
@@ -490,4 +493,51 @@ class AppConfigurationTests {
     @Ignore // TODO
     fun dispatcher() {
     }
+
+    @Test
+    fun multiplexing_default() {
+        val config = AppConfiguration.Builder("foo").build()
+        assertTrue(config.enableSessionMultiplexing)
+    }
+
+    @Test
+    fun multiplexing() {
+        val config = AppConfiguration.Builder("foo")
+            .enableSessionMultiplexing(false)
+            .build()
+        assertFalse(config.enableSessionMultiplexing)
+    }
+
+    @Test
+    fun syncTimeOutOptions_default() {
+        val config = AppConfiguration.Builder("foo").build()
+        with(config.syncTimeoutOptions) {
+            assertEquals(2.minutes, connectTimeout)
+            assertEquals(30.seconds, connectionLingerTime)
+            assertEquals(1.minutes, pingKeepalivePeriod)
+            assertEquals(2.minutes, pongKeepalivePeriod)
+            assertEquals(1.minutes, fastReconnectLimit)
+        }
+    }
+
+    @Test
+    fun syncTimeOutOptions() {
+        val config = AppConfiguration.Builder("foo")
+            .syncTimeouts {
+                connectTimeout = 1.seconds
+                connectionLingerTime = 1.seconds
+                pingKeepalivePeriod = 1.seconds
+                pongKeepalivePeriod = 1.seconds
+                fastReconnectLimit = 1.seconds
+            }
+            .build()
+        with(config.syncTimeoutOptions) {
+            assertEquals(1.seconds, connectTimeout)
+            assertEquals(1.seconds, connectionLingerTime)
+            assertEquals(1.seconds, pingKeepalivePeriod)
+            assertEquals(1.seconds, pongKeepalivePeriod)
+            assertEquals(1.seconds, fastReconnectLimit)
+        }
+    }
+
 }


### PR DESCRIPTION
Closes #971 

This should also put some hooks in place to make it easier to control initial sync performance as reported by the internal help ticket here https://jira.mongodb.org/browse/HELP-47093

This PR will also enable multiplexing by default.