### PR TITLE
Improve tests using Channels

### DIFF
--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SubscriptionSetImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SubscriptionSetImpl.kt
@@ -88,10 +88,10 @@ internal class SubscriptionSetImpl<T : BaseRealm>(
                     val callback = SubscriptionSetCallback { state ->
                         when (state) {
                             CoreSubscriptionSetState.RLM_SYNC_SUBSCRIPTION_COMPLETE -> {
-                                channel.send(true)
+                                channel.trySend(true)
                             }
                             CoreSubscriptionSetState.RLM_SYNC_SUBSCRIPTION_ERROR -> {
-                                channel.send(false)
+                                channel.trySend(false)
                             }
                             else -> {
                                 // Ignore all other states, wait for either complete or error.

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SubscriptionSetImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SubscriptionSetImpl.kt
@@ -88,10 +88,10 @@ internal class SubscriptionSetImpl<T : BaseRealm>(
                     val callback = SubscriptionSetCallback { state ->
                         when (state) {
                             CoreSubscriptionSetState.RLM_SYNC_SUBSCRIPTION_COMPLETE -> {
-                                channel.trySend(true)
+                                channel.send(true)
                             }
                             CoreSubscriptionSetState.RLM_SYNC_SUBSCRIPTION_ERROR -> {
-                                channel.trySend(false)
+                                channel.send(false)
                             }
                             else -> {
                                 // Ignore all other states, wait for either complete or error.

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/Utils.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/Utils.kt
@@ -111,7 +111,7 @@ inline fun <T> TestChannel(
 }
 
 /**
- * Helper method that will use use `trySend` to send a message to a Channel and throw
+ * Helper method that will use `trySend` to send a message to a Channel and throw
  * an error if `trySend` returns false
  */
 inline fun <T : Any?> Channel<T>.trySendOrFail(value: T) {

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/Utils.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/util/Utils.kt
@@ -98,9 +98,15 @@ fun Instant.toRealmInstant(): RealmInstant {
  * Channel implementation specifically suited for tests. Its size is unlimited, but will fail
  * the test if canceled while still containing unconsumed elements.
  */
-inline fun <T> TestChannel(): Channel<T> {
-    return Channel<T>(capacity = Channel.UNLIMITED, onBufferOverflow = BufferOverflow.SUSPEND) {
-        throw AssertionError("Failed to deliver: $it")
+inline fun <T> TestChannel(
+    capacity: Int = Channel.UNLIMITED,
+    onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
+    failIfBufferIsEmptyOnCancel: Boolean = true
+): Channel<T> {
+    return Channel<T>(capacity = capacity, onBufferOverflow = onBufferOverflow) {
+        if (failIfBufferIsEmptyOnCancel) {
+            throw AssertionError("Failed to deliver: $it")
+        }
     }
 }
 

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/QueryTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/QueryTests.kt
@@ -45,6 +45,7 @@ import io.realm.kotlin.query.sum
 import io.realm.kotlin.schema.RealmStorageType
 import io.realm.kotlin.test.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TypeDescriptor
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.types.ObjectId
@@ -342,7 +343,7 @@ class QueryTests {
 
     @Test
     fun asFlow_initialResults() {
-        val channel = Channel<ResultsChange<QuerySample>>(1)
+        val channel = TestChannel<ResultsChange<QuerySample>>()
 
         runBlocking {
             val observer = async {
@@ -366,7 +367,7 @@ class QueryTests {
 
     @Test
     fun asFlow() {
-        val channel = Channel<ResultsChange<QuerySample>>(1)
+        val channel = TestChannel<ResultsChange<QuerySample>>()
 
         runBlocking {
             val observer = async {
@@ -399,7 +400,7 @@ class QueryTests {
 
     @Test
     fun asFlow_deleteObservable() {
-        val channel = Channel<ResultsChange<QuerySample>>(1)
+        val channel = TestChannel<ResultsChange<QuerySample>>()
 
         runBlocking {
             realm.writeBlocking {
@@ -1003,7 +1004,7 @@ class QueryTests {
 
     @Test
     fun count_asFlow_initialValue() {
-        val channel = Channel<Long>(1)
+        val channel = TestChannel<Long>()
 
         runBlocking {
             val observer = async {
@@ -1025,7 +1026,7 @@ class QueryTests {
 
     @Test
     fun count_asFlow() {
-        val channel = Channel<Long>(1)
+        val channel = TestChannel<Long>()
 
         runBlocking {
             val observer = async {
@@ -1052,7 +1053,7 @@ class QueryTests {
 
     @Test
     fun count_asFlow_deleteObservable() {
-        val channel = Channel<Long>(1)
+        val channel = TestChannel<Long>()
 
         runBlocking {
             realm.write {
@@ -1085,8 +1086,8 @@ class QueryTests {
     @Test
     fun count_asFlow_cancel() {
         runBlocking {
-            val channel1 = Channel<Long?>(1)
-            val channel2 = Channel<Long?>(1)
+            val channel1 = TestChannel<Long?>()
+            val channel2 = TestChannel<Long?>()
 
             val observer1 = async {
                 realm.query<QuerySample>()
@@ -2315,7 +2316,7 @@ class QueryTests {
 
     @Test
     fun playground_multiThreadScenario() {
-        val channel = Channel<RealmResults<QuerySample>>(1)
+        val channel = TestChannel<RealmResults<QuerySample>>()
         var query: RealmQuery<QuerySample>? = null
         val scope = singleThreadDispatcher("1")
         val intValue = 666
@@ -2577,7 +2578,7 @@ class QueryTests {
         type: AggregatorQueryType,
         propertyDescriptor: PropertyDescriptor
     ) {
-        val channel = Channel<Any?>(1)
+        val channel = TestChannel<Any?>()
         val expectedAggregate = when (type) {
             AggregatorQueryType.MIN -> expectedMin(propertyDescriptor.clazz)
             AggregatorQueryType.MAX -> expectedMax(propertyDescriptor.clazz)
@@ -2727,7 +2728,7 @@ class QueryTests {
         type: AggregatorQueryType,
         propertyDescriptor: PropertyDescriptor
     ) {
-        val channel = Channel<Any?>(1)
+        val channel = TestChannel<Any?>()
         val expectedAggregate = when (type) {
             AggregatorQueryType.MIN -> expectedMin(propertyDescriptor.clazz)
             AggregatorQueryType.MAX -> expectedMax(propertyDescriptor.clazz)
@@ -2825,8 +2826,8 @@ class QueryTests {
         type: AggregatorQueryType,
         propertyDescriptor: PropertyDescriptor
     ) {
-        val channel1 = Channel<Any?>(1)
-        val channel2 = Channel<Any?>(1)
+        val channel1 = TestChannel<Any?>()
+        val channel2 = TestChannel<Any?>()
 
         runBlocking {
             // Subscribe to flow 1

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmAnyTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmAnyTests.kt
@@ -35,6 +35,7 @@ import io.realm.kotlin.notifications.UpdatedObject
 import io.realm.kotlin.query.find
 import io.realm.kotlin.test.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TypeDescriptor
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
@@ -44,7 +45,6 @@ import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.RealmUUID
 import io.realm.kotlin.types.annotations.Index
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import org.mongodb.kbson.BsonDecimal128
 import org.mongodb.kbson.BsonObjectId
 import org.mongodb.kbson.Decimal128
@@ -373,8 +373,8 @@ class RealmAnyTests {
     @Test
     fun managed_deleteObjectInsideRealmAnyTriggersUpdateInContainer() {
         runBlocking {
-            val sampleChannel = Channel<SingleQueryChange<Sample>>(1)
-            val containerChannel = Channel<SingleQueryChange<RealmAnyContainer>>(1)
+            val sampleChannel = TestChannel<SingleQueryChange<Sample>>()
+            val containerChannel = TestChannel<SingleQueryChange<RealmAnyContainer>>()
 
             val sampleObserver = async {
                 realm.query<Sample>()

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmInMemoryTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmInMemoryTests.kt
@@ -10,10 +10,10 @@ import io.realm.kotlin.internal.platform.fileExists
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.test.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 import kotlin.random.Random
 import kotlin.test.AfterTest
@@ -181,9 +181,9 @@ class RealmInMemoryTests {
     @Test
     fun multiThread() {
         val threadError = arrayOfNulls<Exception>(1)
-        val workerCommittedChannel = Channel<Boolean>(1)
-        val workerClosedChannel = Channel<Boolean>(1)
-        val realmInMainClosedChannel = Channel<Boolean>(1)
+        val workerCommittedChannel = TestChannel<Boolean>()
+        val workerClosedChannel = TestChannel<Boolean>()
+        val realmInMainClosedChannel = TestChannel<Boolean>()
         runBlocking {
             // Step 2.
             async {

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmTests.kt
@@ -32,12 +32,12 @@ import io.realm.kotlin.query.find
 import io.realm.kotlin.test.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.platform.platformFileSystem
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
@@ -449,9 +449,9 @@ class RealmTests {
             .directory(testDir)
             .build()
 
-        val bgThreadReadyChannel = Channel<Unit>(1)
-        val readyToCloseChannel = Channel<Unit>(1)
-        val closedChannel = Channel<Unit>(1)
+        val bgThreadReadyChannel = TestChannel<Unit>()
+        val readyToCloseChannel = TestChannel<Unit>()
+        val closedChannel = TestChannel<Unit>()
 
         runBlocking {
             val testRealm = Realm.open(configuration)

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/VersionTrackingTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/VersionTrackingTests.kt
@@ -32,10 +32,10 @@ import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.notifications.RealmChange
 import io.realm.kotlin.notifications.ResultsChange
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
@@ -171,7 +171,7 @@ class VersionTrackingTests {
 
         // Listening to object causes tracking of all versions even if not returned by the write
         val samples = mutableListOf<ResultsChange<Sample>>()
-        val channel = Channel<ResultsChange<Sample>>(1)
+        val channel = TestChannel<ResultsChange<Sample>>()
         val initialVersion = realm.version().version
         val writes = 5
         val objectListener = async {
@@ -222,7 +222,7 @@ class VersionTrackingTests {
             assertNotNull(realm.initialRealmReference.value, toString())
             assertEquals(1, realm.versionTracker.versions().size, toString())
 
-            val realmUpdates = Channel<Unit>(1)
+            val realmUpdates = TestChannel<Unit>()
 
             runBlocking {
                 val deferred = async {

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/VersionTrackingTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/VersionTrackingTests.kt
@@ -227,7 +227,7 @@ class VersionTrackingTests {
             runBlocking {
                 val deferred = async {
                     realm.asFlow().collect {
-                        realmUpdates.trySend(Unit)
+                        realmUpdates.send(Unit)
                     }
                 }
 

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/BacklinksNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/BacklinksNotificationsTests.kt
@@ -25,6 +25,7 @@ import io.realm.kotlin.notifications.UpdatedResults
 import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.test.common.utils.RealmEntityNotificationTests
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -81,7 +82,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     sample.setBacklinks
                 )
             }.forEach { results ->
-                val c = Channel<ResultsChange<Sample>>(1)
+                val c = TestChannel<ResultsChange<Sample>>()
 
                 val observer = async {
                     results
@@ -233,8 +234,8 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     setBacklinks
                 )
             }.forEach { results ->
-                val c1 = Channel<ResultsChange<Sample>>(1)
-                val c2 = Channel<ResultsChange<Sample>>(1)
+                val c1 = TestChannel<ResultsChange<Sample>>()
+                val c2 = TestChannel<ResultsChange<Sample>>()
 
                 val observer1 = async {
                     results.asFlow().collect {

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/BacklinksNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/BacklinksNotificationsTests.kt
@@ -88,7 +88,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     results
                         .asFlow()
                         .collect {
-                            c.trySend(it)
+                            c.send(it)
                         }
                 }
 
@@ -140,7 +140,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     results
                         .asFlow()
                         .collect {
-                            c.trySend(it)
+                            c.send(it)
                         }
                 }
 
@@ -179,7 +179,7 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
             val c = Channel<ResultsChange<Sample>>(capacity = 5)
             val collection = async {
                 target.objectBacklinks.asFlow().collect {
-                    c.trySend(it)
+                    c.send(it)
                 }
             }
 
@@ -239,12 +239,12 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
 
                 val observer1 = async {
                     results.asFlow().collect {
-                        c1.trySend(it)
+                        c1.send(it)
                     }
                 }
                 val observer2 = async {
                     results.asFlow().collect {
-                        c2.trySend(it)
+                        c2.send(it)
                     }
                 }
 
@@ -289,10 +289,10 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                     results
                         .asFlow()
                         .onCompletion {
-                            c.trySend(null)
+                            c.send(null)
                         }
                         .collect {
-                            c.trySend(it)
+                            c.send(it)
                         }
                 }
 
@@ -301,10 +301,10 @@ class BacklinksNotificationsTests : RealmEntityNotificationTests {
                         .query("TRUEPREDICATE")
                         .asFlow()
                         .onCompletion {
-                            sc.trySend(null)
+                            sc.send(null)
                         }
                         .collect {
-                            sc.trySend(it)
+                            sc.send(it)
                         }
                 }
 

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmDictionaryNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmDictionaryNotificationsTests.kt
@@ -354,14 +354,14 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 container.nullableObjectDictionaryField
                     .asFlow()
                     .collect { mapChange ->
-                        channel1.trySend(mapChange)
+                        channel1.send(mapChange)
                     }
             }
             val observer2 = async {
                 container.nullableObjectDictionaryField
                     .asFlow()
                     .collect { mapChange ->
-                        channel2.trySend(mapChange)
+                        channel2.send(mapChange)
                     }
             }
 
@@ -417,7 +417,7 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
                 container.nullableObjectDictionaryField
                     .asFlow()
                     .collect { mapChange ->
-                        channel.trySend(mapChange)
+                        channel.send(mapChange)
                     }
                 fail("Flow should not be canceled.")
             }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmDictionaryNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmDictionaryNotificationsTests.kt
@@ -28,6 +28,7 @@ import io.realm.kotlin.test.common.DICTIONARY_KEYS_FOR_NULLABLE
 import io.realm.kotlin.test.common.NULLABLE_DICTIONARY_OBJECT_VALUES
 import io.realm.kotlin.test.common.utils.RealmEntityNotificationTests
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -347,8 +348,8 @@ class RealmDictionaryNotificationsTests : RealmEntityNotificationTests {
             val container = realm.write {
                 copyToRealm(RealmDictionaryContainer())
             }
-            val channel1 = Channel<MapChange<String, *>>(1)
-            val channel2 = Channel<MapChange<String, *>>(1)
+            val channel1 = TestChannel<MapChange<String, *>>()
+            val channel2 = TestChannel<MapChange<String, *>>()
             val observer1 = async {
                 container.nullableObjectDictionaryField
                     .asFlow()

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmListNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmListNotificationsTests.kt
@@ -313,14 +313,14 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 container.objectListField
                     .asFlow()
                     .collect { flowList ->
-                        channel1.trySend(flowList)
+                        channel1.send(flowList)
                     }
             }
             val observer2 = async {
                 container.objectListField
                     .asFlow()
                     .collect { flowList ->
-                        channel2.trySend(flowList)
+                        channel2.send(flowList)
                     }
             }
 
@@ -457,7 +457,7 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
                 container.objectListField
                     .asFlow()
                     .collect { flowList ->
-                        channel.trySend(flowList)
+                        channel.send(flowList)
                     }
                 fail("Flow should not be canceled.")
             }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmListNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmListNotificationsTests.kt
@@ -31,6 +31,7 @@ import io.realm.kotlin.test.common.OBJECT_VALUES3
 import io.realm.kotlin.test.common.utils.RealmEntityNotificationTests
 import io.realm.kotlin.test.common.utils.assertIsChangeSet
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.types.RealmList
 import kotlinx.coroutines.async
@@ -306,8 +307,8 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
             val container = realm.write {
                 copyToRealm(RealmListContainer())
             }
-            val channel1 = Channel<ListChange<*>>(1)
-            val channel2 = Channel<ListChange<*>>(1)
+            val channel1 = TestChannel<ListChange<*>>()
+            val channel2 = TestChannel<ListChange<*>>()
             val observer1 = async {
                 container.objectListField
                     .asFlow()

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmNotificationsTests.kt
@@ -27,11 +27,11 @@ import io.realm.kotlin.notifications.RealmChange
 import io.realm.kotlin.notifications.UpdatedRealm
 import io.realm.kotlin.test.common.utils.FlowableTests
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.sync.Mutex
@@ -73,7 +73,7 @@ class RealmNotificationsTests : FlowableTests {
     @Test
     override fun initialElement() {
         runBlocking {
-            val c = Channel<RealmChange<Realm>>(1)
+            val c = TestChannel<RealmChange<Realm>>()
             val startingVersion = realm.version()
             val observer = async {
                 realm.asFlow().collect {
@@ -93,7 +93,7 @@ class RealmNotificationsTests : FlowableTests {
     @Test
     override fun asFlow() {
         runBlocking {
-            val c = Channel<RealmChange<Realm>>(1)
+            val c = TestChannel<RealmChange<Realm>>()
             val startingVersion = realm.version()
             val observer = async {
                 realm.asFlow().collect {
@@ -123,8 +123,8 @@ class RealmNotificationsTests : FlowableTests {
     @Test
     override fun cancelAsFlow() {
         runBlocking {
-            val c1 = Channel<RealmChange<Realm>>(1)
-            val c2 = Channel<RealmChange<Realm>>(1)
+            val c1 = TestChannel<RealmChange<Realm>>()
+            val c2 = TestChannel<RealmChange<Realm>>()
             val startingVersion = realm.version()
 
             val observer1 = async {
@@ -179,7 +179,6 @@ class RealmNotificationsTests : FlowableTests {
                 assertEquals(VersionId(startingVersion.version + 2), realmChange.realm.version())
             }
 
-            realm.write { /* Do nothing */ }
             observer1.cancel()
             c1.close()
             c2.close()

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmObjectNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmObjectNotificationsTests.kt
@@ -83,7 +83,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
             }
             val observer = async {
                 obj.asFlow().collect {
-                    c.trySend(it)
+                    c.send(it)
                 }
             }
 
@@ -106,7 +106,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
             }
             val observer = async {
                 obj.asFlow().collect {
-                    c.trySend(it)
+                    c.send(it)
                 }
             }
 
@@ -158,12 +158,12 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
             val c2 = TestChannel<ObjectChange<Sample>>()
             val observer1 = async {
                 obj.asFlow().collect {
-                    c1.trySend(it)
+                    c1.send(it)
                 }
             }
             val observer2 = async {
                 obj.asFlow().collect {
-                    c2.trySend(it)
+                    c2.send(it)
                 }
             }
             // First event should be the initial value
@@ -288,7 +288,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
             }
             val observer = async {
                 obj.asFlow().collect {
-                    c.trySend(it)
+                    c.send(it)
                 }
                 fail("Flow should not be canceled.")
             }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmObjectNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmObjectNotificationsTests.kt
@@ -26,10 +26,10 @@ import io.realm.kotlin.notifications.ObjectChange
 import io.realm.kotlin.notifications.UpdatedObject
 import io.realm.kotlin.test.common.utils.RealmEntityNotificationTests
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.update
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.single
@@ -75,7 +75,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
     @Test
     override fun initialElement() {
         runBlocking {
-            val c = Channel<ObjectChange<Sample>>(1)
+            val c = TestChannel<ObjectChange<Sample>>()
             val obj = realm.write {
                 copyToRealm(
                     Sample().apply { stringField = "Foo" }
@@ -100,7 +100,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
     @Test
     override fun asFlow() {
         runBlocking {
-            val c = Channel<ObjectChange<Sample>>(1)
+            val c = TestChannel<ObjectChange<Sample>>()
             val obj: Sample = realm.write {
                 copyToRealm(Sample().apply { stringField = "Foo" })
             }
@@ -154,8 +154,8 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
             val obj: Sample = realm.write {
                 copyToRealm(Sample().apply { stringField = "Foo" })
             }
-            val c1 = Channel<ObjectChange<Sample>>(1)
-            val c2 = Channel<ObjectChange<Sample>>(1)
+            val c1 = TestChannel<ObjectChange<Sample>>()
+            val c2 = TestChannel<ObjectChange<Sample>>()
             val observer1 = async {
                 obj.asFlow().collect {
                     c1.trySend(it)
@@ -206,8 +206,8 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
     @Test
     override fun deleteEntity() {
         runBlocking {
-            val c1 = Channel<ObjectChange<Sample>>(1)
-            val c2 = Channel<Unit>(1)
+            val c1 = TestChannel<ObjectChange<Sample>>()
+            val c2 = TestChannel<Unit>()
             val obj: Sample = realm.write {
                 copyToRealm(Sample().apply { stringField = "Foo" })
             }
@@ -282,7 +282,7 @@ class RealmObjectNotificationsTests : RealmEntityNotificationTests {
     @Test
     override fun closingRealmDoesNotCancelFlows() {
         runBlocking {
-            val c = Channel<ObjectChange<Sample>>(1)
+            val c = TestChannel<ObjectChange<Sample>>()
             val obj: Sample = realm.write {
                 copyToRealm(Sample().apply { stringField = "Foo" })
             }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmResultsNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmResultsNotificationsTests.kt
@@ -34,6 +34,7 @@ import io.realm.kotlin.test.common.OBJECT_VALUES3
 import io.realm.kotlin.test.common.utils.FlowableTests
 import io.realm.kotlin.test.common.utils.assertIsChangeSet
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -75,7 +76,7 @@ class RealmResultsNotificationsTests : FlowableTests {
     @Test
     override fun initialElement() {
         runBlocking {
-            val c = Channel<ResultsChange<Sample>>(1)
+            val c = TestChannel<ResultsChange<Sample>>()
             val observer = async {
                 realm.query<Sample>()
                     .asFlow()
@@ -274,8 +275,8 @@ class RealmResultsNotificationsTests : FlowableTests {
     @Test
     override fun cancelAsFlow() {
         runBlocking {
-            val c1 = Channel<ResultsChange<Sample>>(1)
-            val c2 = Channel<ResultsChange<Sample>>(1)
+            val c1 = TestChannel<ResultsChange<Sample>>()
+            val c2 = TestChannel<ResultsChange<Sample>>()
 
             realm.write {
                 copyToRealm(Sample().apply { stringField = "Bar" })

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmResultsNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmResultsNotificationsTests.kt
@@ -81,7 +81,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                 realm.query<Sample>()
                     .asFlow()
                     .collect {
-                        c.trySend(it)
+                        c.send(it)
                     }
             }
 
@@ -109,7 +109,7 @@ class RealmResultsNotificationsTests : FlowableTests {
                     .sort("stringField")
                     .asFlow()
                     .collect {
-                        c.trySend(it)
+                        c.send(it)
                     }
             }
 
@@ -286,14 +286,14 @@ class RealmResultsNotificationsTests : FlowableTests {
                 realm.query<Sample>()
                     .asFlow()
                     .collect {
-                        c1.trySend(it)
+                        c1.send(it)
                     }
             }
             val observer2 = async {
                 realm.query<Sample>()
                     .asFlow()
                     .collect {
-                        c2.trySend(it)
+                        c2.send(it)
                     }
             }
 
@@ -334,10 +334,10 @@ class RealmResultsNotificationsTests : FlowableTests {
                     .asFlow()
                     .collect {
                         when (counter.incrementAndGet()) {
-                            1 -> c.trySend(it.list.size)
+                            1 -> c.send(it.list.size)
                             2 -> {
                                 realm.close()
-                                c.trySend(-1)
+                                c.send(-1)
                                 println("realm closed")
                             }
                         }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmSetNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmSetNotificationsTests.kt
@@ -188,14 +188,14 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
                 container.objectSetField
                     .asFlow()
                     .collect { flowSet ->
-                        channel1.trySend(flowSet)
+                        channel1.send(flowSet)
                     }
             }
             val observer2 = async {
                 container.objectSetField
                     .asFlow()
                     .collect { flowSet ->
-                        channel2.trySend(flowSet)
+                        channel2.send(flowSet)
                     }
             }
 
@@ -331,7 +331,7 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
                 container.objectSetField
                     .asFlow()
                     .collect { flowSet ->
-                        channel.trySend(flowSet)
+                        channel.send(flowSet)
                     }
                 fail("Flow should not be canceled.")
             }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmSetNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmSetNotificationsTests.kt
@@ -28,6 +28,7 @@ import io.realm.kotlin.test.common.SET_OBJECT_VALUES2
 import io.realm.kotlin.test.common.SET_OBJECT_VALUES3
 import io.realm.kotlin.test.common.utils.RealmEntityNotificationTests
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -181,8 +182,8 @@ class RealmSetNotificationsTests : RealmEntityNotificationTests {
             val container = realm.write {
                 copyToRealm(RealmSetContainer())
             }
-            val channel1 = Channel<SetChange<*>>(1)
-            val channel2 = Channel<SetChange<*>>(1)
+            val channel1 = TestChannel<SetChange<*>>()
+            val channel2 = TestChannel<SetChange<*>>()
             val observer1 = async {
                 container.objectSetField
                     .asFlow()

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/jvm/RealmTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/jvm/RealmTests.kt
@@ -22,11 +22,11 @@ import io.realm.kotlin.entities.link.Child
 import io.realm.kotlin.entities.link.Parent
 import io.realm.kotlin.internal.platform.singleThreadDispatcher
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -109,7 +109,7 @@ class RealmTests {
             Realm.open(configuration).close()
             // ClosableCoroutineDispatcher doesn't expose whether or not it has been closed, so test
             // if it has been closed by running work on it.
-            val channel = Channel<Int>(1)
+            val channel = TestChannel<Int>()
             async(notificationDispatcher) {
                 channel.send(1)
             }

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
@@ -36,6 +36,7 @@ import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
+import io.realm.kotlin.test.util.trySendOrFail
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -410,7 +411,7 @@ class AppConfigurationTests {
                         "$AUTH_HEADER_NAME: "
                     )
                 ) {
-                    channel.send(true)
+                    channel.trySendOrFail(true)
                 }
             }
         }

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
@@ -410,7 +410,7 @@ class AppConfigurationTests {
                         "$AUTH_HEADER_NAME: "
                     )
                 ) {
-                    channel.trySend(true)
+                    channel.send(true)
                 }
             }
         }

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppConfigurationTests.kt
@@ -33,9 +33,9 @@ import io.realm.kotlin.test.mongodb.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.mongodb.use
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
-import kotlinx.coroutines.channels.Channel
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -394,7 +394,7 @@ class AppConfigurationTests {
     private suspend fun doCustomHeaderTest(app: App) {
         val originalLevel = RealmLog.level
         RealmLog.level = LogLevel.ALL
-        val channel = Channel<Boolean>(1)
+        val channel = TestChannel<Boolean>()
 
         val logger = object : RealmLogger {
             override val level: LogLevel = LogLevel.DEBUG

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
@@ -40,11 +40,11 @@ import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.mongodb.use
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.TestHelper.randomEmail
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.test.AfterTest
@@ -274,7 +274,7 @@ class AppTests {
 //
     @Test
     fun authenticationChangeAsFlow() = runBlocking<Unit> {
-        val c = Channel<AuthenticationChange>(1)
+        val c = TestChannel<AuthenticationChange>()
         val job = async {
             app.authenticationChangeAsFlow().collect {
                 c.send(it)
@@ -304,7 +304,7 @@ class AppTests {
 
     @Test
     fun authenticationChangeAsFlow_removeUser() = runBlocking<Unit> {
-        val c = Channel<AuthenticationChange>(1)
+        val c = TestChannel<AuthenticationChange>()
         val job = async {
             app.authenticationChangeAsFlow().collect {
                 c.send(it)
@@ -329,7 +329,7 @@ class AppTests {
 
     @Test
     fun authenticationChangeAsFlow_deleteUser() = runBlocking<Unit> {
-        val c = Channel<AuthenticationChange>(1)
+        val c = TestChannel<AuthenticationChange>()
         val job = async {
             app.authenticationChangeAsFlow().collect {
                 c.send(it)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/FlexibleSyncIntegrationTests.kt
@@ -32,11 +32,11 @@ import io.realm.kotlin.mongodb.syncSession
 import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.atomicfu.atomic
-import kotlinx.coroutines.channels.Channel
 import org.mongodb.kbson.BsonObjectId
 import kotlin.random.Random
 import kotlin.test.AfterTest
@@ -301,7 +301,7 @@ class FlexibleSyncIntegrationTests {
     fun compensationWrite_writeOutsideOfSubscriptionsGetsReveredByServer() {
         val user1 = app.createUserAndLogin()
 
-        val channel = Channel<CompensatingWriteException>(1)
+        val channel = TestChannel<CompensatingWriteException>()
 
         val config1 = SyncConfiguration.Builder(user1, FLEXIBLE_SYNC_SCHEMA)
             .errorHandler { _: SyncSession, syncException: SyncException ->

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/HttpLogObfuscatorTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/HttpLogObfuscatorTests.kt
@@ -64,24 +64,24 @@ class HttpLogObfuscatorTests {
         ) {
             message?.also {
                 if (it.contains(""""password":"***"""")) {
-                    channel.trySend(Operation.OBFUSCATED_PASSWORD)
+                    channel.send(Operation.OBFUSCATED_PASSWORD)
                 } else if (it.contains(""""access_token":"***","refresh_token":"***"""")) {
-                    channel.trySend(Operation.OBFUSCATED_ACCESS_AND_REFRESH_TOKENS)
+                    channel.send(Operation.OBFUSCATED_ACCESS_AND_REFRESH_TOKENS)
                 } else if (it.contains(""""key":"***"""")) {
-                    channel.trySend(Operation.OBFUSCATED_API_KEY)
+                    channel.send(Operation.OBFUSCATED_API_KEY)
                 } else if (it.contains(""""id_token":"***"""")) {
-                    channel.trySend(Operation.OBFUSCATED_APPLE_OR_GOOGLE_ID_TOKEN)
+                    channel.send(Operation.OBFUSCATED_APPLE_OR_GOOGLE_ID_TOKEN)
                 } else if (it.contains(""""accessToken":"***"""")) {
-                    channel.trySend(Operation.OBFUSCATED_FACEBOOK)
+                    channel.send(Operation.OBFUSCATED_FACEBOOK)
                 } else if (it.contains(""""authCode":"***"""")) {
-                    channel.trySend(Operation.OBFUSCATED_GOOGLE_AUTH_CODE)
+                    channel.send(Operation.OBFUSCATED_GOOGLE_AUTH_CODE)
                 } else if (it.contains(""""token":"***"""")) {
-                    channel.trySend(Operation.OBFUSCATED_JWT)
+                    channel.send(Operation.OBFUSCATED_JWT)
                 } else if (
                     it.contains(""""arguments":[***]""") ||
                     it.contains("BODY START\n***\nBODY END")
                 ) {
-                    channel.trySend(Operation.OBFUSCATED_CUSTOM_FUNCTION)
+                    channel.send(Operation.OBFUSCATED_CUSTOM_FUNCTION)
                 } else if (it.contains(""""password":"$password"""")) {
                     channel.cancel(CancellationException("Password was not obfuscated: $message"))
                 } else if (it.contains(""""(("access_token"):(".+?")),(("refresh_token"):(".+?"))""".toRegex())) {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/HttpLogObfuscatorTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/HttpLogObfuscatorTests.kt
@@ -64,24 +64,24 @@ class HttpLogObfuscatorTests {
         ) {
             message?.also {
                 if (it.contains(""""password":"***"""")) {
-                    channel.send(Operation.OBFUSCATED_PASSWORD)
+                    channel.trySend(Operation.OBFUSCATED_PASSWORD)
                 } else if (it.contains(""""access_token":"***","refresh_token":"***"""")) {
-                    channel.send(Operation.OBFUSCATED_ACCESS_AND_REFRESH_TOKENS)
+                    channel.trySend(Operation.OBFUSCATED_ACCESS_AND_REFRESH_TOKENS)
                 } else if (it.contains(""""key":"***"""")) {
-                    channel.send(Operation.OBFUSCATED_API_KEY)
+                    channel.trySend(Operation.OBFUSCATED_API_KEY)
                 } else if (it.contains(""""id_token":"***"""")) {
-                    channel.send(Operation.OBFUSCATED_APPLE_OR_GOOGLE_ID_TOKEN)
+                    channel.trySend(Operation.OBFUSCATED_APPLE_OR_GOOGLE_ID_TOKEN)
                 } else if (it.contains(""""accessToken":"***"""")) {
-                    channel.send(Operation.OBFUSCATED_FACEBOOK)
+                    channel.trySend(Operation.OBFUSCATED_FACEBOOK)
                 } else if (it.contains(""""authCode":"***"""")) {
-                    channel.send(Operation.OBFUSCATED_GOOGLE_AUTH_CODE)
+                    channel.trySend(Operation.OBFUSCATED_GOOGLE_AUTH_CODE)
                 } else if (it.contains(""""token":"***"""")) {
-                    channel.send(Operation.OBFUSCATED_JWT)
+                    channel.trySend(Operation.OBFUSCATED_JWT)
                 } else if (
                     it.contains(""""arguments":[***]""") ||
                     it.contains("BODY START\n***\nBODY END")
                 ) {
-                    channel.send(Operation.OBFUSCATED_CUSTOM_FUNCTION)
+                    channel.trySend(Operation.OBFUSCATED_CUSTOM_FUNCTION)
                 } else if (it.contains(""""password":"$password"""")) {
                     channel.cancel(CancellationException("Password was not obfuscated: $message"))
                 } else if (it.contains(""""(("access_token"):(".+?")),(("refresh_token"):(".+?"))""".toRegex())) {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
@@ -49,6 +49,7 @@ import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.addEmailProvider
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initializeFlexibleSync
 import io.realm.kotlin.test.mongodb.util.TestAppInitializer.initializePartitionSync
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
@@ -934,7 +935,7 @@ class SyncClientResetIntegrationTests {
     private fun manuallyRecoverUnsyncedChanges_reported(
         builder: SyncConfiguration.Builder
     ) {
-        val channel = Channel<ClientResetRequiredException>(1)
+        val channel = TestChannel<ClientResetRequiredException>()
 
         val config = builder.syncClientResetStrategy(
             object : ManuallyRecoverUnsyncedChangesStrategy {
@@ -989,7 +990,7 @@ class SyncClientResetIntegrationTests {
         user: User,
         builder: SyncConfiguration.Builder
     ) {
-        val channel = Channel<ClientResetRequiredException>(1)
+        val channel = TestChannel<ClientResetRequiredException>()
 
         val config = builder.syncClientResetStrategy(
             object : ManuallyRecoverUnsyncedChangesStrategy {
@@ -1100,7 +1101,7 @@ class SyncClientResetIntegrationTests {
     private fun recoverUnsyncedChanges_resetErrorHandled(
         builder: SyncConfiguration.Builder
     ) {
-        val channel = Channel<ClientResetRequiredException>(1)
+        val channel = TestChannel<ClientResetRequiredException>()
         val config = builder.syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
                 fail("This test case was not supposed to trigger RecoverUnsyncedChangesStrategy::onBeforeReset()")

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncClientResetIntegrationTests.kt
@@ -317,15 +317,15 @@ class SyncClientResetIntegrationTests {
         ) {
             message?.let {
                 if (message.contains("Client reset: attempting to automatically recover unsynced changes in Realm:")) {
-                    channel.trySend(ClientResetLogEvents.DISCARD_LOCAL_ON_BEFORE_RESET)
+                    channel.send(ClientResetLogEvents.DISCARD_LOCAL_ON_BEFORE_RESET)
                 } else if (message.contains("Client reset: successfully recovered all unsynced changes in Realm:")) {
-                    channel.trySend(ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RECOVERY)
+                    channel.send(ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_RECOVERY)
                 } else if (message.contains("Client reset: couldn't recover successfully, all unsynced changes were discarded in Realm:")) {
-                    channel.trySend(ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_DISCARD)
+                    channel.send(ClientResetLogEvents.DISCARD_LOCAL_ON_AFTER_DISCARD)
                 } else if (message.contains("Client reset: manual reset required for Realm in")) {
-                    channel.trySend(ClientResetLogEvents.DISCARD_LOCAL_ON_ERROR)
+                    channel.send(ClientResetLogEvents.DISCARD_LOCAL_ON_ERROR)
                 } else if (message.contains("Client reset required on Realm:")) {
-                    channel.trySend(ClientResetLogEvents.MANUAL_ON_ERROR)
+                    channel.send(ClientResetLogEvents.MANUAL_ON_ERROR)
                 } else {
                     // Ignore
                 }
@@ -382,7 +382,7 @@ class SyncClientResetIntegrationTests {
                     // This realm contains something as we wrote an object while the session was paused
                     assertEquals(1, countObjects(realm))
                     // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                    channel.send(ClientResetEvents.ON_BEFORE_RESET)
                 }
 
                 override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
@@ -393,7 +393,7 @@ class SyncClientResetIntegrationTests {
                     assertEquals(0, countObjects(after))
 
                     // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                    channel.send(ClientResetEvents.ON_AFTER_RESET)
                 }
 
                 override fun onError(
@@ -423,7 +423,7 @@ class SyncClientResetIntegrationTests {
                     getObjects(realm)
                         .asFlow()
                         .collect {
-                            objectChannel.trySend(it)
+                            objectChannel.send(it)
                         }
                 }
 
@@ -477,7 +477,7 @@ class SyncClientResetIntegrationTests {
             object : DiscardUnsyncedChangesStrategy {
                 override fun onBeforeReset(realm: TypedRealm) {
                     // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                    channel.send(ClientResetEvents.ON_BEFORE_RESET)
                 }
 
                 override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
@@ -487,7 +487,7 @@ class SyncClientResetIntegrationTests {
                     recoverData(before, after)
 
                     // Notify that this callback has been invoked
-                    channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                    channel.send(ClientResetEvents.ON_AFTER_RESET)
                 }
 
                 override fun onError(
@@ -517,7 +517,7 @@ class SyncClientResetIntegrationTests {
                     getObjects(realm)
                         .asFlow()
                         .collect {
-                            objectChannel.trySend(it)
+                            objectChannel.send(it)
                         }
                 }
 
@@ -583,7 +583,7 @@ class SyncClientResetIntegrationTests {
                 exception: ClientResetRequiredException
             ) {
                 // Just notify the callback has been invoked, do the assertions in onManualResetFallback
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
 
             override fun onManualResetFallback(
@@ -602,7 +602,7 @@ class SyncClientResetIntegrationTests {
                     exception.message
                 )
 
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
         }).build()
 
@@ -659,7 +659,7 @@ class SyncClientResetIntegrationTests {
                 exception: ClientResetRequiredException
             ) {
                 // Just notify the callback has been invoked, do the assertions in onManualResetFallback
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
 
             override fun onManualResetFallback(
@@ -679,7 +679,7 @@ class SyncClientResetIntegrationTests {
                 assertFalse(fileExists(originalFilePath))
                 assertTrue(fileExists(recoveryFilePath))
 
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
         }).build()
 
@@ -723,13 +723,13 @@ class SyncClientResetIntegrationTests {
         val config = builder.syncClientResetStrategy(object : DiscardUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
                 // Notify that this callback has been invoked
-                channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                channel.send(ClientResetEvents.ON_BEFORE_RESET)
                 throw IllegalStateException("User exception")
             }
 
             override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
                 // Send event anyways so that the asserts outside would fail
-                channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                channel.send(ClientResetEvents.ON_AFTER_RESET)
             }
 
             override fun onError(
@@ -741,7 +741,7 @@ class SyncClientResetIntegrationTests {
                     "[Sync][AutoClientResetFailed(1028)] A fatal error occurred during client reset: 'User-provided callback failed'.",
                     exception.message
                 )
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
 
             override fun onManualResetFallback(
@@ -753,7 +753,7 @@ class SyncClientResetIntegrationTests {
                     "[Sync][AutoClientResetFailed(1028)] A fatal error occurred during client reset: 'User-provided callback failed'.",
                     exception.message
                 )
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
         }).build()
 
@@ -809,12 +809,12 @@ class SyncClientResetIntegrationTests {
         val config = builder.syncClientResetStrategy(object : DiscardUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
                 // Notify that this callback has been invoked
-                channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                channel.send(ClientResetEvents.ON_BEFORE_RESET)
             }
 
             override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
                 // Notify that this callback has been invoked
-                channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                channel.send(ClientResetEvents.ON_AFTER_RESET)
                 throw IllegalStateException("User exception")
             }
 
@@ -827,7 +827,7 @@ class SyncClientResetIntegrationTests {
                     "[Sync][AutoClientResetFailed(1028)] A fatal error occurred during client reset: 'User-provided callback failed'.",
                     exception.message
                 )
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
 
             override fun onManualResetFallback(
@@ -839,7 +839,7 @@ class SyncClientResetIntegrationTests {
                     "[Sync][AutoClientResetFailed(1028)] A fatal error occurred during client reset: 'User-provided callback failed'.",
                     exception.message
                 )
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
         }).build()
 
@@ -943,7 +943,7 @@ class SyncClientResetIntegrationTests {
                     session: SyncSession,
                     exception: ClientResetRequiredException
                 ) {
-                    channel.trySend(exception)
+                    channel.send(exception)
                 }
             }
         ).build()
@@ -998,7 +998,7 @@ class SyncClientResetIntegrationTests {
                     session: SyncSession,
                     exception: ClientResetRequiredException
                 ) {
-                    channel.trySend(exception)
+                    channel.send(exception)
                 }
             }
         ).build()
@@ -1051,13 +1051,13 @@ class SyncClientResetIntegrationTests {
         val config = builder.syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
                 assertEquals(1, countObjects(realm))
-                channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                channel.send(ClientResetEvents.ON_BEFORE_RESET)
             }
 
             override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
                 assertEquals(1, countObjects(before))
                 assertEquals(1, countObjects(after))
-                channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                channel.send(ClientResetEvents.ON_AFTER_RESET)
             }
 
             override fun onManualResetFallback(
@@ -1115,7 +1115,7 @@ class SyncClientResetIntegrationTests {
                 session: SyncSession,
                 exception: ClientResetRequiredException
             ) {
-                channel.trySend(exception)
+                channel.send(exception)
             }
         }).build()
 
@@ -1159,13 +1159,13 @@ class SyncClientResetIntegrationTests {
         val channel = Channel<ClientResetEvents>(2)
         val config = builder.syncClientResetStrategy(object : RecoverUnsyncedChangesStrategy {
             override fun onBeforeReset(realm: TypedRealm) {
-                channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                channel.send(ClientResetEvents.ON_BEFORE_RESET)
                 throw IllegalStateException("User exception")
             }
 
             override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
                 // Send event anyways so that the asserts outside would fail
-                channel.trySend(ClientResetEvents.ON_AFTER_RESET)
+                channel.send(ClientResetEvents.ON_AFTER_RESET)
             }
 
             override fun onManualResetFallback(
@@ -1177,7 +1177,7 @@ class SyncClientResetIntegrationTests {
                     "[Sync][AutoClientResetFailed(1028)] A fatal error occurred during client reset: 'User-provided callback failed'.",
                     exception.message
                 )
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
         }).build()
 
@@ -1249,7 +1249,7 @@ class SyncClientResetIntegrationTests {
                     exception.message
                 )
 
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
         }).build()
 
@@ -1294,11 +1294,11 @@ class SyncClientResetIntegrationTests {
         val config = builder.syncClientResetStrategy(
             object : RecoverOrDiscardUnsyncedChangesStrategy {
                 override fun onBeforeReset(realm: TypedRealm) {
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                    channel.send(ClientResetEvents.ON_BEFORE_RESET)
                 }
 
                 override fun onAfterRecovery(before: TypedRealm, after: MutableRealm) {
-                    channel.trySend(ClientResetEvents.ON_AFTER_RECOVERY)
+                    channel.send(ClientResetEvents.ON_AFTER_RECOVERY)
                 }
 
                 override fun onAfterDiscard(before: TypedRealm, after: MutableRealm) {
@@ -1358,7 +1358,7 @@ class SyncClientResetIntegrationTests {
             object : RecoverOrDiscardUnsyncedChangesStrategy {
                 override fun onBeforeReset(realm: TypedRealm) {
                     assertEquals(1, countObjects(realm))
-                    channel.trySend(ClientResetEvents.ON_BEFORE_RESET)
+                    channel.send(ClientResetEvents.ON_BEFORE_RESET)
                 }
 
                 override fun onAfterRecovery(before: TypedRealm, after: MutableRealm) {
@@ -1368,7 +1368,7 @@ class SyncClientResetIntegrationTests {
                 override fun onAfterDiscard(before: TypedRealm, after: MutableRealm) {
                     assertEquals(1, countObjects(before))
                     assertEquals(0, countObjects(after))
-                    channel.trySend(ClientResetEvents.ON_AFTER_DISCARD)
+                    channel.send(ClientResetEvents.ON_AFTER_DISCARD)
                 }
 
                 override fun onManualResetFallback(
@@ -1455,7 +1455,7 @@ class SyncClientResetIntegrationTests {
                     exception.message
                 )
 
-                channel.trySend(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
+                channel.send(ClientResetEvents.ON_MANUAL_RESET_FALLBACK)
             }
         }).build()
 

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncSessionTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncSessionTests.kt
@@ -36,12 +36,12 @@ import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
@@ -318,7 +318,7 @@ class SyncSessionTests {
         // See 'canWritePartition' in TestAppInitializer.kt.
         val (email, password) = "test_nowrite_noread_${TestHelper.randomEmail()}" to "password1234"
         val user = app.createUserAndLogIn(email, password)
-        val channel = Channel<SyncSession>(1)
+        val channel = TestChannel<SyncSession>()
         val config = SyncConfiguration.Builder(
             schema = PARTITION_BASED_SCHEMA,
             user = user,
@@ -396,7 +396,7 @@ class SyncSessionTests {
             val oid = json["insertedId"]!!.jsonObject["${'$'}oid"]!!.jsonPrimitive.content
             assertNotNull(oid)
 
-            val channel = Channel<ObjectIdPk>(1)
+            val channel = TestChannel<ObjectIdPk>()
             val job = async {
                 realm.query<ObjectIdPk>("_id = $0", BsonObjectId(oid)).first()
                     .asFlow().collect {
@@ -477,7 +477,7 @@ class SyncSessionTests {
     @Test
     fun getConfiguration_inErrorHandlerThrows() = runBlocking {
         // Open and close a realm with a schema.
-        val channel = Channel<SyncSession>(1)
+        val channel = TestChannel<SyncSession>()
         val (email, password) = TestHelper.randomEmail() to "password1234"
         val user = app.createUserAndLogIn(email, password)
         val config1 = SyncConfiguration.Builder(

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncSessionTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncSessionTests.kt
@@ -324,7 +324,7 @@ class SyncSessionTests {
             user = user,
             partitionValue = partitionValue
         ).errorHandler { session, _ ->
-            channel.trySend(session)
+            channel.send(session)
         }.build()
 
         var realm: Realm? = null
@@ -401,7 +401,7 @@ class SyncSessionTests {
                 realm.query<ObjectIdPk>("_id = $0", BsonObjectId(oid)).first()
                     .asFlow().collect {
                         if (it.obj != null) {
-                            channel.trySend(it.obj!!)
+                            channel.send(it.obj!!)
                         }
                     }
             }
@@ -499,7 +499,7 @@ class SyncSessionTests {
             partitionValue = partitionValue
         )
             .name("test2.realm")
-            .errorHandler { session, _ -> channel.trySend(session) }
+            .errorHandler { session, _ -> channel.send(session) }
             .build()
         Realm.open(config2).use { realm2 ->
             // Await the sync session sent.

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncSessionTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncSessionTests.kt
@@ -39,6 +39,7 @@ import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
+import io.realm.kotlin.test.util.trySendOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
@@ -324,7 +325,7 @@ class SyncSessionTests {
             user = user,
             partitionValue = partitionValue
         ).errorHandler { session, _ ->
-            channel.send(session)
+            channel.trySendOrFail(session)
         }.build()
 
         var realm: Realm? = null
@@ -499,7 +500,7 @@ class SyncSessionTests {
             partitionValue = partitionValue
         )
             .name("test2.realm")
-            .errorHandler { session, _ -> channel.send(session) }
+            .errorHandler { session, _ -> channel.trySendOrFail(session) }
             .build()
         Realm.open(config2).use { realm2 ->
             // Await the sync session sent.

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
@@ -59,13 +59,13 @@ import io.realm.kotlin.test.mongodb.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.mongodb.use
 import io.realm.kotlin.test.platform.PlatformUtils
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.TestHelper.randomEmail
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -170,7 +170,7 @@ class SyncedRealmTests {
                     name = "A"
                 }
 
-                val channel = Channel<ResultsChange<ChildPk>>(1)
+                val channel = TestChannel<ResultsChange<ChildPk>>()
 
                 // There was a race condition where construction of a query against the user facing frozen
                 // version could throw, due to the underlying version being deleted when the live realm was
@@ -220,7 +220,7 @@ class SyncedRealmTests {
             partitionValue = partitionValue
         )
         val realm1 = Realm.open(config1)
-        val c = Channel<RealmChange<Realm>>(1)
+        val c = TestChannel<RealmChange<Realm>>()
         val observer = async {
             realm1.asFlow().collect {
                 c.send(it)
@@ -303,7 +303,7 @@ class SyncedRealmTests {
 
     @Test
     fun errorHandlerReceivesPermissionDeniedSyncError() {
-        val channel = Channel<Throwable>(1)
+        val channel = TestChannel<Throwable>()
         // Remove permissions to generate a sync error containing ONLY the original path
         // This way we assert we don't read wrong data from the user_info field
         val (email, password) = "test_nowrite_noread_${randomEmail()}" to "password1234"
@@ -344,7 +344,7 @@ class SyncedRealmTests {
     @Test
     fun testErrorHandler() {
         // Open a realm with a schema. Close it without doing anything else
-        val channel = Channel<SyncException>(1)
+        val channel = TestChannel<SyncException>()
         val (email, password) = randomEmail() to "password1234"
         val user = runBlocking {
             app.createUserAndLogIn(email, password)
@@ -556,9 +556,9 @@ class SyncedRealmTests {
         val syncDir: Path =
             pathOf(app.configuration.syncRootDirectory, "mongodb-realm", app.configuration.appId, user.id).toPath()
 
-        val bgThreadReadyChannel = Channel<Unit>(1)
-        val readyToCloseChannel = Channel<Unit>(1)
-        val closedChannel = Channel<Unit>(1)
+        val bgThreadReadyChannel = TestChannel<Unit>()
+        val readyToCloseChannel = TestChannel<Unit>()
+        val closedChannel = TestChannel<Unit>()
 
         kotlinx.coroutines.runBlocking {
             val testRealm = Realm.open(configuration)
@@ -713,7 +713,7 @@ class SyncedRealmTests {
             name = "db3",
         )
 
-        val counterValue = Channel<Long>(1)
+        val counterValue = TestChannel<Long>()
 
         // Asynchronously receive updates
         val updates = async {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
@@ -221,7 +221,7 @@ class SyncedRealmTests {
             partitionValue = partitionValue
         )
         val realm1 = Realm.open(config1)
-        // We don't fully control all events from the server, so do not check the
+        // We don't fully control all events from the server, so do not check 
         // for an empty buffer because we might accidentally see multiple updates
         // from the server.
         val c = TestChannel<RealmChange<Realm>>(failIfBufferIsEmptyOnCancel = false)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
@@ -316,7 +316,7 @@ class SyncedRealmTests {
             user = user,
             partitionValue = partitionValue
         ).errorHandler { _, error ->
-            channel.trySend(error)
+            channel.send(error)
         }.build()
 
         runBlocking {
@@ -325,7 +325,7 @@ class SyncedRealmTests {
                     // Make sure that the test eventually fail. Coroutines can cancel a delay
                     // so this doesn't always block the test for 10 seconds.
                     delay(10 * 1000)
-                    channel.trySend(AssertionError("Realm was successfully opened"))
+                    channel.send(AssertionError("Realm was successfully opened"))
                 }
             }
 
@@ -368,7 +368,7 @@ class SyncedRealmTests {
             ).name("test2.realm")
                 .errorHandler(object : ErrorHandler {
                     override fun onError(session: SyncSession, error: SyncException) {
-                        channel.trySend(error)
+                        channel.send(error)
                     }
                 }).build()
             val realm2 = Realm.open(config2)
@@ -724,7 +724,7 @@ class SyncedRealmTests {
                     .collect {
                         if (it.obj != null) {
                             val counter = it.obj!!.mutableRealmIntField
-                            counterValue.trySend(counter.get())
+                            counterValue.send(counter.get())
                         }
                     }
             }

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
@@ -256,9 +256,9 @@ class SyncedRealmTests {
                 }
             }
         } finally {
+            c.cancel()
             realm1.close()
             observer.cancel()
-            c.cancel()
         }
     }
 

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
@@ -63,6 +63,7 @@ import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.TestHelper.randomEmail
 import io.realm.kotlin.test.util.receiveOrFail
+import io.realm.kotlin.test.util.trySendOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -316,7 +317,7 @@ class SyncedRealmTests {
             user = user,
             partitionValue = partitionValue
         ).errorHandler { _, error ->
-            channel.send(error)
+            channel.trySendOrFail(error)
         }.build()
 
         runBlocking {
@@ -368,7 +369,7 @@ class SyncedRealmTests {
             ).name("test2.realm")
                 .errorHandler(object : ErrorHandler {
                     override fun onError(session: SyncSession, error: SyncException) {
-                        channel.send(error)
+                        channel.trySendOrFail(error)
                     }
                 }).build()
             val realm2 = Realm.open(config2)
@@ -579,7 +580,7 @@ class SyncedRealmTests {
             fileSystem.list(syncDir)
                 .also { testDirPathList ->
                     assertEquals(4, testDirPathList.size) // db file, .lock, .management, .note
-                    readyToCloseChannel.send(Unit)
+                    readyToCloseChannel.trySendOrFail(Unit)
                 }
             testRealm.close()
             closedChannel.receiveOrFail()

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/SyncedRealmTests.kt
@@ -221,7 +221,10 @@ class SyncedRealmTests {
             partitionValue = partitionValue
         )
         val realm1 = Realm.open(config1)
-        val c = TestChannel<RealmChange<Realm>>()
+        // We don't fully control all events from the server, so do not check the
+        // for an empty buffer because we might accidentally see multiple updates
+        // from the server.
+        val c = TestChannel<RealmChange<Realm>>(failIfBufferIsEmptyOnCancel = false)
         val observer = async {
             realm1.asFlow().collect {
                 c.send(it)

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/internal/KtorNetworkTransportTest.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/internal/KtorNetworkTransportTest.kt
@@ -32,6 +32,7 @@ import io.realm.kotlin.test.mongodb.util.Service
 import io.realm.kotlin.test.mongodb.util.TEST_METHODS
 import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
+import io.realm.kotlin.test.util.trySendOrFail
 import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -92,7 +93,7 @@ internal class KtorNetworkTransportTest {
                     url,
                     mapOf(),
                     body
-                ) { response -> channel.send(response) }
+                ) { response -> channel.trySendOrFail(response) }
                 channel.receiveOrFail()
             }
             assertEquals(200, response.httpResponseCode, "$method failed")
@@ -113,7 +114,7 @@ internal class KtorNetworkTransportTest {
                     url,
                     mapOf(),
                     body
-                ) { response -> channel.send(response) }
+                ) { response -> channel.trySendOrFail(response) }
                 channel.receiveOrFail()
             }
             assertEquals(500, response.httpResponseCode, "$method failed")
@@ -137,7 +138,7 @@ internal class KtorNetworkTransportTest {
                     url,
                     mapOf(),
                     body
-                ) { response -> channel.send(response) }
+                ) { response -> channel.trySendOrFail(response) }
                 channel.receiveOrFail()
             }
             assertEquals(200, response.httpResponseCode, "$method failed")

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/internal/KtorNetworkTransportTest.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/internal/KtorNetworkTransportTest.kt
@@ -92,7 +92,7 @@ internal class KtorNetworkTransportTest {
                     url,
                     mapOf(),
                     body
-                ) { response -> channel.trySend(response) }
+                ) { response -> channel.send(response) }
                 channel.receiveOrFail()
             }
             assertEquals(200, response.httpResponseCode, "$method failed")
@@ -113,7 +113,7 @@ internal class KtorNetworkTransportTest {
                     url,
                     mapOf(),
                     body
-                ) { response -> channel.trySend(response) }
+                ) { response -> channel.send(response) }
                 channel.receiveOrFail()
             }
             assertEquals(500, response.httpResponseCode, "$method failed")
@@ -137,7 +137,7 @@ internal class KtorNetworkTransportTest {
                     url,
                     mapOf(),
                     body
-                ) { response -> channel.trySend(response) }
+                ) { response -> channel.send(response) }
                 channel.receiveOrFail()
             }
             assertEquals(200, response.httpResponseCode, "$method failed")

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/internal/KtorNetworkTransportTest.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/internal/KtorNetworkTransportTest.kt
@@ -30,9 +30,9 @@ import io.realm.kotlin.test.mongodb.util.BaasApp
 import io.realm.kotlin.test.mongodb.util.KtorTestAppInitializer.initialize
 import io.realm.kotlin.test.mongodb.util.Service
 import io.realm.kotlin.test.mongodb.util.TEST_METHODS
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
 import kotlinx.coroutines.CloseableCoroutineDispatcher
-import kotlinx.coroutines.channels.Channel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
@@ -86,7 +86,7 @@ internal class KtorNetworkTransportTest {
         val url = "$endpoint?success=true"
         for (method in TEST_METHODS) {
             val body = if (emptyBodyMethods.contains(method)) "" else "{ \"body\" : \"some content\" }"
-            val response = Channel<Response>(1).use { channel ->
+            val response = TestChannel<Response>().use { channel ->
                 transport.sendRequest(
                     method.value.lowercase(),
                     url,
@@ -107,7 +107,7 @@ internal class KtorNetworkTransportTest {
         for (method in TEST_METHODS) {
             val body = if (emptyBodyMethods.contains(method)) "" else "{ \"body\" : \"some content\" }"
 
-            val response = Channel<Response>(1).use { channel ->
+            val response = TestChannel<Response>().use { channel ->
                 transport.sendRequest(
                     method.value.lowercase(),
                     url,
@@ -131,7 +131,7 @@ internal class KtorNetworkTransportTest {
         for (method in TEST_METHODS) {
             val body = if (emptyBodyMethods.contains(method)) "" else "Boom!"
 
-            val response = Channel<Response>(1).use { channel ->
+            val response = TestChannel<Response>().use { channel ->
                 transport.sendRequest(
                     method.value.lowercase(),
                     url,

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/nonlatin/NonLatinTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/nonlatin/NonLatinTests.kt
@@ -10,11 +10,11 @@ import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
 import io.realm.kotlin.test.mongodb.common.PARTITION_BASED_SCHEMA
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
+import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.TestHelper
 import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.Channel
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -69,7 +69,7 @@ class NonLatinTests {
             val oid = json["insertedId"]!!.jsonObject["${'$'}oid"]!!.jsonPrimitive.content
             assertNotNull(oid)
 
-            val channel = Channel<ObjectIdPk>(1)
+            val channel = TestChannel<ObjectIdPk>()
             val job = async {
                 realm.query<ObjectIdPk>("_id = $0", BsonObjectId(oid)).first()
                     .asFlow().collect {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/nonlatin/NonLatinTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/nonlatin/NonLatinTests.kt
@@ -74,7 +74,7 @@ class NonLatinTests {
                 realm.query<ObjectIdPk>("_id = $0", BsonObjectId(oid)).first()
                     .asFlow().collect {
                         if (it.obj != null) {
-                            channel.trySend(it.obj!!)
+                            channel.send(it.obj!!)
                         }
                     }
             }


### PR DESCRIPTION
This PR streamlines how we are using Channels in tests by introducing a new TestChannel factory method which will ensure we construct the same channel across all tests.

This channel has a few changes compared to the previous one:
- It has an unlimited buffer, which means that `send` should never suspend and we should never accidentally overwrite an event.
- When the channel is canceled, it will check if some elements have not been delivered and throw an assertion if that is true (as it indicates the writer of the test doesn't fully understand the event flow)

I also refactored `Channel.receiveOrFail()`, `onReceive` in channels does not consume elements and we suspect it might be the cause of some of our flaky tests (but hasn't been 100% confirmed).

All uses of `trySend()` in tests has also been replaced by `send()` since `trySend()` might fail silently causing us to miss an error.
