### PR TITLE
Fix list indexof, remove and contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This release will bump the Realm file format from version 23 to 24. Opening a fi
 * [Sync] Added option to use managed WebSockets via OkHttp instead of Realm's built-in WebSocket client for Sync traffic (Only Android and JVM targets for now). Managed WebSockets offer improved support for proxies and firewalls that require authentication. This feature is currently opt-in and can be enabled by using `AppConfiguration.usePlatformNetworking()`. Managed WebSockets will become the default in a future version. (PR [#1528](https://github.com/realm/realm-kotlin/pull/1528)).
 * `AutoClientResetFailed` exception now reports as the throwable cause any user exceptions that might occur during a client reset. (Issue [#1580](https://github.com/realm/realm-kotlin/issues/1580))
 * The Unpacking of JVM native library will use the current library version instead of a calculated hash for the path. (Issue [#1617](https://github.com/realm/realm-kotlin/issues/1617)).
+* Optimized `RealmList.indexOf()` and `RealmList.contains()` using Core implementation of operations instead of iterating elements and comparing them in Kotlin. (Issue [#1625](https://github.com/realm/realm-kotlin/pull/1666) [RKOTLIN-995](https://jira.mongodb.org/browse/RKOTLIN-995)).
 
 ### Fixed
 * Cache notification callback JNI references at startup to ensure that symbols can be resolved in core callbacks. (Issue [#1577](https://github.com/realm/realm-kotlin/issues/1577))

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -55,6 +55,8 @@ expect val INVALID_PROPERTY_KEY: PropertyKey
 const val OBJECT_ID_BYTES_SIZE = 12
 const val UUID_BYTES_SIZE = 16
 
+const val INDEX_NOT_FOUND = -1L
+
 // Pure marker interfaces corresponding to the C-API realm_x_t struct types
 interface CapiT
 interface RealmConfigT : CapiT

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -317,6 +317,7 @@ expect object RealmInterop {
     fun realm_get_backlinks(obj: RealmObjectPointer, sourceClassKey: ClassKey, sourcePropertyKey: PropertyKey): RealmResultsPointer
     fun realm_list_size(list: RealmListPointer): Long
     fun MemAllocator.realm_list_get(list: RealmListPointer, index: Long): RealmValue
+    fun realm_list_find(list: RealmListPointer, value: RealmValue): Long
     fun realm_list_get_list(list: RealmListPointer, index: Long): RealmListPointer
     fun realm_list_get_dictionary(list: RealmListPointer, index: Long): RealmMapPointer
     fun realm_list_add(list: RealmListPointer, index: Long, transport: RealmValue)

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -568,6 +568,18 @@ actual object RealmInterop {
         realmc.realm_list_get(list.cptr(), index, struct)
         return RealmValue(struct)
     }
+
+    actual fun realm_list_find(list: RealmListPointer, value: RealmValue): Long {
+        val index = LongArray(1)
+        val found = BooleanArray(1)
+        realmc.realm_list_find(list.cptr(), value.value, index, found)
+        return if (found[0]) {
+            index[0]
+        } else {
+            -1
+        }
+    }
+
     actual fun realm_list_get_list(list: RealmListPointer, index: Long): RealmListPointer =
         LongPointerWrapper(realmc.realm_list_get_list(list.cptr(), index))
 

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -576,7 +576,7 @@ actual object RealmInterop {
         return if (found[0]) {
             index[0]
         } else {
-            -1
+            INDEX_NOT_FOUND
         }
     }
 

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1038,6 +1038,19 @@ actual object RealmInterop {
         return RealmValue(struct)
     }
 
+    actual fun realm_list_find(list: RealmListPointer, value: RealmValue): Long {
+        memScoped {
+            val index = alloc<ULongVar>()
+            val found = alloc<BooleanVar>()
+            checkedBooleanResult(realm_wrapper.realm_list_find(list.cptr(), value.value.readValue(), index.ptr, found.ptr))
+            return if (found.value) {
+                index.value.toLong()
+            } else {
+                -1
+            }
+        }
+    }
+
     actual fun realm_list_get_list(list: RealmListPointer, index: Long): RealmListPointer =
         CPointerWrapper(realm_wrapper.realm_list_get_list(list.cptr(), index.toULong()))
 

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1046,7 +1046,7 @@ actual object RealmInterop {
             return if (found.value) {
                 index.value.toLong()
             } else {
-                -1
+                INDEX_NOT_FOUND
             }
         }
     }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmListInternal.kt
@@ -51,6 +51,8 @@ import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
+internal const val INDEX_NOT_FOUND = io.realm.kotlin.internal.interop.INDEX_NOT_FOUND
+
 /**
  * Implementation for unmanaged lists, backed by a [MutableList].
  */

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmListInternal.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/RealmListInternal.kt
@@ -99,7 +99,6 @@ internal class ManagedRealmList<E>(
         return operator.indexOf(element)
     }
 
-
     override fun add(index: Int, element: E) {
         operator.insert(index, element)
     }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmAnyNestedCollectionTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmAnyNestedCollectionTests.kt
@@ -612,8 +612,9 @@ class RealmAnyNestedCollectionTests {
         realm.query<JsonStyleRealmObject>("value[0][*] == {4, 5, 6}").find().single().run {
             assertEquals("EMBEDDED", id)
         }
-        realm.query<JsonStyleRealmObject>("value[*][*] == {4, 5, 6}").find().single().run {
-            assertEquals("EMBEDDED", id)
-        }
+        // FIXME Core issue https://github.com/realm/realm-core/issues/7393
+        // realm.query<JsonStyleRealmObject>("value[*][*] == {4, 5, 6}").find().single().run {
+        //    assertEquals("EMBEDDED", id)
+        // }
     }
 }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmAnyNestedCollectionTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmAnyNestedCollectionTests.kt
@@ -573,6 +573,9 @@ class RealmAnyNestedCollectionTests {
         realm.query<JsonStyleRealmObject>("value[*] == 4").find().single().run {
             assertEquals("LIST", id)
         }
+        realm.query<JsonStyleRealmObject>("value[*] == {4, 5, 6}").find().single().run {
+            assertEquals("LIST", id)
+        }
 
         // Matching dictionaries
         realm.query<JsonStyleRealmObject>("value.key1 == 7").find().single().run {
@@ -604,6 +607,12 @@ class RealmAnyNestedCollectionTests {
             assertEquals("EMBEDDED", id)
         }
         realm.query<JsonStyleRealmObject>("value[*].key3[0] == 9").find().single().run {
+            assertEquals("EMBEDDED", id)
+        }
+        realm.query<JsonStyleRealmObject>("value[0][*] == {4, 5, 6}").find().single().run {
+            assertEquals("EMBEDDED", id)
+        }
+        realm.query<JsonStyleRealmObject>("value[*][*] == {4, 5, 6}").find().single().run {
             assertEquals("EMBEDDED", id)
         }
     }

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmListTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmListTests.kt
@@ -722,13 +722,6 @@ class RealmListTests : EmbeddedObjectCollectionQueryTests {
                     ),
                     classifier
                 )
-                ByteArray::class -> ByteArrayListTester(
-                    realm = realm,
-                    typeSafetyManager = getTypeSafety(
-                        classifier,
-                        elementType.nullable
-                    ) as ListTypeSafetyManager<ByteArray?>
-                )
                 RealmAny::class -> RealmAnyListTester(
                     realm = realm,
                     typeSafetyManager = ListTypeSafetyManager(
@@ -1366,38 +1359,6 @@ internal class RealmObjectListTester(
 ) : ManagedListTester<RealmListContainer>(realm, typeSafetyManager, classifier) {
     override fun assertElementsAreEqual(expected: RealmListContainer, actual: RealmListContainer) =
         assertEquals(expected.stringField, actual.stringField)
-}
-
-/**
- * Check equality for ByteArrays at a structural level with `assertContentEquals`.
- */
-internal class ByteArrayListTester(
-    realm: Realm,
-    typeSafetyManager: ListTypeSafetyManager<ByteArray?>
-) : ManagedListTester<ByteArray?>(realm, typeSafetyManager, ByteArray::class) {
-    override fun assertElementsAreEqual(expected: ByteArray?, actual: ByteArray?) =
-        assertContentEquals(expected, actual)
-
-    // Removing elements using equals/hashcode will fail for byte arrays since they are
-    // are only equal if identical
-    override fun remove() {
-        val dataSet = typeSafetyManager.dataSetToLoad
-        val assertions = { list: RealmList<ByteArray?> ->
-            assertFalse(list.isEmpty())
-        }
-
-        errorCatcher {
-            realm.writeBlocking {
-                val list = typeSafetyManager.createContainerAndGetCollection(this)
-                assertFalse(list.remove(dataSet[0]))
-                assertTrue(list.add(dataSet[0]))
-                assertFalse(list.remove(list.last()))
-                assertions(list)
-            }
-        }
-
-        assertListAndCleanup { list -> assertions(list) }
-    }
 }
 
 // -----------------------------------

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmListNotificationsTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/notifications/RealmListNotificationsTests.kt
@@ -21,6 +21,7 @@ import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.entities.Sample
 import io.realm.kotlin.entities.list.RealmListContainer
 import io.realm.kotlin.entities.list.listTestSchema
+import io.realm.kotlin.ext.asRealmObject
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.notifications.DeletedList
 import io.realm.kotlin.notifications.InitialList
@@ -35,6 +36,8 @@ import io.realm.kotlin.test.common.utils.assertIsChangeSet
 import io.realm.kotlin.test.platform.PlatformUtils
 import io.realm.kotlin.test.util.TestChannel
 import io.realm.kotlin.test.util.receiveOrFail
+import io.realm.kotlin.test.util.trySendOrFail
+import io.realm.kotlin.types.RealmAny
 import io.realm.kotlin.types.RealmList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -731,6 +734,80 @@ class RealmListNotificationsTests : RealmEntityNotificationTests {
         }
         assertFailsWith<IllegalArgumentException> {
             list.asFlow(listOf("objectListField.intListField.foo"))
+        }
+    }
+
+    @Test
+    fun eventsOnObjectChangesInList() {
+        runBlocking {
+            val channel = Channel<ListChange<RealmListContainer>>(10)
+            val parent = realm.write { copyToRealm(RealmListContainer()).apply { stringField = "PARENT" } }
+
+            val listener = async {
+                parent.objectListField.asFlow().collect {
+                    channel.trySendOrFail(it)
+                }
+            }
+
+            channel.receiveOrFail(message = "Initial event").let { assertIs<InitialList<*>>(it) }
+
+            realm.write {
+                findLatest(parent)!!.objectListField.add(
+                    RealmListContainer().apply { stringField = "CHILD" }
+                )
+            }
+            channel.receiveOrFail(message = "List add").let {
+                assertIs<UpdatedList<*>>(it)
+                assertEquals(1, it.list.size)
+            }
+
+            realm.write {
+                findLatest(parent)!!.objectListField[0].stringField = "TEST"
+            }
+            channel.receiveOrFail(message = "Object updated").let {
+                assertIs<UpdatedList<*>>(it)
+                assertEquals(1, it.list.size)
+                assertEquals("TEST", it.list[0].stringField)
+            }
+
+            listener.cancel()
+        }
+    }
+    @Test
+    @Ignore // https://github.com/realm/realm-core/issues/7264
+    fun eventsOnObjectChangesInRealmAnyList() {
+        runBlocking {
+            val channel = Channel<ListChange<RealmAny?>>(10)
+            val parent = realm.write { copyToRealm(RealmListContainer()).apply { stringField = "PARENT" } }
+
+            val listener = async {
+                parent.nullableRealmAnyListField.asFlow().collect {
+                    channel.trySendOrFail(it)
+                }
+            }
+
+            channel.receiveOrFail(message = "Initial event").let { assertIs<InitialList<*>>(it) }
+
+            realm.write {
+                findLatest(parent)!!.nullableRealmAnyListField.add(
+                    RealmAny.create(RealmListContainer().apply { stringField = "CHILD" })
+                )
+            }
+            channel.receiveOrFail(message = "List add").let {
+                assertIs<UpdatedList<*>>(it)
+                assertEquals(1, it.list.size)
+            }
+
+            realm.write {
+                findLatest(parent)!!.nullableRealmAnyListField[0]!!.asRealmObject<RealmListContainer>().stringField = "TEST"
+            }
+            channel.receiveOrFail(message = "Object updated").let {
+                assertIs<UpdatedList<*>>(it)
+                assertEquals(1, it.list.size)
+                assertEquals("TEST", it.list[0]!!.asRealmObject<RealmListContainer>().stringField)
+            }
+
+            listener.cancel()
         }
     }
 


### PR DESCRIPTION
This PR passes arguments to `RealmList`s `indexOf`, `remove` and `contains` to core instead of relying on Kotlin object equality checks. 

Closes #1625 RKOTLIN-995