### PR TITLE
Fix race condition in ProgressListenerTest

### DIFF
--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/ProgressListenerTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/ProgressListenerTests.kt
@@ -32,8 +32,11 @@ import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.common.utils.assertFailsWithMessage
 import io.realm.kotlin.test.mongodb.createUserAndLogIn
 import io.realm.kotlin.test.mongodb.use
+import io.realm.kotlin.test.util.TestChannel
+import io.realm.kotlin.test.util.receiveOrFail
 import io.realm.kotlin.test.util.use
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -253,6 +256,7 @@ class ProgressListenerTests {
 
     @Test
     fun completesOnClose() = runBlocking {
+        val channel = TestChannel<Boolean>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
         TestApp("completesOnClose", TEST_APP_PARTITION).use { app ->
             val user = app.createUserAndLogIn()
             val realm = Realm.open(createSyncConfig(user))
@@ -260,12 +264,18 @@ class ProgressListenerTests {
                 val flow = realm.syncSession.progressAsFlow(Direction.DOWNLOAD, ProgressMode.INDEFINITELY)
                 val job = async {
                     withTimeout(10.seconds) {
-                        flow.collect { }
+                        flow.collect {
+                            channel.send(true)
+                        }
                     }
                 }
+                // Wait for Flow to start, so we do not close the Realm before
+                // `flow.collect()` can be called.
+                channel.receiveOrFail()
                 realm.close()
                 job.await()
             } finally {
+                channel.close()
                 if (!realm.isClosed()) {
                     realm.close()
                 }


### PR DESCRIPTION
Closes #1628 

This race condition was hit on GitHub Actions, and was hit when we called `Realm.close()` before the async task could run. This resulted in an exception about a closed pointer when `flow.collect { }` was subsequently called.