### PR TITLE
[RKOTLIN-1062] Remove CMake required version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Minimum R8: 8.0.34.
 
 ### Internal
-- None
+- Remove CMake required version.
 
 ## 1.14.2-SNAPSHOT (YYYY-MM-DD)
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -113,9 +113,6 @@ object Versions {
     const val atomicfu = "0.18.5" // https://github.com/Kotlin/kotlinx.atomicfu
     const val autoService = "1.0" // https://mvnrepository.com/artifact/com.google.auto.service/auto-service
     const val buildkonfig = "0.13.3" // https://github.com/yshrsmz/BuildKonfig
-    // Not currently used, so mostly here for documentation. Core requires minimum 3.15, but 3.18.1 is available through the Android SDK.
-    // Build also tested successfully with 3.21.4 (latest release).
-    const val cmake = "3.27.7"
     const val coroutines = "1.7.0" // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
     const val datetime = "0.4.0" // https://github.com/Kotlin/kotlinx-datetime
     const val detektPlugin = "1.22.0-RC2" // https://github.com/detekt/detekt

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -328,7 +328,6 @@ android {
     // Inner externalNativeBuild (inside defaultConfig) does not seem to have correct type for setting path
     externalNativeBuild {
         cmake {
-            version = Versions.cmake
             path = project.file("src/jvm/CMakeLists.txt")
         }
     }


### PR DESCRIPTION
Removes the fixed cmake version required by cinterop to rely on Cores cmake minimum version.
