### PR TITLE
[RKOTLIN-1040] Fixing doc mime type

### DIFF
--- a/packages/build.gradle.kts
+++ b/packages/build.gradle.kts
@@ -185,6 +185,8 @@ tasks.register("uploadDokka") {
                 commandLine = listOf(
                     "s3cmd",
                     "put",
+                    "--no-mime-magic",
+                    "--guess-mime-type",
                     "--recursive",
                     "--acl-public",
                     "--access_key=$awsAccessKey",


### PR DESCRIPTION
API docs didn't publish with the correct styles. Fix inspired by https://github.com/realm/realm-swift/pull/8488/files#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R1297

I did a manual push of the doc with this fix and it looks fine https://www.mongodb.com/docs/realm-sdks/kotlin/latest/index.html
<img width="1335" alt="image" src="https://github.com/realm/realm-kotlin/assets/1793238/43af3981-1423-4e75-98ae-37ea981e94d8">
