### PR TITLE
[RKOTLIN-1037] Copy missing JVM binaries (Win/Linux) when releasing

### DIFF
--- a/.github/workflows/include-deploy-release.yml
+++ b/.github/workflows/include-deploy-release.yml
@@ -108,5 +108,5 @@ jobs:
          "${{ secrets.DOCS_S3_ACCESS_KEY }}" "${{ secrets.DOCS_S3_SECRET_KEY }}" \
          "${{ secrets.SLACK_URL_RELEASE }}" "${{ secrets.SLACK_URL_CI }}" \
          "${{ secrets.GRADLE_PORTAL_KEY }}" "${{ secrets.GRADLE_PORTAL_SECRET }}" \
-         '-PsignBuild=true -PsignSecretRingFileKotlin="${{ secrets.GPG_SIGNING_KEY_BASE_64_DBG }}" -PsignPasswordKotlin=${{ secrets.GPG_PASS_PHRASE_DBG }}'
+         '-PsignBuild=true -PsignSecretRingFileKotlin="${{ secrets.GPG_SIGNING_KEY_BASE_64_DBG }}" -PsignPasswordKotlin=${{ secrets.GPG_PASS_PHRASE_DBG }} -Prealm.kotlin.copyNativeJvmLibs=linux,windows'
         

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -145,7 +145,11 @@ jobs:
             rm -rf realmLinuxBuild
             mkdir realmLinuxBuild
             cd realmLinuxBuild
-            cmake ../../src/jvm
+            cmake -DCMAKE_BUILD_TYPE=Release \
+            -DREALM_ENABLE_SYNC=1 \
+            -DREALM_NO_TESTS=1 \
+            -DREALM_BUILD_LIB_ONLY=true \
+            ../../src/jvm
             make -j8
 
       - name: Upload artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Enhancements
 
-- None.
+- Fixes missing binaries files for Windows and Linux platforms when releasing. (Issue [#1671](https://github.com/realm/realm-kotlin/issues/1690) [JIRA](https://jira.mongodb.org/browse/RKOTLIN-1037))
 
 ### Fixed
 


### PR DESCRIPTION
- Fixes https://github.com/realm/realm-kotlin/issues/1690 
- Building cinterop-jvm Linux shared library in Release mode