### PR TITLE
Make it configurable which native libs to copy when building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -367,11 +367,11 @@ def genAndStashSwigJNI() {
     stash includes: 'packages/jni-swig-stub/build/generated/sources/jni/realmc.cpp,packages/jni-swig-stub/build/generated/sources/jni/realmc.h', name: 'swig_jni'
 }
 def runBuild() {
-    def buildJvmAbiFlag = "-Prealm.kotlin.copyNativeJvmLibs=false"
+    def buildJvmAbiFlag = "-Prealm.kotlin.copyNativeJvmLibs="
     if (shouldBuildJvmABIs()) {
         unstash name: 'linux_so_file'
         unstash name: 'win_dll'
-        buildJvmAbiFlag = "-Prealm.kotlin.copyNativeJvmLibs=true"
+        buildJvmAbiFlag = "-Prealm.kotlin.copyNativeJvmLibs=windows,linux" // Macos is built in-place
     }
 
     withCredentials([

--- a/packages/gradle.properties
+++ b/packages/gradle.properties
@@ -56,14 +56,18 @@ realm.kotlin.mainHost=true
 # when only building docs or compiler/gradle plugins.
 realm.kotlin.buildRealmCore=true
 
-# Whether or not to copy pre-built JVM native files into place, making them
-# ready to run or package the final JVM JARs.
+# Comma-seperated list of pre-built JVM native files that should be copied into place, making them
+# ready to run or package into the final JVM JARs.
 #
-# The prebuilt files must be placed in this location for this to work:
-# - MacOS: <root>/packages/cinterop/build/realmMacOsBuild/librealmc.dylib
-# - Linux: <root>/packages/cinterop/build/realmWindowsBuild/librealmc.so
-# - Windows: <root>/packages/cinterop/build/realmWindowsBuild/Release/realmc.dll
-realm.kotlin.copyNativeJvmLibs=false
+# If the list is empty, no files are copied, and must instead be built locally.
+#
+# The following options are allowed and will copy the prebuilt file if it is placed in the defined location.
+# If a platform is enabled, but the file doesn't exist, then the build will crash.
+# 
+# - macos: <root>/packages/cinterop/build/realmMacOsBuild/librealmc.dylib
+# - linux: <root>/packages/cinterop/build/realmWindowsBuild/librealmc.so
+# - windows: <root>/packages/cinterop/build/realmWindowsBuild/Release/realmc.dll
+realm.kotlin.copyNativeJvmLibs=
 
 # See https://kotlinlang.org/docs/mpp-publish-lib.html#publish-an-android-library
 # Allow the default dependency name to match the client debug build type. Otherwise the client project has to


### PR DESCRIPTION
When I merged https://github.com/realm/realm-kotlin/pull/1607 I forgot to account for Jenkins only copying 2 architectures  rather than all 3 as on Github Actions. 

This is now made configurable. The default is still that no copying is done.