### PR TITLE
Using test parameter to feed BAAS URL to device farm

### DIFF
--- a/.github/actions/run-android-device-farm-test/action.yml
+++ b/.github/actions/run-android-device-farm-test/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Install additional APKs needed for the tests'
     default: ''
     required: false
+  baas_url:
+    description: 'URL of the test server to be used'
+    required: true
+    type: string
   app-id:
     description: 'The test runner class to use'
     required: true
@@ -46,7 +50,7 @@ runs:
             test:
               commands:
                 - adb shell pm list packages | grep realm
-                - adb shell am instrument -w -r ${{ inputs.app-id }}/androidx.test.runner.AndroidJUnitRunner | egrep 'OK \([0-9]+ test[s]?\)'
+                - adb shell am instrument -w -e baas_url ${{ inputs.baas_url }} -r ${{ inputs.app-id }}/androidx.test.runner.AndroidJUnitRunner | egrep 'OK \([0-9]+ test[s]?\)'
 
     - run: |
         Install-Module -Name AWSPowerShell -Force

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -530,23 +530,6 @@ jobs:
       - name: Install JSON parser
         run: brew install jq
 
-      # checkout BAAS CLI repo
-      - name: Checkout BAAS repo
-        run: |
-          echo ${{ secrets.BAAS_CLI }} | gh auth login --with-token
-          gh repo clone 10gen/baasaas
-          
-      # Start BAAS instance in the background
-      # We save the container id to poll against and get the hostname info later
-      - name: Start Baas instance in the background
-        id: baas_cli_start
-        working-directory: baasaas
-        env:
-          APIKEY: ${{ secrets.BAAS_CLI_API_KEY }}
-        run: |
-          OUTPUT=$(bash cli.sh start | jq -r '.id')
-          echo "baas_container_id=$OUTPUT" >> $GITHUB_OUTPUT
-
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.13
         with:
@@ -584,16 +567,6 @@ jobs:
         working-directory: packages
         run: ./gradlew  :test-base:assembleAndroidTest -Prealm.kotlin.buildRealmCore=false -Prealm.kotlin.mainHost=false
 
-      # We poll the previously started BAAS container to get the hostname of the container to use with Device Farm tests
-      - name: Fetching the BAAS CLI hostname
-        id: baas_cli_poll
-        working-directory: baasaas
-        env:
-          APIKEY: ${{ secrets.BAAS_CLI_API_KEY }}
-        run: |
-          OUTPUT=$(bash cli.sh poll ${{ steps.baas_cli_start.outputs.baas_container_id }} | jq -r '.httpUrl')
-          echo "baas_container_hostname=$OUTPUT" >> $GITHUB_OUTPUT
-      
       - name: Build Android Sync Test Apk
         working-directory: packages
         run: ./gradlew -PsyncTestUrl=${{ steps.baas_cli_poll.outputs.baas_container_hostname }} :test-sync:packageDebug :test-sync:assembleAndroidTest -Prealm.kotlin.buildRealmCore=false -Prealm.kotlin.mainHost=false
@@ -1122,6 +1095,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      # checkout BAAS CLI repo
+      - name: Checkout BAAS repo
+        run: |
+          echo ${{ secrets.BAAS_CLI }} | gh auth login --with-token
+          gh repo clone 10gen/baasaas
+
+      # Start BAAS instance in the background
+      # We save the container id to poll against and get the hostname info later
+      - name: Start Baas instance in the background
+        id: baas_cli_start
+        working-directory: baasaas
+        env:
+          APIKEY: ${{ secrets.BAAS_CLI_API_KEY }}
+        run: |
+          OUTPUT=$(bash cli.sh start | jq -r '.id')
+          echo "baas_container_id=$OUTPUT" >> $GITHUB_OUTPUT
+
       - name: Restore Android Sync Test APK
         uses: actions/download-artifact@v3
         with:
@@ -1135,29 +1125,35 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_DEVICEFARM_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
+      # We poll the previously started BAAS container to get the hostname of the container to use with Device Farm tests
+      - name: Fetching the BAAS CLI hostname
+        id: baas_cli_poll
+        working-directory: baasaas
+        env:
+          APIKEY: ${{ secrets.BAAS_CLI_API_KEY }}
+        run: |
+          OUTPUT=$(bash cli.sh poll ${{ steps.baas_cli_start.outputs.baas_container_id }} | jq -r '.httpUrl')
+          echo "baas_container_hostname=$OUTPUT" >> $GITHUB_OUTPUT
+
       - name: Run the Sync tests
         uses: ./.github/actions/run-android-device-farm-test
         id: run_android_tests
         with:
           apk-path: ${{ github.workspace }}/packages/test-sync/build/outputs/apk/androidTest/debug/test-sync-debug-androidTest.apk
           apk-auxiliary-path: ${{ github.workspace }}/packages/test-sync/build/outputs/apk/debug/test-sync-debug.apk
+          baas_url: ${{ steps.baas_cli_poll.outputs.baas_container_hostname }}
           app-id: io.realm.sync.testapp.test
           project-arn: ${{ secrets.DEVICEFARM_PROJECT_ARN }}
           device-pool-arn: ${{ secrets.DEVICEFARM_POOL_ARN }}
 
-      - name: Checkout BAAS repo
-        if: always()
-        run: |
-          echo ${{ secrets.BAAS_CLI }} | gh auth login --with-token
-          gh repo clone 10gen/baasaas
       - name: Stopping the BAAS container
         if: always()
         working-directory: baasaas
         env:
           APIKEY: ${{ secrets.BAAS_CLI_API_KEY }}
         run: |
-          if [ -n "${{ needs.build-android-packages.outputs.baas-container-id }}" ]; then
-            bash cli.sh stop ${{ needs.build-android-packages.outputs.baas-container-id }}
+          if [ -n "${{ steps.baas_cli_start.outputs.baas_container_id }}" ]; then
+            bash cli.sh stop ${{ steps.baas_cli_start.outputs.baas_container_id }}
           fi  
 
   test-macos-packages:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -569,7 +569,7 @@ jobs:
 
       - name: Build Android Sync Test Apk
         working-directory: packages
-        run: ./gradlew -PsyncTestUrl=${{ steps.baas_cli_poll.outputs.baas_container_hostname }} :test-sync:packageDebug :test-sync:assembleAndroidTest -Prealm.kotlin.buildRealmCore=false -Prealm.kotlin.mainHost=false
+        run: ./gradlew :test-sync:packageDebug :test-sync:assembleAndroidTest -Prealm.kotlin.buildRealmCore=false -Prealm.kotlin.mainHost=false
 
       - name: Build packages
         working-directory: packages

--- a/packages/test-sync/src/androidMain/kotlin/io/realm/kotlin/test/mongodb/BaasUtils.kt
+++ b/packages/test-sync/src/androidMain/kotlin/io/realm/kotlin/test/mongodb/BaasUtils.kt
@@ -1,0 +1,11 @@
+package io.realm.kotlin.test.mongodb
+
+import android.os.Bundle
+import androidx.test.platform.app.InstrumentationRegistry
+
+actual fun baasTestUrl(): String {
+    val arguments: Bundle = InstrumentationRegistry.getArguments()
+    // if the test runner provided an argument for the BAAS URL use it
+    // Example: adb shell am instrument -w -e baas_url "http"//8.8.8.8:2134" -r io.realm.sync.testapp.test/androidx.test.runner.AndroidJUnitRunner
+    return arguments.getString("baas_url") ?: SyncServerConfig.url
+}

--- a/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
+++ b/packages/test-sync/src/commonMain/kotlin/io/realm/kotlin/test/mongodb/TestApp.kt
@@ -49,8 +49,10 @@ val TEST_APP_PARTITION = syncServerAppName("pbs") // With Partition-based Sync
 val TEST_APP_FLEX = syncServerAppName("flx") // With Flexible Sync
 val TEST_APP_CLUSTER_NAME = SyncServerConfig.clusterName
 
-val TEST_SERVER_BASE_URL = SyncServerConfig.url
+val TEST_SERVER_BASE_URL = baasTestUrl()
 const val DEFAULT_PASSWORD = "password1234"
+
+expect fun baasTestUrl(): String
 
 // Expose a try-with-resource pattern for Test Apps
 inline fun App.use(action: (App) -> Unit) {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/CredentialsTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/CredentialsTests.kt
@@ -369,7 +369,7 @@ class CredentialsTests {
             payload = mapOf("mail" to TestHelper.randomEmail(), "id" to 0)
         )
 
-        assertFailsWithMessage<AuthException>("[Service][AuthError(4346)] error executing auth function: Error: Authentication failed.") {
+        assertFailsWithMessage<AuthException>("[Service][AuthError(4346)] Error: Authentication failed.") {
             runBlocking {
                 app.login(credentials)
             }

--- a/packages/test-sync/src/jvmMain/kotlin/io/realm/kotlin/test/mongodb/BaasUtils.kt
+++ b/packages/test-sync/src/jvmMain/kotlin/io/realm/kotlin/test/mongodb/BaasUtils.kt
@@ -1,0 +1,3 @@
+package io.realm.kotlin.test.mongodb
+
+actual fun baasTestUrl(): String = SyncServerConfig.url

--- a/packages/test-sync/src/nativeDarwin/kotlin/io/realm/kotlin/test/mongodb/BaasUtils.kt
+++ b/packages/test-sync/src/nativeDarwin/kotlin/io/realm/kotlin/test/mongodb/BaasUtils.kt
@@ -1,0 +1,3 @@
+package io.realm.kotlin.test.mongodb
+
+actual fun baasTestUrl(): String = SyncServerConfig.url


### PR DESCRIPTION
Using AndroidTestRunner to parametrise the URL of the BAAS server when running Sync tests on Device Farm. We now can replay the sync test without the need to rebuild the APK. see https://github.com/realm/realm-kotlin/actions/runs/7679635078/job/20931215946#step:8:43 
<img width="1288" alt="image" src="https://github.com/realm/realm-kotlin/assets/1793238/d6fde2bc-32e7-4519-8a48-d5c15632a570">
