### PR TITLE
Passing encryption key via a callback

### DIFF
--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -192,6 +192,7 @@ expect object RealmInterop {
     fun realm_config_set_schema(config: RealmConfigurationPointer, schema: RealmSchemaPointer)
     fun realm_config_set_max_number_of_active_versions(config: RealmConfigurationPointer, maxNumberOfVersions: Long)
     fun realm_config_set_encryption_key(config: RealmConfigurationPointer, encryptionKey: ByteArray)
+    fun realm_config_set_encryption_key_from_pointer(config: RealmConfigurationPointer, aesEncryptionKeyAddress: Long)
     fun realm_config_get_encryption_key(config: RealmConfigurationPointer): ByteArray?
     fun realm_config_set_should_compact_on_launch_function(config: RealmConfigurationPointer, callback: CompactOnLaunchCallback)
     fun realm_config_set_migration_function(config: RealmConfigurationPointer, callback: MigrationCallback)

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -184,6 +184,10 @@ actual object RealmInterop {
         realmc.realm_config_set_encryption_key(config.cptr(), encryptionKey, encryptionKey.size.toLong())
     }
 
+    actual fun realm_config_set_encryption_key_from_pointer(config: RealmConfigurationPointer, aesEncryptionKeyAddress: Long) {
+        realmc.realm_config_set_encryption_key_from_pointer(config.cptr(), aesEncryptionKeyAddress)
+    }
+
     actual fun realm_config_get_encryption_key(config: RealmConfigurationPointer): ByteArray? {
         val key = ByteArray(ENCRYPTION_KEY_LENGTH)
         val keyLength: Long = realmc.realm_config_get_encryption_key(config.cptr(), key)

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -54,6 +54,7 @@ import kotlinx.cinterop.CPointerVar
 import kotlinx.cinterop.CPointerVarOf
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.CVariable
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.LongVar
 import kotlinx.cinterop.MemScope
 import kotlinx.cinterop.StableRef
@@ -77,6 +78,7 @@ import kotlinx.cinterop.readValue
 import kotlinx.cinterop.refTo
 import kotlinx.cinterop.set
 import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.toCPointer
 import kotlinx.cinterop.toCStringArray
 import kotlinx.cinterop.toCValues
 import kotlinx.cinterop.toKString
@@ -416,6 +418,16 @@ actual object RealmInterop {
                 encryptionKeyPointer as CPointer<uint8_tVar>,
                 encryptionKey.size.toULong()
             )
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    actual fun realm_config_set_encryption_key_from_pointer(config: RealmConfigurationPointer, aesEncryptionKeyAddress: Long) {
+        memScoped { // Ensure memory cleanup
+            val ptr = aesEncryptionKeyAddress.toCPointer<ByteVarOf<Byte>>()
+            val encryptionKey = ByteArray(64)
+            memcpy(encryptionKey.refTo(0), ptr, 64u)
+            realm_config_set_encryption_key(config, encryptionKey)
         }
     }
 

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.cpp
@@ -937,6 +937,12 @@ void realm_sync_websocket_closed(int64_t observer_ptr, bool was_clean, int error
     realm_sync_socket_websocket_closed(reinterpret_cast<realm_websocket_observer_t*>(observer_ptr), was_clean, static_cast<realm_web_socket_errno_e>(error_code), reason);
 }
 
+void realm_config_set_encryption_key_from_pointer(realm_config_t* config, int64_t aesKeyAddress) {
+    uint8_t key_array[64];
+    std::memcpy(key_array, reinterpret_cast<uint8_t*>(aesKeyAddress), 64);
+    realm_config_set_encryption_key(config, key_array, 64);
+}
+
 realm_sync_socket_t* realm_sync_websocket_new(int64_t sync_client_config_ptr, jobject websocket_transport) {
     auto jenv = get_env(false); // Always called from JVM
     realm_sync_socket_t* socket_provider = realm_sync_socket_new(jenv->NewGlobalRef(websocket_transport), /*userdata*/

--- a/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
+++ b/packages/jni-swig-stub/src/main/jni/realm_api_helpers.h
@@ -161,4 +161,5 @@ bool realm_sync_websocket_message(int64_t observer_ptr, jbyteArray data, size_t 
 
 void realm_sync_websocket_closed(int64_t observer_ptr, bool was_clean, int error_code, const char* reason);
 
+void realm_config_set_encryption_key_from_pointer(realm_config_t* config, int64_t aesKeyAddress);
 #endif //TEST_REALM_API_HELPERS_H

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/RealmConfiguration.kt
@@ -185,6 +185,7 @@ public interface RealmConfiguration : Configuration {
                 writerDispatcherFactory,
                 schemaVersion,
                 encryptionKey,
+                encryptionKeyAsCallback,
                 deleteRealmIfMigrationNeeded,
                 compactOnLaunchCallback,
                 migration,

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/ConfigurationImpl.kt
@@ -17,6 +17,7 @@
 package io.realm.kotlin.internal
 
 import io.realm.kotlin.CompactOnLaunchCallback
+import io.realm.kotlin.EncryptionKeyCallback
 import io.realm.kotlin.InitialDataCallback
 import io.realm.kotlin.InitialRealmFileConfiguration
 import io.realm.kotlin.LogConfiguration
@@ -60,8 +61,9 @@ public open class ConfigurationImpl(
     schemaVersion: Long,
     schemaMode: SchemaMode,
     private val userEncryptionKey: ByteArray?,
+    override val encryptionKeyAsCallback: EncryptionKeyCallback?,
     compactOnLaunchCallback: CompactOnLaunchCallback?,
-    private val userMigration: RealmMigration?,
+    userMigration: RealmMigration?,
     automaticBacklinkHandling: Boolean,
     initialDataCallback: InitialDataCallback?,
     override val isFlexibleSyncConfiguration: Boolean,
@@ -228,6 +230,10 @@ public open class ConfigurationImpl(
 
             userEncryptionKey?.let { key: ByteArray ->
                 RealmInterop.realm_config_set_encryption_key(nativeConfig, key)
+            }
+
+            encryptionKeyAsCallback?.let {
+                RealmInterop.realm_config_set_encryption_key_from_pointer(nativeConfig, it.keyPointer())
             }
 
             RealmInterop.realm_config_set_in_memory(nativeConfig, inMemory)

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmConfigurationImpl.kt
@@ -17,6 +17,7 @@
 package io.realm.kotlin.internal
 
 import io.realm.kotlin.CompactOnLaunchCallback
+import io.realm.kotlin.EncryptionKeyCallback
 import io.realm.kotlin.InitialDataCallback
 import io.realm.kotlin.InitialRealmFileConfiguration
 import io.realm.kotlin.LogConfiguration
@@ -40,6 +41,7 @@ internal class RealmConfigurationImpl(
     writeDispatcherFactory: CoroutineDispatcherFactory,
     schemaVersion: Long,
     encryptionKey: ByteArray?,
+    encryptionKeyAsCallback: EncryptionKeyCallback?,
     override val deleteRealmIfMigrationNeeded: Boolean,
     compactOnLaunchCallback: CompactOnLaunchCallback?,
     migration: RealmMigration?,
@@ -62,6 +64,7 @@ internal class RealmConfigurationImpl(
         false -> SchemaMode.RLM_SCHEMA_MODE_AUTOMATIC
     },
     encryptionKey,
+    encryptionKeyAsCallback,
     compactOnLaunchCallback,
     migration,
     automaticBacklinkHandling,

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/sync/SyncConfiguration.kt
@@ -565,6 +565,7 @@ public interface SyncConfiguration : Configuration {
                 schemaVersion,
                 SchemaMode.RLM_SCHEMA_MODE_ADDITIVE_DISCOVERED,
                 encryptionKey,
+                encryptionKeyAsCallback,
                 compactOnLaunchCallback,
                 null, // migration is not relevant for sync,
                 false, // automatic backlink handling is not relevant for sync

--- a/packages/test-base/src/androidMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/androidMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -56,6 +56,17 @@ actual object PlatformUtils {
         }
         SystemClock.sleep(5000) // 5 seconds to give the GC some time to process
     }
+
+    actual fun allocateEncryptionKeyOnNativeMemory(aesKey: ByteArray): Long {
+        // Note: the ByteBuffer is not guaranteed to be in native memory (it could use a backing array)
+        //       use allocateDirect.hasArray() to find out. Ideally we want to use JNI for Android to
+        //       create such native array.
+        TODO()
+    }
+
+    actual fun freeEncryptionKeyFromNativeMemory(aesKeyPointer: Long) {
+        TODO()
+    }
 }
 
 // Allocs as much garbage as we can. Pass maxSize = 0 to use all available memory in the process.

--- a/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
+++ b/packages/test-base/src/commonMain/kotlin/io/realm/kotlin/test/platform/PlatformUtils.kt
@@ -10,4 +10,17 @@ expect object PlatformUtils {
     fun sleep(duration: Duration)
     fun threadId(): ULong
     fun triggerGC()
+
+    /**
+     * Allocate a 64 byte array in native memory that contains the encryption key to be used.
+     *
+     * @param aesKey the value of the byte array to be copied.
+     * @return the address pointer to the memory region allocated.
+     */
+    fun allocateEncryptionKeyOnNativeMemory(aesKey: ByteArray): Long
+
+    /**
+     * Zero-out and release a previously written encryption key from native memory.
+     */
+    fun freeEncryptionKeyFromNativeMemory(aesKeyPointer: Long)
 }


### PR DESCRIPTION
This PR adds the ability to use pass in the AES encryption key from a native memory region. After opening the Realm the caller can reset this native memory region to reduce the window where the key is available clear in memory.

- [ ] Changelog 
- [ ] Test will not pass on Android (need to add a helper method in JNI to allocate native memory for the `openEncryptedRealmWithEncryptionKeyCallback` test)