### PR TITLE
Add specific exception for auth errors being sent to to the Sync Session error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 
 ### Enhancements
 * [Sync] Added option to use managed WebSockets via OkHttp instead of Realm's built-in WebSocket client for Sync traffic (Only Android and JVM targets for now). Managed WebSockets offer improved support for proxies and firewalls that require authentication. This feature is currently opt-in and can be enabled by using `AppConfiguration.usePlatformNetworking()`. Managed WebSockets will become the default in a future version. (PR [#1528](https://github.com/realm/realm-kotlin/pull/1528)).
-* `AutoClientResetFailed` exception now reports as the throwable cause any user exceptions that might occur during a client reset. (Issue [#1580](https://github.com/realm/realm-kotlin/issues/1580))
+* [Sync] `AutoClientResetFailed` exception now reports as the throwable cause any user exceptions that might occur during a client reset. (Issue [#1580](https://github.com/realm/realm-kotlin/issues/1580))
+* [Sync] Added a new `SyncSessionAuthExpired` exception subclass that will be sent to the `SyncConfiguration.errorHandler` if the sync session is stopped because the users refresh token
+is no longer valid and they need to log in again. (Isse [#1640](https://github.com/realm/realm-kotlin/issues/1640))
 
 ### Fixed
 * Cache notification callback JNI references at startup to ensure that symbols can be resolved in core callbacks. (Issue [#1577](https://github.com/realm/realm-kotlin/issues/1577))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 ### Enhancements
 * [Sync] Added option to use managed WebSockets via OkHttp instead of Realm's built-in WebSocket client for Sync traffic (Only Android and JVM targets for now). Managed WebSockets offer improved support for proxies and firewalls that require authentication. This feature is currently opt-in and can be enabled by using `AppConfiguration.usePlatformNetworking()`. Managed WebSockets will become the default in a future version. (PR [#1528](https://github.com/realm/realm-kotlin/pull/1528)).
 * [Sync] `AutoClientResetFailed` exception now reports as the throwable cause any user exceptions that might occur during a client reset. (Issue [#1580](https://github.com/realm/realm-kotlin/issues/1580))
-* [Sync] Added a new `SyncSessionAuthExpired` exception subclass that will be sent to the `SyncConfiguration.errorHandler` if the sync session is stopped because the users refresh token
-is no longer valid and they need to log in again. (Isse [#1640](https://github.com/realm/realm-kotlin/issues/1640))
+* [Sync] Added a new `SyncSessionAuthExpired` exception subclass that will be sent to the `SyncConfiguration.errorHandler` if the sync session is stopped because the users refresh token is no longer valid and they need to log in again. (Isse [#1640](https://github.com/realm/realm-kotlin/issues/1640))
 
 ### Fixed
 * Cache notification callback JNI references at startup to ensure that symbols can be resolved in core callbacks. (Issue [#1577](https://github.com/realm/realm-kotlin/issues/1577))

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/SyncExceptions.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/SyncExceptions.kt
@@ -64,6 +64,18 @@ public class BadFlexibleSyncQueryException internal constructor(message: String)
     SyncException(message)
 
 /**
+ * Thrown when the sync sessions access token expires and it isn't possible to renew it
+ * automatically because the users refresh token is no longer valid.
+ *
+ * Device Sync is stopped and can only be resumed after closing the realm, logging the user
+ * back in and reopen the realm by using the new user object.
+ *
+ * @see https://www.mongodb.com/docs/atlas/app-services/users/sessions/
+ */
+public class SyncSessionAuthExpired internal constructor(message: String) :
+    SyncException(message)
+
+/**
  * Thrown when the server undoes one or more client writes. Details on undone writes can be found in
  * [writes].
  */

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/SyncExceptions.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/SyncExceptions.kt
@@ -72,7 +72,7 @@ public class BadFlexibleSyncQueryException internal constructor(message: String)
  *
  * @see https://www.mongodb.com/docs/atlas/app-services/users/sessions/
  */
-public class SyncSessionAuthExpired internal constructor(message: String) :
+public class AuthExpiredException internal constructor(message: String) :
     SyncException(message)
 
 /**

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/RealmSyncUtils.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/RealmSyncUtils.kt
@@ -17,6 +17,7 @@ import io.realm.kotlin.mongodb.exceptions.FunctionExecutionException
 import io.realm.kotlin.mongodb.exceptions.InvalidCredentialsException
 import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.mongodb.exceptions.SyncException
+import io.realm.kotlin.mongodb.exceptions.SyncSessionAuthExpired
 import io.realm.kotlin.mongodb.exceptions.UnrecoverableSyncException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyConfirmedException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
@@ -79,6 +80,7 @@ internal fun convertSyncError(syncError: SyncError): SyncException {
     val errorCode = syncError.errorCode
     val message = createMessageFromSyncError(errorCode)
     return when (errorCode.errorCode) {
+        ErrorCode.RLM_ERR_AUTH_ERROR -> SyncSessionAuthExpired(message)
         ErrorCode.RLM_ERR_WRONG_SYNC_TYPE -> WrongSyncTypeException(message)
 
         ErrorCode.RLM_ERR_INVALID_SUBSCRIPTION_QUERY -> {

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/RealmSyncUtils.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/RealmSyncUtils.kt
@@ -8,6 +8,7 @@ import io.realm.kotlin.internal.interop.sync.AppError
 import io.realm.kotlin.internal.interop.sync.SyncError
 import io.realm.kotlin.mongodb.exceptions.AppException
 import io.realm.kotlin.mongodb.exceptions.AuthException
+import io.realm.kotlin.mongodb.exceptions.AuthExpiredException
 import io.realm.kotlin.mongodb.exceptions.BadFlexibleSyncQueryException
 import io.realm.kotlin.mongodb.exceptions.BadRequestException
 import io.realm.kotlin.mongodb.exceptions.CompensatingWriteException
@@ -17,7 +18,6 @@ import io.realm.kotlin.mongodb.exceptions.FunctionExecutionException
 import io.realm.kotlin.mongodb.exceptions.InvalidCredentialsException
 import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.mongodb.exceptions.SyncException
-import io.realm.kotlin.mongodb.exceptions.SyncSessionAuthExpired
 import io.realm.kotlin.mongodb.exceptions.UnrecoverableSyncException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyConfirmedException
 import io.realm.kotlin.mongodb.exceptions.UserAlreadyExistsException
@@ -80,7 +80,7 @@ internal fun convertSyncError(syncError: SyncError): SyncException {
     val errorCode = syncError.errorCode
     val message = createMessageFromSyncError(errorCode)
     return when (errorCode.errorCode) {
-        ErrorCode.RLM_ERR_AUTH_ERROR -> SyncSessionAuthExpired(message)
+        ErrorCode.RLM_ERR_AUTH_ERROR -> AuthExpiredException(message)
         ErrorCode.RLM_ERR_WRONG_SYNC_TYPE -> WrongSyncTypeException(message)
 
         ErrorCode.RLM_ERR_INVALID_SUBSCRIPTION_QUERY -> {


### PR DESCRIPTION
Closes #1640 

This adds a specific exception class for auth errors being sent to the SyncSession error handler. This is relevant as this indicates the user's credentials are no longer valid and they need to log in again.

Some open questions:

- [ ] Should it be possible to update the refresh token on an already open Realm? (this will require changes in Core)
- [ ] It is a bit annoying to create an "auth" type exception under `SyncException` when we already have `AuthException` under `AppException`. But relaxing the interface would be a breaking change and besides, this is the only "App" type exception that would surface here anyway.
- [ ] Naming... alternatives considered:  `SyncSessionExpiredException`, `SyncAuthException`, `SyncSessionAuthExpired`. Choosing `AuthExpiredException` was somewhat arbitrary, except it felt short and to the point. Not sure if `Sync` or `Session` should somehow be part of the name to separate it more from the generic `AuthException` that is an `AppException`. All our other specific exception types end with `Exception`
