### PR TITLE
Add support for type adapters

### DIFF
--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
@@ -239,7 +239,7 @@ public interface Configuration {
         protected var initialDataCallback: InitialDataCallback? = null
         protected var inMemory: Boolean = false
         protected var initialRealmFileConfiguration: InitialRealmFileConfiguration? = null
-        protected var typeAdapters: List<RealmTypeAdapter<*, *>> = listOf()
+        protected var typeAdapters: Map<KClass<*>, RealmTypeAdapter<*, *>> = mapOf()
 
         /**
          * Sets the filename of the realm file.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
@@ -50,6 +50,17 @@ public fun interface CompactOnLaunchCallback {
     public fun shouldCompact(totalBytes: Long, usedBytes: Long): Boolean
 }
 
+
+/**
+ * TODO
+ */
+public class TypeAdapterBuilder {
+    internal val typeAdapters: MutableList<RealmTypeAdapter<*, *>> = mutableListOf()
+    public fun add(adapter: RealmTypeAdapter<*,*>) {
+        typeAdapters.add(adapter)
+    }
+}
+
 /**
  * This interface is used to write data to a Realm file when the file is first created.
  * It will be used in a way similar to using [Realm.writeBlocking].
@@ -198,6 +209,11 @@ public interface Configuration {
     public val initialRealmFileConfiguration: InitialRealmFileConfiguration?
 
     /**
+     * TODO
+     */
+    public val typeAdapters: List<RealmTypeAdapter<*, *>>
+
+    /**
      * Base class for configuration builders that holds properties available to both
      * [RealmConfiguration] and [SyncConfiguration].
      *
@@ -239,7 +255,7 @@ public interface Configuration {
         protected var initialDataCallback: InitialDataCallback? = null
         protected var inMemory: Boolean = false
         protected var initialRealmFileConfiguration: InitialRealmFileConfiguration? = null
-        protected var typeAdapters: Map<KClass<*>, RealmTypeAdapter<*, *>> = mapOf()
+        protected var typeAdapters: List<RealmTypeAdapter<*, *>> = listOf()
 
         /**
          * Sets the filename of the realm file.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/Configuration.kt
@@ -25,6 +25,7 @@ import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.log.RealmLogger
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.RealmTypeAdapter
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.reflect.KClass
 
@@ -238,6 +239,7 @@ public interface Configuration {
         protected var initialDataCallback: InitialDataCallback? = null
         protected var inMemory: Boolean = false
         protected var initialRealmFileConfiguration: InitialRealmFileConfiguration? = null
+        protected var typeAdapters: List<RealmTypeAdapter<*, *>> = listOf()
 
         /**
          * Sets the filename of the realm file.

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
@@ -24,6 +24,7 @@ import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.log.RealmLogger
 import io.realm.kotlin.migration.AutomaticSchemaMigration
 import io.realm.kotlin.migration.RealmMigration
+import io.realm.kotlin.types.RealmTypeAdapter
 import io.realm.kotlin.types.TypedRealmObject
 import kotlin.reflect.KClass
 
@@ -88,6 +89,19 @@ public interface RealmConfiguration : Configuration {
          */
         public fun directory(directoryPath: String): Builder =
             apply { this.directory = directoryPath }
+
+        // TODO misplaced, move around
+        public class TypeAdapterBuilder {
+            internal val adapters: MutableList<RealmTypeAdapter<*, *>> = mutableListOf()
+            public fun add(adapter: RealmTypeAdapter<*,*>) {
+                adapters.add(adapter)
+            }
+        }
+
+        public fun typeAdapters(block: TypeAdapterBuilder.()->Unit): Builder =
+            apply {
+                this.typeAdapters = TypeAdapterBuilder().apply(block).adapters
+            }
 
         /**
          * Setting this will change the behavior of how migration exceptions are handled. Instead of
@@ -192,7 +206,8 @@ public interface RealmConfiguration : Configuration {
                 initialDataCallback,
                 inMemory,
                 initialRealmFileConfiguration,
-                realmLogger
+                realmLogger,
+                typeAdapters,
             )
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
@@ -90,17 +90,12 @@ public interface RealmConfiguration : Configuration {
         public fun directory(directoryPath: String): Builder =
             apply { this.directory = directoryPath }
 
-        // TODO misplaced, move around
-        public class TypeAdapterBuilder {
-            internal val adapters: MutableMap<KClass<*>, RealmTypeAdapter<*, *>> = mutableMapOf()
-            public fun add(adapter: RealmTypeAdapter<*,*>) {
-                adapters[adapter::class] = adapter
-            }
-        }
-
+        /**
+         * TODO
+         */
         public fun typeAdapters(block: TypeAdapterBuilder.()->Unit): Builder =
             apply {
-                this.typeAdapters = TypeAdapterBuilder().apply(block).adapters
+                this.typeAdapters = TypeAdapterBuilder().apply(block).typeAdapters
             }
 
         /**

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
@@ -92,9 +92,9 @@ public interface RealmConfiguration : Configuration {
 
         // TODO misplaced, move around
         public class TypeAdapterBuilder {
-            internal val adapters: MutableList<RealmTypeAdapter<*, *>> = mutableListOf()
+            internal val adapters: MutableMap<KClass<*>, RealmTypeAdapter<*, *>> = mutableMapOf()
             public fun add(adapter: RealmTypeAdapter<*,*>) {
-                adapters.add(adapter)
+                adapters[adapter::class] = adapter
             }
         }
 

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -69,7 +69,7 @@ public open class ConfigurationImpl(
     inMemory: Boolean,
     initialRealmFileConfiguration: InitialRealmFileConfiguration?,
     logger: ContextLogger,
-    override val adapters: List<RealmTypeAdapter<*, *>>,
+    override val adapters: Map<KClass<*>, RealmTypeAdapter<*, *>>,
 ) : InternalConfiguration {
 
     override val path: String

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -69,7 +69,7 @@ public open class ConfigurationImpl(
     inMemory: Boolean,
     initialRealmFileConfiguration: InitialRealmFileConfiguration?,
     logger: ContextLogger,
-    override val adapters: Map<KClass<*>, RealmTypeAdapter<*, *>>,
+    override val typeAdapters: List<RealmTypeAdapter<*, *>>,
 ) : InternalConfiguration {
 
     override val path: String
@@ -104,6 +104,7 @@ public open class ConfigurationImpl(
     override val initialDataCallback: InitialDataCallback?
     override val inMemory: Boolean
     override val initialRealmFileConfiguration: InitialRealmFileConfiguration?
+    override val typeAdapterMap: Map<KClass<*>, RealmTypeAdapter<*, *>>
 
     override fun createNativeConfiguration(): RealmConfigurationPointer {
         val nativeConfig: RealmConfigurationPointer = RealmInterop.realm_config_new()
@@ -150,6 +151,7 @@ public open class ConfigurationImpl(
         this.initialDataCallback = initialDataCallback
         this.inMemory = inMemory
         this.initialRealmFileConfiguration = initialRealmFileConfiguration
+        this.typeAdapterMap = typeAdapters.associateBy { it::class }
 
         // We need to freeze `compactOnLaunchCallback` reference on initial thread for Kotlin Native
         val compactCallback = compactOnLaunchCallback?.let { callback ->

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -45,6 +45,7 @@ import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
 import io.realm.kotlin.migration.AutomaticSchemaMigration
 import io.realm.kotlin.migration.RealmMigration
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.RealmTypeAdapter
 import kotlin.reflect.KClass
 
 // TODO Public due to being accessed from `library-sync`
@@ -67,7 +68,8 @@ public open class ConfigurationImpl(
     override val isFlexibleSyncConfiguration: Boolean,
     inMemory: Boolean,
     initialRealmFileConfiguration: InitialRealmFileConfiguration?,
-    logger: ContextLogger
+    logger: ContextLogger,
+    override val adapters: List<RealmTypeAdapter<*, *>>,
 ) : InternalConfiguration {
 
     override val path: String

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/Converters.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/Converters.kt
@@ -267,7 +267,7 @@ public inline fun toRealm(
 ): Any? {
     val adapter = obj.owner.owner
         .configuration
-        .adapters.let { adapters ->
+        .typeAdapterMap.let { adapters ->
             require(adapters.contains(adapterClass)) {"User provided adaptes don't contains adapter ${adapterClass.simpleName}"}
             adapters[adapterClass] as RealmTypeAdapter<Any?, Any?>
         }
@@ -282,7 +282,7 @@ public inline fun fromRealm(
 ): Any? {
     val adapter = obj.owner.owner
         .configuration
-        .adapters.let { adapters ->
+        .typeAdapterMap.let { adapters ->
             require(adapters.contains(adapterClass)) {"User provided adaptes don't contains adapter ${adapterClass.simpleName}"}
             adapters[adapterClass] as RealmTypeAdapter<Any?, Any?>
         }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/Converters.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/Converters.kt
@@ -262,26 +262,30 @@ public inline fun longToInt(value: Long?): Int? = value?.toInt()
 
 public inline fun toRealm(
     obj: RealmObjectReference<out BaseRealmObject>,
-    converterClass: KClass<RealmTypeAdapter<Any, Any>>,
-    userValue: Any,
-): Any {
+    adapterClass: KClass<*>,
+    userValue: Any?,
+): Any? {
     val adapter = obj.owner.owner
         .configuration
-        .adapters
-        .first { it::class == converterClass } as RealmTypeAdapter<Any, Any>
+        .adapters.let { adapters ->
+            require(adapters.contains(adapterClass)) {"User provided adaptes don't contains adapter ${adapterClass.simpleName}"}
+            adapters[adapterClass] as RealmTypeAdapter<Any?, Any?>
+        }
 
     return adapter.toRealm(userValue)
 }
 
 public inline fun fromRealm(
     obj: RealmObjectReference<out BaseRealmObject>,
-    converterClass: KClass<RealmTypeAdapter<*, *>>,
+    adapterClass: KClass<*>,
     realmValue: Any,
-): Any {
+): Any? {
     val adapter = obj.owner.owner
         .configuration
-        .adapters
-        .first { it::class == converterClass } as RealmTypeAdapter<Any, Any>
+        .adapters.let { adapters ->
+            require(adapters.contains(adapterClass)) {"User provided adaptes don't contains adapter ${adapterClass.simpleName}"}
+            adapters[adapterClass] as RealmTypeAdapter<Any?, Any?>
+        }
 
     return adapter.fromRealm(realmValue)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/Converters.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/Converters.kt
@@ -36,6 +36,7 @@ import io.realm.kotlin.types.ObjectId
 import io.realm.kotlin.types.RealmAny
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.RealmTypeAdapter
 import io.realm.kotlin.types.RealmUUID
 import io.realm.kotlin.types.geo.GeoBox
 import io.realm.kotlin.types.geo.GeoCircle
@@ -258,6 +259,32 @@ internal object IntConverter : CoreIntConverter, CompositeConverter<Int, Long>()
 // Top level methods to allow inlining from compiler plugin
 public inline fun intToLong(value: Int?): Long? = value?.toLong()
 public inline fun longToInt(value: Long?): Int? = value?.toInt()
+
+public inline fun toRealm(
+    obj: RealmObjectReference<out BaseRealmObject>,
+    converterClass: KClass<RealmTypeAdapter<Any, Any>>,
+    userValue: Any,
+): Any {
+    val adapter = obj.owner.owner
+        .configuration
+        .adapters
+        .first { it::class == converterClass } as RealmTypeAdapter<Any, Any>
+
+    return adapter.toRealm(userValue)
+}
+
+public inline fun fromRealm(
+    obj: RealmObjectReference<out BaseRealmObject>,
+    converterClass: KClass<RealmTypeAdapter<*, *>>,
+    realmValue: Any,
+): Any {
+    val adapter = obj.owner.owner
+        .configuration
+        .adapters
+        .first { it::class == converterClass } as RealmTypeAdapter<Any, Any>
+
+    return adapter.fromRealm(realmValue)
+}
 
 internal object RealmInstantConverter : PassThroughPublicConverter<RealmInstant>() {
     override inline fun fromRealmValue(realmValue: RealmValue): RealmInstant? =

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalConfiguration.kt
@@ -37,7 +37,7 @@ public interface InternalConfiguration : Configuration {
     public val writeDispatcherFactory: CoroutineDispatcherFactory
     public val schemaMode: SchemaMode
     public val logger: ContextLogger
-    public val adapters: Map<KClass<*>, RealmTypeAdapter<*, *>>
+    public val typeAdapterMap: Map<KClass<*>, RealmTypeAdapter<*, *>>
 
     // Temporary work-around for https://github.com/realm/realm-kotlin/issues/724
     public val isFlexibleSyncConfiguration: Boolean

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalConfiguration.kt
@@ -37,6 +37,8 @@ public interface InternalConfiguration : Configuration {
     public val writeDispatcherFactory: CoroutineDispatcherFactory
     public val schemaMode: SchemaMode
     public val logger: ContextLogger
+    // TODO make it a map
+//    public val adapters: Map<KClass<RealmTypeAdapter<*, *>>, RealmTypeAdapter<*, *>>
     public val adapters: List<RealmTypeAdapter<*, *>>
 
     // Temporary work-around for https://github.com/realm/realm-kotlin/issues/724

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalConfiguration.kt
@@ -21,6 +21,7 @@ import io.realm.kotlin.internal.interop.RealmConfigurationPointer
 import io.realm.kotlin.internal.interop.SchemaMode
 import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.RealmTypeAdapter
 import kotlin.reflect.KClass
 
 /**
@@ -36,6 +37,7 @@ public interface InternalConfiguration : Configuration {
     public val writeDispatcherFactory: CoroutineDispatcherFactory
     public val schemaMode: SchemaMode
     public val logger: ContextLogger
+    public val adapters: List<RealmTypeAdapter<*, *>>
 
     // Temporary work-around for https://github.com/realm/realm-kotlin/issues/724
     public val isFlexibleSyncConfiguration: Boolean

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/InternalConfiguration.kt
@@ -37,9 +37,7 @@ public interface InternalConfiguration : Configuration {
     public val writeDispatcherFactory: CoroutineDispatcherFactory
     public val schemaMode: SchemaMode
     public val logger: ContextLogger
-    // TODO make it a map
-//    public val adapters: Map<KClass<RealmTypeAdapter<*, *>>, RealmTypeAdapter<*, *>>
-    public val adapters: List<RealmTypeAdapter<*, *>>
+    public val adapters: Map<KClass<*>, RealmTypeAdapter<*, *>>
 
     // Temporary work-around for https://github.com/realm/realm-kotlin/issues/724
     public val isFlexibleSyncConfiguration: Boolean

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
@@ -49,7 +49,7 @@ internal class RealmConfigurationImpl(
     inMemory: Boolean,
     override val initialRealmFileConfiguration: InitialRealmFileConfiguration?,
     logger: ContextLogger,
-    adapters: Map<KClass<*>, RealmTypeAdapter<*, *>>
+    typeAdapters: List<RealmTypeAdapter<*, *>>
 ) : ConfigurationImpl(
     directory,
     name,
@@ -72,6 +72,6 @@ internal class RealmConfigurationImpl(
     inMemory,
     initialRealmFileConfiguration,
     logger,
-    adapters,
+    typeAdapters,
 ),
     RealmConfiguration

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
@@ -25,6 +25,7 @@ import io.realm.kotlin.internal.interop.SchemaMode
 import io.realm.kotlin.internal.util.CoroutineDispatcherFactory
 import io.realm.kotlin.migration.RealmMigration
 import io.realm.kotlin.types.BaseRealmObject
+import io.realm.kotlin.types.RealmTypeAdapter
 import kotlin.reflect.KClass
 
 public const val REALM_FILE_EXTENSION: String = ".realm"
@@ -47,7 +48,8 @@ internal class RealmConfigurationImpl(
     initialDataCallback: InitialDataCallback?,
     inMemory: Boolean,
     override val initialRealmFileConfiguration: InitialRealmFileConfiguration?,
-    logger: ContextLogger
+    logger: ContextLogger,
+    adapters: List<RealmTypeAdapter<*, *>>
 ) : ConfigurationImpl(
     directory,
     name,
@@ -69,6 +71,7 @@ internal class RealmConfigurationImpl(
     false,
     inMemory,
     initialRealmFileConfiguration,
-    logger
+    logger,
+    adapters,
 ),
     RealmConfiguration

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
@@ -49,7 +49,7 @@ internal class RealmConfigurationImpl(
     inMemory: Boolean,
     override val initialRealmFileConfiguration: InitialRealmFileConfiguration?,
     logger: ContextLogger,
-    adapters: List<RealmTypeAdapter<*, *>>
+    adapters: Map<KClass<*>, RealmTypeAdapter<*, *>>
 ) : ConfigurationImpl(
     directory,
     name,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmTypeAdapter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmTypeAdapter.kt
@@ -1,0 +1,14 @@
+package io.realm.kotlin.types
+
+/**
+ * TODO
+ *
+ * @param R realm type.
+ * @param U user type.
+ */
+public interface RealmTypeAdapter<R, U> { // where P is a supported realm type
+
+    public fun fromRealm(realmValue: R): U
+
+    public fun toRealm(value: U): R
+}

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmTypeAdapter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/RealmTypeAdapter.kt
@@ -6,6 +6,7 @@ package io.realm.kotlin.types
  * @param R realm type.
  * @param U user type.
  */
+// TODO Perform some validation on supported R realm-types
 public interface RealmTypeAdapter<R, U> { // where P is a supported realm type
 
     public fun fromRealm(realmValue: R): U

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/TypeAdapter.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/types/annotations/TypeAdapter.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.types.annotations
+
+import io.realm.kotlin.types.RealmTypeAdapter
+import kotlin.reflect.KClass
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+@MustBeDocumented
+/**
+ * TODO
+ */
+public annotation class TypeAdapter(val adapter: KClass<out RealmTypeAdapter<*, *>>)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
@@ -572,7 +572,8 @@ public interface SyncConfiguration : Configuration {
                 partitionValue == null,
                 inMemory,
                 initialRealmFileConfiguration,
-                realmLogger
+                realmLogger,
+                typeAdapters,
             )
 
             return SyncConfigurationImpl(

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/Identifiers.kt
@@ -69,6 +69,9 @@ internal object Names {
     val REALM_OBJECT_HELPER_SET_OBJECT = Name.identifier("setObject")
     val REALM_OBJECT_HELPER_SET_EMBEDDED_REALM_OBJECT = Name.identifier("setEmbeddedRealmObject")
 
+    val REALM_TYPE_ADAPTER_FROM_REALM = Name.identifier("fromRealm")
+    val REALM_TYPE_ADAPTER_TO_REALM = Name.identifier("toRealm")
+
     // C-interop methods
     val REALM_OBJECT_HELPER_GET_LIST = Name.identifier("getList")
     val REALM_OBJECT_HELPER_SET_LIST = Name.identifier("setList")
@@ -146,6 +149,7 @@ object ClassIds {
     val PERSISTED_NAME_ANNOTATION = ClassId(FqNames.PACKAGE_ANNOTATIONS, Name.identifier("PersistedName"))
     val TRANSIENT_ANNOTATION = ClassId(FqName("kotlin.jvm"), Name.identifier("Transient"))
     val MODEL_OBJECT_ANNOTATION = ClassId(FqName("io.realm.kotlin.internal.platform"), Name.identifier("ModelObject"))
+    val TYPE_ADAPTER_ANNOTATION = ClassId(FqNames.PACKAGE_ANNOTATIONS, Name.identifier("TypeAdapter"))
     val PROPERTY_INFO_CREATE = CallableId(FqName("io.realm.kotlin.internal.schema"), Name.identifier("createPropertyInfo"))
     val CLASS_KIND_TYPE = ClassId(FqName("io.realm.kotlin.schema"), Name.identifier("RealmClassKind"))
 

--- a/packages/plugin-compiler/src/test/kotlin/io/realm/kotlin/compiler/GenerationExtensionTest.kt
+++ b/packages/plugin-compiler/src/test/kotlin/io/realm/kotlin/compiler/GenerationExtensionTest.kt
@@ -319,7 +319,11 @@ class GenerationExtensionTest {
             // @PersistedName annotated fields
             "persistedNameStringField" to PropertyType.RLM_PROPERTY_TYPE_STRING,
             "persistedNameChildField" to PropertyType.RLM_PROPERTY_TYPE_OBJECT,
-            "persistedNameLinkingObjectsField" to PropertyType.RLM_PROPERTY_TYPE_LINKING_OBJECTS
+            "persistedNameLinkingObjectsField" to PropertyType.RLM_PROPERTY_TYPE_LINKING_OBJECTS,
+
+            // Adapted types
+            "singletonAdaptedRealmInstant" to PropertyType.RLM_PROPERTY_TYPE_TIMESTAMP,
+            "instancedAdaptedRealmInstant" to PropertyType.RLM_PROPERTY_TYPE_TIMESTAMP,
         )
         assertEquals(expectedProperties.size, properties.size)
         properties.map { property ->

--- a/packages/plugin-compiler/src/test/resources/sample/expected/01_AFTER.ValidateIrBeforeLowering.ir
+++ b/packages/plugin-compiler/src/test/resources/sample/expected/01_AFTER.ValidateIrBeforeLowering.ir
@@ -1,6 +1,6 @@
 // --- IR for <main> after Validate IR before lowering
 MODULE_FRAGMENT name:<main>
-  FILE fqName:sample.input fileName:input/Sample.kt
+  FILE fqName:sample.input fileName:/Users/clemente.tort/realm-kotlin/packages/plugin-compiler/build/resources/test/sample/input/Sample.kt
     CLASS CLASS name:Sample modality:OPEN visibility:public superTypes:[io.realm.kotlin.types.RealmObject; io.realm.kotlin.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Sample
       CONSTRUCTOR visibility:public <> () returnType:sample.input.Sample [primary]
@@ -6422,6 +6422,118 @@ MODULE_FRAGMENT name:<main>
                   receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-publicNameLinkingObjectsField>' type=sample.input.Sample origin=null
                 reference: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-publicNameLinkingObjectsField>' type=sample.input.Sample origin=null
                 targetProperty: PROPERTY_REFERENCE 'public final publicNameLinkingObjectsField: io.realm.kotlin.query.RealmResults<sample.input.Sample> [delegated,val]' field=null getter='public final fun <get-publicNameLinkingObjectsField> (): io.realm.kotlin.query.RealmResults<sample.input.Sample> declared in sample.input.Sample' setter=null type=kotlin.reflect.KProperty1<sample.input.Sample, io.realm.kotlin.query.RealmResults<sample.input.Sample>> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+      PROPERTY name:singletonAdaptedRealmInstant visibility:public modality:FINAL [var]
+        annotations:
+          TypeAdapter(adapter = CLASS_REFERENCE 'CLASS OBJECT name:RealmInstantBsonDateTimeAdapterSingleton modality:FINAL visibility:public superTypes:[io.realm.kotlin.types.RealmTypeAdapter<io.realm.kotlin.types.RealmInstant, org.mongodb.kbson.BsonDateTime>]' type=kotlin.reflect.KClass<sample.input.RealmInstantBsonDateTimeAdapterSingleton>)
+        FIELD PROPERTY_BACKING_FIELD name:singletonAdaptedRealmInstant type:org.mongodb.kbson.BsonDateTime visibility:private
+          EXPRESSION_BODY
+            CONSTRUCTOR_CALL 'public constructor <init> () declared in org.mongodb.kbson.BsonDateTime' type=org.mongodb.kbson.BsonDateTime origin=null
+        FUN name:<get-singletonAdaptedRealmInstant> visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:org.mongodb.kbson.BsonDateTime
+          correspondingProperty: PROPERTY name:singletonAdaptedRealmInstant visibility:public modality:FINAL [var]
+          $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public final fun <get-singletonAdaptedRealmInstant> (): org.mongodb.kbson.BsonDateTime declared in sample.input.Sample'
+              BLOCK type=org.mongodb.kbson.BsonDateTime origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-singletonAdaptedRealmInstant>' type=sample.input.Sample origin=null
+                WHEN type=org.mongodb.kbson.BsonDateTime origin=null
+                  BRANCH
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-singletonAdaptedRealmInstant>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
+                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:singletonAdaptedRealmInstant type:org.mongodb.kbson.BsonDateTime visibility:private' type=org.mongodb.kbson.BsonDateTime origin=null
+                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-singletonAdaptedRealmInstant>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'public open fun fromRealm (realmValue: io.realm.kotlin.types.RealmInstant): org.mongodb.kbson.BsonDateTime declared in sample.input.RealmInstantBsonDateTimeAdapterSingleton' type=org.mongodb.kbson.BsonDateTime origin=null
+                      $this: GET_OBJECT 'CLASS OBJECT name:RealmInstantBsonDateTimeAdapterSingleton modality:FINAL visibility:public superTypes:[io.realm.kotlin.types.RealmTypeAdapter<io.realm.kotlin.types.RealmInstant, org.mongodb.kbson.BsonDateTime>]' type=sample.input.RealmInstantBsonDateTimeAdapterSingleton
+                      realmValue: CALL 'internal final fun getInstant (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.types.RealmInstant? [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.types.RealmInstant? origin=GET_PROPERTY
+                        $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-singletonAdaptedRealmInstant>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+                        propertyName: CONST String type=kotlin.String value="singletonAdaptedRealmInstant"
+        FUN name:<set-singletonAdaptedRealmInstant> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:org.mongodb.kbson.BsonDateTime) returnType:kotlin.Unit
+          correspondingProperty: PROPERTY name:singletonAdaptedRealmInstant visibility:public modality:FINAL [var]
+          $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
+          VALUE_PARAMETER name:<set-?> index:0 type:org.mongodb.kbson.BsonDateTime
+          BLOCK_BODY
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-singletonAdaptedRealmInstant>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-singletonAdaptedRealmInstant>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:singletonAdaptedRealmInstant type:org.mongodb.kbson.BsonDateTime visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-singletonAdaptedRealmInstant>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: org.mongodb.kbson.BsonDateTime declared in sample.input.Sample.<set-singletonAdaptedRealmInstant>' type=org.mongodb.kbson.BsonDateTime origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: kotlin.Any?): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-singletonAdaptedRealmInstant>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+                    propertyName: CONST String type=kotlin.String value="singletonAdaptedRealmInstant"
+                    value: CALL 'public open fun toRealm (value: org.mongodb.kbson.BsonDateTime): io.realm.kotlin.types.RealmInstant declared in sample.input.RealmInstantBsonDateTimeAdapterSingleton' type=io.realm.kotlin.types.RealmInstant origin=null
+                      $this: GET_OBJECT 'CLASS OBJECT name:RealmInstantBsonDateTimeAdapterSingleton modality:FINAL visibility:public superTypes:[io.realm.kotlin.types.RealmTypeAdapter<io.realm.kotlin.types.RealmInstant, org.mongodb.kbson.BsonDateTime>]' type=sample.input.RealmInstantBsonDateTimeAdapterSingleton
+                      value: GET_VAR '<set-?>: org.mongodb.kbson.BsonDateTime declared in sample.input.Sample.<set-singletonAdaptedRealmInstant>' type=org.mongodb.kbson.BsonDateTime origin=null
+      PROPERTY name:instancedAdaptedRealmInstant visibility:public modality:FINAL [var]
+        annotations:
+          TypeAdapter(adapter = CLASS_REFERENCE 'CLASS CLASS name:RealmInstantBsonDateTimeAdapterInstanced modality:FINAL visibility:public superTypes:[io.realm.kotlin.types.RealmTypeAdapter<io.realm.kotlin.types.RealmInstant, org.mongodb.kbson.BsonDateTime>]' type=kotlin.reflect.KClass<sample.input.RealmInstantBsonDateTimeAdapterInstanced>)
+        FIELD PROPERTY_BACKING_FIELD name:instancedAdaptedRealmInstant type:org.mongodb.kbson.BsonDateTime visibility:private
+          EXPRESSION_BODY
+            CONSTRUCTOR_CALL 'public constructor <init> () declared in org.mongodb.kbson.BsonDateTime' type=org.mongodb.kbson.BsonDateTime origin=null
+        FUN name:<get-instancedAdaptedRealmInstant> visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:org.mongodb.kbson.BsonDateTime
+          correspondingProperty: PROPERTY name:instancedAdaptedRealmInstant visibility:public modality:FINAL [var]
+          $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public final fun <get-instancedAdaptedRealmInstant> (): org.mongodb.kbson.BsonDateTime declared in sample.input.Sample'
+              BLOCK type=org.mongodb.kbson.BsonDateTime origin=null
+                VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                  CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-instancedAdaptedRealmInstant>' type=sample.input.Sample origin=null
+                WHEN type=org.mongodb.kbson.BsonDateTime origin=null
+                  BRANCH
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-instancedAdaptedRealmInstant>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
+                    then: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:instancedAdaptedRealmInstant type:org.mongodb.kbson.BsonDateTime visibility:private' type=org.mongodb.kbson.BsonDateTime origin=null
+                      receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<get-instancedAdaptedRealmInstant>' type=sample.input.Sample origin=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'public final fun fromRealm (converterClass: kotlin.reflect.KClass<io.realm.kotlin.types.RealmTypeAdapter<*, *>>, realmValue: kotlin.Any): kotlin.Any [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any origin=null
+                      converterClass: CONST Null type=kotlin.Nothing? value=null
+                      realmValue: CALL 'internal final fun getInstant (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String): io.realm.kotlin.types.RealmInstant? [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=io.realm.kotlin.types.RealmInstant? origin=GET_PROPERTY
+                        $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
+                        obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<get-instancedAdaptedRealmInstant>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+                        propertyName: CONST String type=kotlin.String value="instancedAdaptedRealmInstant"
+        FUN name:<set-instancedAdaptedRealmInstant> visibility:public modality:FINAL <> ($this:sample.input.Sample, <set-?>:org.mongodb.kbson.BsonDateTime) returnType:kotlin.Unit
+          correspondingProperty: PROPERTY name:instancedAdaptedRealmInstant visibility:public modality:FINAL [var]
+          $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
+          VALUE_PARAMETER name:<set-?> index:0 type:org.mongodb.kbson.BsonDateTime
+          BLOCK_BODY
+            BLOCK type=kotlin.Unit origin=null
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val]
+                CALL 'public open fun <get-io_realm_kotlin_objectReference> (): io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-instancedAdaptedRealmInstant>' type=sample.input.Sample origin=null
+              WHEN type=kotlin.Unit origin=null
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-instancedAdaptedRealmInstant>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:instancedAdaptedRealmInstant type:org.mongodb.kbson.BsonDateTime visibility:private' type=kotlin.Unit origin=null
+                    receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-instancedAdaptedRealmInstant>' type=sample.input.Sample origin=null
+                    value: GET_VAR '<set-?>: org.mongodb.kbson.BsonDateTime declared in sample.input.Sample.<set-instancedAdaptedRealmInstant>' type=org.mongodb.kbson.BsonDateTime origin=null
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: CALL 'internal final fun setValue (obj: io.realm.kotlin.internal.RealmObjectReference<out io.realm.kotlin.types.BaseRealmObject>, propertyName: kotlin.String, value: kotlin.Any?): kotlin.Unit [inline] declared in io.realm.kotlin.internal.RealmObjectHelper' type=kotlin.Unit origin=GET_PROPERTY
+                    $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:RealmObjectHelper modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.RealmObjectHelper
+                    obj: GET_VAR 'val tmp0_objectReference: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? [val] declared in sample.input.Sample.<set-instancedAdaptedRealmInstant>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+                    propertyName: CONST String type=kotlin.String value="instancedAdaptedRealmInstant"
+                    value: CALL 'public final fun toRealm (converterClass: kotlin.reflect.KClass<io.realm.kotlin.types.RealmTypeAdapter<kotlin.Any, kotlin.Any>>, userValue: kotlin.Any): kotlin.Any [inline] declared in io.realm.kotlin.internal.ConvertersKt' type=kotlin.Any origin=null
+                      converterClass: CONST Null type=kotlin.Nothing? value=null
+                      userValue: GET_VAR '<set-?>: org.mongodb.kbson.BsonDateTime declared in sample.input.Sample.<set-instancedAdaptedRealmInstant>' type=org.mongodb.kbson.BsonDateTime origin=null
       FUN name:dumpSchema visibility:public modality:FINAL <> ($this:sample.input.Sample) returnType:kotlin.String
         $this: VALUE_PARAMETER name:<this> type:sample.input.Sample
         BLOCK_BODY
@@ -6459,7 +6571,7 @@ MODULE_FRAGMENT name:<main>
                   $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.kotlin.internal.interop.ClassInfo.Companion
                   name: CONST String type=kotlin.String value="Sample"
                   primaryKey: CONST String type=kotlin.String value="id"
-                  numProperties: CONST Long type=kotlin.Long value=123
+                  numProperties: CONST Long type=kotlin.Long value=125
                   isEmbedded: CONST Boolean type=kotlin.Boolean value=false
                   isAsymmetric: CONST Boolean type=kotlin.Boolean value=false
                 cinteropProperties: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.CollectionsKt.listOf): kotlin.collections.List<T of kotlin.collections.CollectionsKt.listOf> declared in kotlin.collections.CollectionsKt' type=kotlin.collections.List<io.realm.kotlin.internal.interop.PropertyInfo> origin=null
@@ -7818,6 +7930,28 @@ MODULE_FRAGMENT name:<main>
                       isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
                       isIndexed: CONST Boolean type=kotlin.Boolean value=false
                       isFullTextIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'internal final fun createPropertyInfo (name: kotlin.String, publicName: kotlin.String?, type: io.realm.kotlin.internal.interop.PropertyType, collectionType: io.realm.kotlin.internal.interop.CollectionType, linkTarget: kotlin.reflect.KClass<io.realm.kotlin.types.TypedRealmObject>?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean, isFullTextIndexed: kotlin.Boolean): io.realm.kotlin.internal.interop.PropertyInfo declared in io.realm.kotlin.internal.schema.CompilerPluginBridgeUtilsKt' type=io.realm.kotlin.internal.interop.PropertyInfo origin=null
+                      name: CONST String type=kotlin.String value="singletonAdaptedRealmInstant"
+                      publicName: CONST String type=kotlin.String value=""
+                      type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_TIMESTAMP' type=io.realm.kotlin.internal.interop.PropertyType
+                      collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.kotlin.internal.interop.CollectionType
+                      linkTarget: CONST Null type=kotlin.reflect.KClass<io.realm.kotlin.types.TypedRealmObject>? value=null
+                      linkOriginPropertyName: CONST String type=kotlin.String value=""
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                      isFullTextIndexed: CONST Boolean type=kotlin.Boolean value=false
+                    CALL 'internal final fun createPropertyInfo (name: kotlin.String, publicName: kotlin.String?, type: io.realm.kotlin.internal.interop.PropertyType, collectionType: io.realm.kotlin.internal.interop.CollectionType, linkTarget: kotlin.reflect.KClass<io.realm.kotlin.types.TypedRealmObject>?, linkOriginPropertyName: kotlin.String?, isNullable: kotlin.Boolean, isPrimaryKey: kotlin.Boolean, isIndexed: kotlin.Boolean, isFullTextIndexed: kotlin.Boolean): io.realm.kotlin.internal.interop.PropertyInfo declared in io.realm.kotlin.internal.schema.CompilerPluginBridgeUtilsKt' type=io.realm.kotlin.internal.interop.PropertyInfo origin=null
+                      name: CONST String type=kotlin.String value="instancedAdaptedRealmInstant"
+                      publicName: CONST String type=kotlin.String value=""
+                      type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_PROPERTY_TYPE_TIMESTAMP' type=io.realm.kotlin.internal.interop.PropertyType
+                      collectionType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RLM_COLLECTION_TYPE_NONE' type=io.realm.kotlin.internal.interop.CollectionType
+                      linkTarget: CONST Null type=kotlin.reflect.KClass<io.realm.kotlin.types.TypedRealmObject>? value=null
+                      linkOriginPropertyName: CONST String type=kotlin.String value=""
+                      isNullable: CONST Boolean type=kotlin.Boolean value=false
+                      isPrimaryKey: CONST Boolean type=kotlin.Boolean value=false
+                      isIndexed: CONST Boolean type=kotlin.Boolean value=false
+                      isFullTextIndexed: CONST Boolean type=kotlin.Boolean value=false
         FUN name:io_realm_kotlin_newInstance visibility:public modality:OPEN <> ($this:sample.input.Sample.Companion) returnType:kotlin.Any
           overridden:
             public abstract fun io_realm_kotlin_newInstance (): kotlin.Any declared in io.realm.kotlin.internal.RealmObjectCompanion
@@ -8473,6 +8607,16 @@ MODULE_FRAGMENT name:<main>
                     <class: B>: kotlin.reflect.KProperty1<io.realm.kotlin.types.RealmObject, kotlin.Any?>
                     first: CONST String type=kotlin.String value="persistedNameLinkingObjectsField"
                     second: PROPERTY_REFERENCE 'public final publicNameLinkingObjectsField: io.realm.kotlin.query.RealmResults<sample.input.Sample> [delegated,val]' field=null getter='public final fun <get-publicNameLinkingObjectsField> (): io.realm.kotlin.query.RealmResults<sample.input.Sample> declared in sample.input.Sample' setter=null type=kotlin.reflect.KMutableProperty1<sample.input.Sample, kotlin.Any?> origin=null
+                  CONSTRUCTOR_CALL 'public constructor <init> (first: A of kotlin.Pair, second: B of kotlin.Pair) [primary] declared in kotlin.Pair' type=kotlin.Pair<kotlin.String, kotlin.reflect.KMutableProperty1<io.realm.kotlin.types.RealmObject, kotlin.Any?>> origin=null
+                    <class: A>: kotlin.String
+                    <class: B>: kotlin.reflect.KMutableProperty1<io.realm.kotlin.types.RealmObject, kotlin.Any?>
+                    first: CONST String type=kotlin.String value="singletonAdaptedRealmInstant"
+                    second: PROPERTY_REFERENCE 'public final singletonAdaptedRealmInstant: org.mongodb.kbson.BsonDateTime [var]' field=null getter='public final fun <get-singletonAdaptedRealmInstant> (): org.mongodb.kbson.BsonDateTime declared in sample.input.Sample' setter='public final fun <set-singletonAdaptedRealmInstant> (<set-?>: org.mongodb.kbson.BsonDateTime): kotlin.Unit declared in sample.input.Sample' type=kotlin.reflect.KMutableProperty1<sample.input.Sample, kotlin.Any?> origin=null
+                  CONSTRUCTOR_CALL 'public constructor <init> (first: A of kotlin.Pair, second: B of kotlin.Pair) [primary] declared in kotlin.Pair' type=kotlin.Pair<kotlin.String, kotlin.reflect.KMutableProperty1<io.realm.kotlin.types.RealmObject, kotlin.Any?>> origin=null
+                    <class: A>: kotlin.String
+                    <class: B>: kotlin.reflect.KMutableProperty1<io.realm.kotlin.types.RealmObject, kotlin.Any?>
+                    first: CONST String type=kotlin.String value="instancedAdaptedRealmInstant"
+                    second: PROPERTY_REFERENCE 'public final instancedAdaptedRealmInstant: org.mongodb.kbson.BsonDateTime [var]' field=null getter='public final fun <get-instancedAdaptedRealmInstant> (): org.mongodb.kbson.BsonDateTime declared in sample.input.Sample' setter='public final fun <set-instancedAdaptedRealmInstant> (<set-?>: org.mongodb.kbson.BsonDateTime): kotlin.Unit declared in sample.input.Sample' type=kotlin.reflect.KMutableProperty1<sample.input.Sample, kotlin.Any?> origin=null
           FUN DEFAULT_PROPERTY_ACCESSOR name:<get-io_realm_kotlin_fields> visibility:public modality:FINAL <> ($this:sample.input.Sample.Companion) returnType:kotlin.collections.Map<kotlin.String, kotlin.reflect.KMutableProperty1<io.realm.kotlin.types.RealmObject, kotlin.Any?>>
             correspondingProperty: PROPERTY name:io_realm_kotlin_fields visibility:public modality:FINAL [var]
             overridden:
@@ -8560,6 +8704,80 @@ MODULE_FRAGMENT name:<main>
             SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:io_realm_kotlin_objectReference type:io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? visibility:private' type=kotlin.Unit origin=null
               receiver: GET_VAR '<this>: sample.input.Sample declared in sample.input.Sample.<set-io_realm_kotlin_objectReference>' type=sample.input.Sample origin=null
               value: GET_VAR '<set-?>: io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? declared in sample.input.Sample.<set-io_realm_kotlin_objectReference>' type=io.realm.kotlin.internal.RealmObjectReference<sample.input.Sample>? origin=null
+    CLASS OBJECT name:RealmInstantBsonDateTimeAdapterSingleton modality:FINAL visibility:public superTypes:[io.realm.kotlin.types.RealmTypeAdapter<io.realm.kotlin.types.RealmInstant, org.mongodb.kbson.BsonDateTime>]
+      $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.RealmInstantBsonDateTimeAdapterSingleton
+      CONSTRUCTOR visibility:private <> () returnType:sample.input.RealmInstantBsonDateTimeAdapterSingleton [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:RealmInstantBsonDateTimeAdapterSingleton modality:FINAL visibility:public superTypes:[io.realm.kotlin.types.RealmTypeAdapter<io.realm.kotlin.types.RealmInstant, org.mongodb.kbson.BsonDateTime>]'
+      FUN name:fromRealm visibility:public modality:OPEN <> ($this:sample.input.RealmInstantBsonDateTimeAdapterSingleton, realmValue:io.realm.kotlin.types.RealmInstant) returnType:org.mongodb.kbson.BsonDateTime
+        overridden:
+          public abstract fun fromRealm (realmValue: R of io.realm.kotlin.types.RealmTypeAdapter): U of io.realm.kotlin.types.RealmTypeAdapter declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:sample.input.RealmInstantBsonDateTimeAdapterSingleton
+        VALUE_PARAMETER name:realmValue index:0 type:io.realm.kotlin.types.RealmInstant
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun fromRealm (realmValue: io.realm.kotlin.types.RealmInstant): org.mongodb.kbson.BsonDateTime declared in sample.input.RealmInstantBsonDateTimeAdapterSingleton'
+            CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.Long) [primary] declared in org.mongodb.kbson.BsonDateTime' type=org.mongodb.kbson.BsonDateTime origin=null
+              value: CONST Long type=kotlin.Long value=100
+      FUN name:toRealm visibility:public modality:OPEN <> ($this:sample.input.RealmInstantBsonDateTimeAdapterSingleton, value:org.mongodb.kbson.BsonDateTime) returnType:io.realm.kotlin.types.RealmInstant
+        overridden:
+          public abstract fun toRealm (value: U of io.realm.kotlin.types.RealmTypeAdapter): R of io.realm.kotlin.types.RealmTypeAdapter declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:sample.input.RealmInstantBsonDateTimeAdapterSingleton
+        VALUE_PARAMETER name:value index:0 type:org.mongodb.kbson.BsonDateTime
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun toRealm (value: org.mongodb.kbson.BsonDateTime): io.realm.kotlin.types.RealmInstant declared in sample.input.RealmInstantBsonDateTimeAdapterSingleton'
+            CALL 'public final fun now (): io.realm.kotlin.types.RealmInstant declared in io.realm.kotlin.types.RealmInstant.Companion' type=io.realm.kotlin.types.RealmInstant origin=null
+              $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.kotlin.types.RealmInstant.Companion
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+        VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+        overridden:
+          public open fun hashCode (): kotlin.Int [fake_override] declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+        overridden:
+          public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    CLASS CLASS name:RealmInstantBsonDateTimeAdapterInstanced modality:FINAL visibility:public superTypes:[io.realm.kotlin.types.RealmTypeAdapter<io.realm.kotlin.types.RealmInstant, org.mongodb.kbson.BsonDateTime>]
+      $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.RealmInstantBsonDateTimeAdapterInstanced
+      CONSTRUCTOR visibility:public <> () returnType:sample.input.RealmInstantBsonDateTimeAdapterInstanced [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:RealmInstantBsonDateTimeAdapterInstanced modality:FINAL visibility:public superTypes:[io.realm.kotlin.types.RealmTypeAdapter<io.realm.kotlin.types.RealmInstant, org.mongodb.kbson.BsonDateTime>]'
+      FUN name:fromRealm visibility:public modality:OPEN <> ($this:sample.input.RealmInstantBsonDateTimeAdapterInstanced, realmValue:io.realm.kotlin.types.RealmInstant) returnType:org.mongodb.kbson.BsonDateTime
+        overridden:
+          public abstract fun fromRealm (realmValue: R of io.realm.kotlin.types.RealmTypeAdapter): U of io.realm.kotlin.types.RealmTypeAdapter declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:sample.input.RealmInstantBsonDateTimeAdapterInstanced
+        VALUE_PARAMETER name:realmValue index:0 type:io.realm.kotlin.types.RealmInstant
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun fromRealm (realmValue: io.realm.kotlin.types.RealmInstant): org.mongodb.kbson.BsonDateTime declared in sample.input.RealmInstantBsonDateTimeAdapterInstanced'
+            CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.Long) [primary] declared in org.mongodb.kbson.BsonDateTime' type=org.mongodb.kbson.BsonDateTime origin=null
+              value: CONST Long type=kotlin.Long value=100
+      FUN name:toRealm visibility:public modality:OPEN <> ($this:sample.input.RealmInstantBsonDateTimeAdapterInstanced, value:org.mongodb.kbson.BsonDateTime) returnType:io.realm.kotlin.types.RealmInstant
+        overridden:
+          public abstract fun toRealm (value: U of io.realm.kotlin.types.RealmTypeAdapter): R of io.realm.kotlin.types.RealmTypeAdapter declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:sample.input.RealmInstantBsonDateTimeAdapterInstanced
+        VALUE_PARAMETER name:value index:0 type:org.mongodb.kbson.BsonDateTime
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun toRealm (value: org.mongodb.kbson.BsonDateTime): io.realm.kotlin.types.RealmInstant declared in sample.input.RealmInstantBsonDateTimeAdapterInstanced'
+            CALL 'public final fun now (): io.realm.kotlin.types.RealmInstant declared in io.realm.kotlin.types.RealmInstant.Companion' type=io.realm.kotlin.types.RealmInstant origin=null
+              $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.realm.kotlin.types.RealmInstant.Companion
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+        VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+        overridden:
+          public open fun hashCode (): kotlin.Int [fake_override] declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+        overridden:
+          public open fun toString (): kotlin.String [fake_override] declared in io.realm.kotlin.types.RealmTypeAdapter
+        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
     CLASS CLASS name:Child modality:OPEN visibility:public superTypes:[io.realm.kotlin.types.RealmObject; io.realm.kotlin.internal.RealmObjectInternal]
       $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:sample.input.Child
       CONSTRUCTOR visibility:public <> () returnType:sample.input.Child [primary]

--- a/packages/plugin-compiler/src/test/resources/sample/input/Sample.kt
+++ b/packages/plugin-compiler/src/test/resources/sample/input/Sample.kt
@@ -30,10 +30,13 @@ import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.RealmSet
 import io.realm.kotlin.types.RealmUUID
+import io.realm.kotlin.types.RealmTypeAdapter
 import io.realm.kotlin.types.annotations.Ignore
 import io.realm.kotlin.types.annotations.Index
 import io.realm.kotlin.types.annotations.PrimaryKey
 import io.realm.kotlin.types.annotations.PersistedName
+import io.realm.kotlin.types.annotations.TypeAdapter
+import org.mongodb.kbson.BsonDateTime
 import org.mongodb.kbson.BsonObjectId
 import org.mongodb.kbson.Decimal128
 import java.util.*
@@ -201,7 +204,25 @@ class Sample : RealmObject {
     @PersistedName("persistedNameLinkingObjectsField")
     val publicNameLinkingObjectsField by backlinks(Sample::objectSetField)
 
+    @TypeAdapter(adapter = RealmInstantBsonDateTimeAdapterSingleton::class)
+    var singletonAdaptedRealmInstant: BsonDateTime = BsonDateTime()
+
+    @TypeAdapter(adapter = RealmInstantBsonDateTimeAdapterInstanced::class)
+    var instancedAdaptedRealmInstant: BsonDateTime = BsonDateTime()
+
     fun dumpSchema(): String = "${Sample.`io_realm_kotlin_schema`()}"
+}
+
+object RealmInstantBsonDateTimeAdapterSingleton: RealmTypeAdapter<RealmInstant, BsonDateTime> {
+    override fun fromRealm(realmValue: RealmInstant): BsonDateTime = BsonDateTime(100)
+
+    override fun toRealm(value: BsonDateTime): RealmInstant = RealmInstant.now()
+}
+
+class RealmInstantBsonDateTimeAdapterInstanced: RealmTypeAdapter<RealmInstant, BsonDateTime> {
+    override fun fromRealm(realmValue: RealmInstant): BsonDateTime = BsonDateTime(100)
+
+    override fun toRealm(value: BsonDateTime): RealmInstant = RealmInstant.now()
 }
 
 class Child : RealmObject {

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/adapters/UsingInstancedAdapter.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/adapters/UsingInstancedAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("invisible_member", "invisible_reference")
+
+package io.realm.kotlin.entities.adapters
+
+import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.RealmTypeAdapter
+import io.realm.kotlin.types.annotations.TypeAdapter
+import org.mongodb.kbson.BsonDateTime
+import io.realm.kotlin.internal.asBsonDateTime
+import io.realm.kotlin.internal.toRealmInstant
+import kotlin.time.Duration.Companion.milliseconds
+
+class UsingInstancedAdapter : RealmObject {
+    @TypeAdapter(adapter = RealmInstantBsonDateTimeAdapterInstanced::class)
+    var date: BsonDateTime = BsonDateTime()
+}
+
+class RealmInstantBsonDateTimeAdapterInstanced : RealmTypeAdapter<RealmInstant, BsonDateTime> {
+    override fun fromRealm(realmValue: RealmInstant): BsonDateTime = realmValue.asBsonDateTime()
+
+    override fun toRealm(value: BsonDateTime): RealmInstant =
+        value.value.milliseconds.toRealmInstant()
+}
+

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/adapters/UsingSingletonAdapter.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/entities/adapters/UsingSingletonAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("invisible_member", "invisible_reference")
+
+package io.realm.kotlin.entities.adapters
+
+import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.RealmTypeAdapter
+import io.realm.kotlin.types.annotations.TypeAdapter
+import org.mongodb.kbson.BsonDateTime
+import io.realm.kotlin.internal.asBsonDateTime
+import io.realm.kotlin.internal.toRealmInstant
+import kotlin.time.Duration.Companion.milliseconds
+
+class UsingSingletonAdapter : RealmObject {
+    @TypeAdapter(adapter = RealmInstantBsonDateTimeAdapterSingleton::class)
+    var date: BsonDateTime = BsonDateTime()
+}
+
+object RealmInstantBsonDateTimeAdapterSingleton : RealmTypeAdapter<RealmInstant, BsonDateTime> {
+    override fun fromRealm(realmValue: RealmInstant): BsonDateTime = realmValue.asBsonDateTime()
+
+    override fun toRealm(value: BsonDateTime): RealmInstant =
+        value.value.milliseconds.toRealmInstant()
+}
+

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmConfigurationTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmConfigurationTests.kt
@@ -34,6 +34,7 @@ import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.platform.platformFileSystem
 import io.realm.kotlin.test.util.TestLogger
 import io.realm.kotlin.test.util.use
+import io.realm.kotlin.types.RealmTypeAdapter
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.newSingleThreadContext
 import okio.Path.Companion.toPath
@@ -41,6 +42,7 @@ import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -491,6 +493,37 @@ class RealmConfigurationTests {
         assertEquals(expectedLogLevel, RealmLog.level)
 
         RealmLog.reset()
+    }
+
+    @Test
+    fun customTypeAdapters_defaultEmpty() {
+        val typeAdapter = object: RealmTypeAdapter<String, String> {
+            override fun fromRealm(realmValue: String): String = TODO("Not yet implemented")
+
+            override fun toRealm(value: String): String = TODO("Not yet implemented")
+        }
+
+        val config = RealmConfiguration.Builder(setOf())
+            .build()
+
+        assertTrue(config.typeAdapters.isEmpty())
+    }
+
+    @Test
+    fun defineCustomTypeAdapters() {
+        val typeAdapter = object: RealmTypeAdapter<String, String> {
+            override fun fromRealm(realmValue: String): String = TODO("Not yet implemented")
+
+            override fun toRealm(value: String): String = TODO("Not yet implemented")
+        }
+
+        val config = RealmConfiguration.Builder(setOf())
+            .typeAdapters {
+                add(typeAdapter)
+            }
+            .build()
+
+        assertContains(config.typeAdapters, typeAdapter)
     }
 
     private fun assertFailsWithEncryptionKey(builder: RealmConfiguration.Builder, keyLength: Int) {

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/TypeAdapterTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/TypeAdapterTests.kt
@@ -28,6 +28,24 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+/**
+ * This test suite should cover these points
+ * Schema validation
+ * Singleton / instanced adapters
+ * All types including collections
+ * Nullability
+ * Default values
+ * Compatibility with other annotations:
+ * - PrimaryKey
+ * - Index
+ * - Fulltext search
+ * - PersistedName
+ * - Ignore
+ * Backlinks
+ * missing instance type adapters
+ * copyFromRealm
+ * access objects realm?
+ */
 class TypeAdapterTests {
     private lateinit var tmpDir: String
     private lateinit var realm: Realm
@@ -53,22 +71,6 @@ class TypeAdapterTests {
         }
         PlatformUtils.deleteTempDir(tmpDir)
     }
-
-    /**
-     * We shall cover with these tests:
-     *
-     * Singleton / instanced adapters
-     * All types including collections
-     * Nullability
-     * Default values
-     * Compatibility with other annotations:
-     * - PrimaryKey
-     * - Index
-     * - Fulltext search
-     * - PersistedName
-     * - Ignore
-     * Backlinks
-     */
 
     @Test
     fun useSingletonAdapter() {

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/TypeAdapterTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/TypeAdapterTests.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.kotlin.test.common
+
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+import io.realm.kotlin.entities.adapters.RealmInstantBsonDateTimeAdapterInstanced
+import io.realm.kotlin.entities.adapters.UsingInstancedAdapter
+//import io.realm.kotlin.entities.adapters.UsingInstancedAdapter
+import io.realm.kotlin.entities.adapters.UsingSingletonAdapter
+import io.realm.kotlin.test.platform.PlatformUtils
+import org.mongodb.kbson.BsonDateTime
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TypeAdapterTests {
+    private lateinit var tmpDir: String
+    private lateinit var realm: Realm
+
+    private lateinit var configuration: RealmConfiguration
+
+    @BeforeTest
+    fun setup() {
+        tmpDir = PlatformUtils.createTempDir()
+        configuration = RealmConfiguration.Builder(setOf(UsingSingletonAdapter::class, UsingInstancedAdapter::class))
+            .directory(tmpDir)
+            .typeAdapters {
+                add(RealmInstantBsonDateTimeAdapterInstanced())
+            }
+            .build()
+        realm = Realm.open(configuration)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (this::realm.isInitialized && !realm.isClosed()) {
+            realm.close()
+        }
+        PlatformUtils.deleteTempDir(tmpDir)
+    }
+
+    /**
+     * We shall cover with these tests:
+     *
+     * Singleton / instanced adapters
+     * All types including collections
+     * Nullability
+     * Default values
+     * Compatibility with other annotations:
+     * - PrimaryKey
+     * - Index
+     * - Fulltext search
+     * - PersistedName
+     * - Ignore
+     * Backlinks
+     */
+
+    @Test
+    fun useSingletonAdapter() {
+        val expectedDate = BsonDateTime()
+
+        val adapted = UsingSingletonAdapter().apply {
+            this.date = expectedDate
+        }
+        assertEquals(expectedDate, adapted.date)
+
+        val storedAdapted = realm.writeBlocking {
+            copyToRealm(adapted)
+        }
+
+        assertEquals(expectedDate, storedAdapted.date)
+    }
+
+    @Test
+    fun useInstancedAdapter() {
+        val expectedDate = BsonDateTime()
+
+        val adapted = UsingInstancedAdapter().apply {
+            this.date = expectedDate
+        }
+        assertEquals(expectedDate, adapted.date)
+
+        val storedAdapted = realm.writeBlocking {
+            copyToRealm(adapted)
+        }
+
+        assertEquals(expectedDate, storedAdapted.date)
+    }
+
+}

--- a/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/TypeAdaptersTests.kt
+++ b/packages/test-base/src/jvmTest/kotlin/io/realm/kotlin/test/compiler/TypeAdaptersTests.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.kotlin.test.compiler
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.realm.kotlin.internal.interop.CollectionType
+import io.realm.kotlin.test.util.Compiler.compileFromSource
+import io.realm.kotlin.test.util.TypeDescriptor.allFieldTypes
+import io.realm.kotlin.types.MutableRealmInt
+import io.realm.kotlin.types.ObjectId
+import io.realm.kotlin.types.RealmAny
+import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmUUID
+import org.junit.Test
+import org.mongodb.kbson.BsonObjectId
+import org.mongodb.kbson.Decimal128
+import kotlin.reflect.KClassifier
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TypeAdaptersTests {
+    // TODO: Add tests to validate type adapter definitions
+    // TODO: Q. Shall we fail with declaring type adapters or when we apply them?
+
+
+    @Test
+    fun nonRealmTypesThrow() {
+        val result = compileFromSource(
+            plugins = listOf(io.realm.kotlin.compiler.Registrar()),
+            source = SourceFile.kotlin(
+                "typeAdapter_unsupported_type.kt",
+                """
+                    import io.realm.kotlin.types.RealmInstant
+                    import io.realm.kotlin.types.RealmObject
+                    import io.realm.kotlin.types.RealmTypeAdapter
+                    import io.realm.kotlin.types.annotations.TypeAdapter
+                       
+                    class UserType
+                    
+                    class NonRealmType
+                    
+                    class TestObject : RealmObject {
+                        @TypeAdapter(adapter = UnsupportedRealmTypeParameter::class)
+                        var userType: UserType = UserType()
+                    }
+                    
+                    object UnsupportedRealmTypeParameter : RealmTypeAdapter<NonRealmType, UserType> {
+                        override fun fromRealm(realmValue: NonRealmType): UserType = TODO()
+                    
+                        override fun toRealm(value: UserType): NonRealmType = TODO()
+                    }
+                """.trimIndent()
+            )
+        )
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode, result.messages)
+        assertTrue(result.messages.contains("Invalid type parameter, only Realm types are supported"), result.messages)
+    }
+
+    // TODO: What happens if we apply the annotation to: Delegates backlinks
+}


### PR DESCRIPTION
WIP

Type adapters allow users to persist their types in Realm by doing some transformation to Realm-supported types. 