### PR TITLE
Fix native libs other than macos being copied correctly.

### DIFF
--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -413,7 +413,8 @@ val buildJVMSharedLibs: TaskProvider<Task> by tasks.registering {
  * mostly useful on CI.
  */
 val copyJVMSharedLibs: TaskProvider<Task> by tasks.registering {
-    val copyJvmABIs = project.hasProperty("copyJvmABIs") && project.property("copyJvmABIs") == "true"
+    val copyJvmABIs = project.hasProperty("realm.kotlin.copyNativeJvmLibs") && project.property("realm.kotlin.copyNativeJvmLibs") == "true"
+    logger.info("Copy native Realm JVM libraries: $copyJvmABIs")
     if (copyJvmABIs) {
         // copy MacOS pre-built binaries
         project.file("$buildDir/realmMacOsBuild/librealmc.dylib")


### PR DESCRIPTION
I made a mistake in https://github.com/realm/realm-kotlin/pull/1607 so we didn't copy native libs for Linux and Windows correctly. It only worked on CI because the MacOS JVM libs where in the correct place because of them being built in-place on Jenkins and we do not run Windows/Linux tests there.

But it was caught by our Github Actions branch.

I added an extra debug log that makes it easier to check for in the future.