### PR TITLE
[RKOTLIN-1023] Add support for changing App Services base URL

### DIFF
--- a/.github/workflows/include-deploy-release.yml
+++ b/.github/workflows/include-deploy-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: macos-latest
+    runs-on: macos-12
     name: Deploy release 
 
     steps:

--- a/.github/workflows/include-integration-tests.yml
+++ b/.github/workflows/include-integration-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
   # TODO: The Monkey seems to crash the app all the time, but with failures that are not coming from the app. Figure out why.
   # android-sample-app:
-  #   runs-on: macos-latest
+  #   runs-on: macos-12
   #   steps:
   #     - name: Checkout code
   #       uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
           ./gradlew assembleDebug jvmJar
 
   realm-java-compatibiliy:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -217,7 +217,7 @@ jobs:
           - type: gradle75
             path: integration-tests/gradle/gradle75-test
             arguments: integrationTest
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
 
@@ -295,7 +295,7 @@ jobs:
           - type: gradle8
             path: integration-tests/gradle/gradle8-test
             arguments: integrationTest
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -229,7 +229,7 @@ jobs:
           retention-days: 1
 
   build-jvm-macos-native-lib:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: [check-cache, build-jni-swig-stub]
     if: |
       always() &&
@@ -395,7 +395,7 @@ jobs:
   # This task is also responsible for creating the Gradle and Compiler Plugin as well as 
   # all Kotlin Multiplatform Metadata
   build-jvm-packages:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: [check-cache, build-jvm-linux-native-lib, build-jvm-windows-native-lib, build-jvm-macos-native-lib]
     if: |
       always() && 
@@ -638,7 +638,7 @@ jobs:
 
   # TODO: ccache is not being used by this build for some reason
   build-macos-x64-packages:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: check-cache
     if: always() && !cancelled() && needs.check-cache.outputs.packages-macos-x64-cache-hit != 'true'
 
@@ -706,7 +706,7 @@ jobs:
           retention-days: 1
 
   build-macos-arm64-packages:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: check-cache
     # needs: static-analysis
     if: always() && !cancelled() && needs.check-cache.outputs.packages-macos-arm64-cache-hit != 'true'
@@ -774,7 +774,7 @@ jobs:
           retention-days: 1
 
   build-ios-x64-packages:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: check-cache
     # needs: static-analysis
     if: always() && !cancelled() && needs.check-cache.outputs.packages-ios-x64-cache-hit != 'true'
@@ -843,7 +843,7 @@ jobs:
           retention-days: 1
 
   build-ios-arm64-packages:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: check-cache
     # needs: static-analysis
     if: always() && !cancelled() && needs.check-cache.outputs.packages-ios-arm64-cache-hit != 'true'
@@ -931,7 +931,7 @@ jobs:
           - type: sync
             test-title: Unit Test Results - Android Sync (Emulator)
  
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: [check-cache, build-android-packages, build-jvm-packages, build-kotlin-metadata-package]
     if: |
       always() && 
@@ -1175,15 +1175,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest] # , macos-arm]
+        os: [macos-12] # , macos-arm]
         type: [base, sync]
         include:
-          - os: macos-latest
+          - os: macos-12
             type: base
             os-id: macos
             package-prefix: macos-x64
             test-title: Unit Test Results - MacOS x64 Base
-          - os: macos-latest
+          - os: macos-12
             type: sync
             os-id: macos
             package-prefix: macos-x64
@@ -1297,15 +1297,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest] # , macos-arm]
+        os: [macos-12] # , macos-arm]
         type: [base, sync]
         include:
-          - os: macos-latest
+          - os: macos-12
             type: base
             package-prefix: x64
             test-title: Unit Test Results - iOS x64 Base
             test-task: iosTest
-          - os: macos-latest
+          - os: macos-12
             type: sync
             package-prefix: x64
             test-title: Unit Test Results - iOS x64 Sync
@@ -1419,10 +1419,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest] # TODO Should we also test om MacOS arm64?
+        os: [macos-12, ubuntu-latest, windows-latest] # TODO Should we also test om MacOS arm64?
         type: [base, sync]
         include:
-          - os: macos-latest
+          - os: macos-12
             os-id: mac
             type: base
             test-title: Unit Test Results - Base JVM MacOS x64
@@ -1434,7 +1434,7 @@ jobs:
             os-id: win
             type: base
             test-title: Unit Test Results - Base JVM Windows
-          - os: macos-latest
+          - os: macos-12
             os-id: mac
             type: sync
             test-title: Unit Test Results - Sync JVM MacOS x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This release will bump the Realm file format from version 23 to 24. Opening a fi
 * None.
 
 ### Enhancements
-* Add support for changing the App Services base URL. It allows to roam between Atlas and Edge Server. Changing the url would trigger a client reset. ([JIRA]https://jira.mongodb.org/browse/RKOTLIN-1023)
+* Add support for changing the App Services base URL. It allows to roam between Atlas and Edge Server. Changing the url would trigger a client reset. (Issue [#1659](https://github.com/realm/realm-kotlin/issues/1659)/[RKOTLIN-1013](https://jira.mongodb.org/browse/RKOTLIN-1023))
 
 ### Fixed
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This release will bump the Realm file format from version 23 to 24. Opening a fi
 * None.
 
 ### Enhancements
-* None.
+* Add support for changing the App Services base URL. It allows to roam between Atlas and Edge Server. Changing the url would trigger a client reset. ([JIRA]https://jira.mongodb.org/browse/RKOTLIN-1023)
 
 ### Fixed
 * None.

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -557,7 +557,7 @@ expect object RealmInterop {
 
     fun realm_app_update_base_url(
         app: RealmAppPointer,
-        baseUrl: String,
+        baseUrl: String?,
         callback: AppCallback<Unit>,
     )
 

--- a/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/commonMain/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -551,6 +551,16 @@ expect object RealmInterop {
         callback: AppCallback<Array<ApiKeyWrapper>>,
     )
 
+    fun realm_app_get_base_url(
+        app: RealmAppPointer,
+    ): String
+
+    fun realm_app_update_base_url(
+        app: RealmAppPointer,
+        baseUrl: String,
+        callback: AppCallback<Unit>,
+    )
+
     // User
     fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity>
     fun realm_user_get_identity(user: RealmUserPointer): String

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1170,6 +1170,18 @@ actual object RealmInterop {
         return result
     }
 
+    actual fun realm_app_get_base_url(
+        app: RealmAppPointer,
+    ): String = realmc.realm_app_get_base_url(app.cptr())
+
+    actual fun realm_app_update_base_url(
+        app: RealmAppPointer,
+        baseUrl: String,
+        callback: AppCallback<Unit>,
+    ) {
+        realmc.realm_app_update_base_url(app.cptr(), baseUrl, callback)
+    }
+
     actual fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity> {
         val count = AuthProvider.values().size.toLong() // Optimistically allocate the max size of the array
         val keys = realmc.new_identityArray(count.toInt())

--- a/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/jvm/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -1176,7 +1176,7 @@ actual object RealmInterop {
 
     actual fun realm_app_update_base_url(
         app: RealmAppPointer,
-        baseUrl: String,
+        baseUrl: String?,
         callback: AppCallback<Unit>,
     ) {
         realmc.realm_app_update_base_url(app.cptr(), baseUrl, callback)

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -2309,6 +2309,33 @@ actual object RealmInterop {
             .also { realm_wrapper.realm_free(cPath) }
     }
 
+    actual fun realm_app_get_base_url(
+        app: RealmAppPointer,
+    ): String = realm_wrapper.realm_app_get_base_url(app.cptr())?.toKString()!!
+
+    actual fun realm_app_update_base_url(
+        app: RealmAppPointer,
+        baseUrl: String,
+        callback: AppCallback<Unit>,
+    ) {
+        checkedBooleanResult(
+            realm_wrapper.realm_app_update_base_url(
+                app.cptr(),
+                baseUrl,
+                callback = staticCFunction { userData, error ->
+                    handleAppCallback(
+                        userData,
+                        error
+                    ) { /* No-op, returns Unit */ }
+                },
+                StableRef.create(callback).asCPointer(),
+                staticCFunction { userdata ->
+                    disposeUserData<AppCallback<Unit>>(userdata)
+                }
+            )
+        )
+    }
+
     actual fun realm_user_get_all_identities(user: RealmUserPointer): List<SyncUserIdentity> {
         memScoped {
             val count = AuthProvider.values().size

--- a/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
+++ b/packages/cinterop/src/nativeDarwin/kotlin/io/realm/kotlin/internal/interop/RealmInterop.kt
@@ -2315,7 +2315,7 @@ actual object RealmInterop {
 
     actual fun realm_app_update_base_url(
         app: RealmAppPointer,
-        baseUrl: String,
+        baseUrl: String?,
         callback: AppCallback<Unit>,
     ) {
         checkedBooleanResult(

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
@@ -17,6 +17,7 @@
 package io.realm.kotlin.mongodb
 
 import io.realm.kotlin.internal.util.Validation
+import io.realm.kotlin.mongodb.annotations.ExperimentalEdgeServerApi
 import io.realm.kotlin.mongodb.auth.EmailPasswordAuth
 import io.realm.kotlin.mongodb.exceptions.AppException
 import io.realm.kotlin.mongodb.exceptions.AuthException
@@ -87,15 +88,19 @@ public interface App {
     /**
      * Current base URL to communicate with App Services.
      */
+    @ExperimentalEdgeServerApi
     public val baseUrl: String
 
     /**
-     * Sets the App Services base url. Changing the URL would trigger a client reset.
+     * Sets the App Services base url.
      *
-     * @param baseUrl The new App Services base url. Use [AppConfiguration.DEFAULT_BASE_URL] to set it
-     * to the default value.
+     * *NOTE* Changing the URL would trigger a client reset.
+     *
+     * @param baseUrl The new App Services base url. If `null` it will be using the default value
+     * ([AppConfiguration.DEFAULT_BASE_URL]).
      */
-    public suspend fun updateBaseUrl(baseUrl: String)
+    @ExperimentalEdgeServerApi
+    public suspend fun updateBaseUrl(baseUrl: String?)
 
     /**
      * Returns all known users that are either [User.State.LOGGED_IN] or [User.State.LOGGED_OUT].

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
@@ -92,6 +92,8 @@ public interface App {
     /**
      * Sets the App Services base url. The default base URL is defined by [AppConfiguration.DEFAULT_BASE_URL].
      *
+     * Changing the URL would trigger a client reset.
+     *
      * @param baseUrl App Services base URL. An empty string would set it to [AppConfiguration.DEFAULT_BASE_URL].
      */
     public suspend fun updateBaseUrl(baseUrl: String)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
@@ -85,6 +85,18 @@ public interface App {
     public val sync: Sync
 
     /**
+     * Current base URL to communicate with App Services.
+     */
+    public val baseUrl: String
+
+    /**
+     * Sets the App Services base url. The default base URL is defined by [AppConfiguration.DEFAULT_BASE_URL].
+     *
+     * @param baseUrl App Services base URL. An empty string would set it to [AppConfiguration.DEFAULT_BASE_URL].
+     */
+    public suspend fun updateBaseUrl(baseUrl: String)
+
+    /**
      * Returns all known users that are either [User.State.LOGGED_IN] or [User.State.LOGGED_OUT].
      * Only users that at some point logged into this device will be returned.
      *

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/App.kt
@@ -90,11 +90,10 @@ public interface App {
     public val baseUrl: String
 
     /**
-     * Sets the App Services base url. The default base URL is defined by [AppConfiguration.DEFAULT_BASE_URL].
+     * Sets the App Services base url. Changing the URL would trigger a client reset.
      *
-     * Changing the URL would trigger a client reset.
-     *
-     * @param baseUrl App Services base URL. An empty string would set it to [AppConfiguration.DEFAULT_BASE_URL].
+     * @param baseUrl The new App Services base url. Use [AppConfiguration.DEFAULT_BASE_URL] to set it
+     * to the default value.
      */
     public suspend fun updateBaseUrl(baseUrl: String)
 

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/annotations/ExperimentalEdgeServerApi.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/annotations/ExperimentalEdgeServerApi.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Realm Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.realm.kotlin.mongodb.annotations
+
+/**
+ * This annotation mark Realm APIs specific to the Atlas Edge server and are considered
+ * **experimental**, i.e. there are no guarantees given that these APIs cannot change without
+ * warning between minor and major versions. They will not change between patch versions.
+ *
+ * For all other purposes these APIs are considered stable, i.e. they undergo the same testing
+ * as other parts of the API and should behave as documented with no bugs. They are primarily
+ * marked as experimental because we are unsure if these APIs provide value and solve the use
+ * cases that people have. If not, they will be changed or removed altogether.
+ */
+@MustBeDocumented
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPEALIAS
+)
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
+public annotation class ExperimentalEdgeServerApi

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppImpl.kt
@@ -31,6 +31,7 @@ import io.realm.kotlin.mongodb.AppConfiguration
 import io.realm.kotlin.mongodb.AuthenticationChange
 import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.mongodb.annotations.ExperimentalEdgeServerApi
 import io.realm.kotlin.mongodb.auth.EmailPasswordAuth
 import io.realm.kotlin.mongodb.sync.Sync
 import io.realm.kotlin.types.RealmInstant
@@ -63,9 +64,11 @@ public class AppImpl(
     @Suppress("MagicNumber")
     private val reconnectThreshold = 5.seconds
 
+    @ExperimentalEdgeServerApi
     override val baseUrl: String
         get() = RealmInterop.realm_app_get_base_url(nativePointer)
 
+    @ExperimentalEdgeServerApi
     override suspend fun updateBaseUrl(baseUrl: String?) {
         Channel<Result<Unit>>(1).use { channel ->
             RealmInterop.realm_app_update_base_url(

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppImpl.kt
@@ -66,11 +66,11 @@ public class AppImpl(
     override val baseUrl: String
         get() = RealmInterop.realm_app_get_base_url(nativePointer)
 
-    override suspend fun updateBaseUrl(baseUrl: String) {
+    override suspend fun updateBaseUrl(baseUrl: String?) {
         Channel<Result<Unit>>(1).use { channel ->
             RealmInterop.realm_app_update_base_url(
                 app = nativePointer,
-                baseUrl = baseUrl.trimEnd('/'), // trailing slashes are not handled properly in core
+                baseUrl = baseUrl?.trimEnd('/'), // trailing slashes are not handled properly in core
                 callback = channelResultCallback<Unit, Unit>(channel) {
                     // No-op
                 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/AppImpl.kt
@@ -63,6 +63,22 @@ public class AppImpl(
     @Suppress("MagicNumber")
     private val reconnectThreshold = 5.seconds
 
+    override val baseUrl: String
+        get() = RealmInterop.realm_app_get_base_url(nativePointer)
+
+    override suspend fun updateBaseUrl(baseUrl: String) {
+        Channel<Result<Unit>>(1).use { channel ->
+            RealmInterop.realm_app_update_base_url(
+                app = nativePointer,
+                baseUrl = baseUrl.trimEnd('/'), // trailing slashes are not handled properly in core
+                callback = channelResultCallback<Unit, Unit>(channel) {
+                    // No-op
+                }
+            )
+            channel.receive().getOrThrow()
+        }
+    }
+
     @Suppress("invisible_member", "invisible_reference", "MagicNumber")
     private val connectionListener = NetworkStateObserver.ConnectionListener { connectionAvailable ->
         // In an ideal world, we would be able to reliably detect the network coming and

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
@@ -21,6 +21,8 @@ import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.internal.platform.appFilesDirectory
 import io.realm.kotlin.internal.platform.fileExists
 import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.log.LogLevel
+import io.realm.kotlin.log.RealmLog
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.AppConfiguration
 import io.realm.kotlin.mongodb.AuthenticationChange
@@ -30,9 +32,11 @@ import io.realm.kotlin.mongodb.LoggedIn
 import io.realm.kotlin.mongodb.LoggedOut
 import io.realm.kotlin.mongodb.Removed
 import io.realm.kotlin.mongodb.User
+import io.realm.kotlin.mongodb.annotations.ExperimentalEdgeServerApi
 import io.realm.kotlin.mongodb.exceptions.InvalidCredentialsException
 import io.realm.kotlin.mongodb.exceptions.ServiceException
 import io.realm.kotlin.mongodb.sync.SyncConfiguration
+import io.realm.kotlin.test.mongodb.SyncServerConfig
 import io.realm.kotlin.test.mongodb.TEST_APP_FLEX
 import io.realm.kotlin.test.mongodb.TestApp
 import io.realm.kotlin.test.mongodb.asTestApp
@@ -487,6 +491,7 @@ class AppTests {
      * app, as it is not validated on initialization. And then updating the base url the the test server.
      */
     @Test
+    @OptIn(ExperimentalEdgeServerApi::class)
     fun changeBaseUrl() {
         TestApp(
             testId = "changeBaseUrl",
@@ -507,8 +512,27 @@ class AppTests {
         }
     }
 
+//    @OptIn(ExperimentalEdgeServerApi::class)
+    @Test
+    @Ignore // We don't have a way to test this on CI, so for now just verify manually that the
+            // request towards the server after setting the URL to null is using the default URL.
+    @OptIn(ExperimentalEdgeServerApi::class)
+    fun changeBaseUrl_null() {
+        TestApp(
+            testId = "changeBaseUrl",
+        ).use { testApp ->
+            assertEquals(SyncServerConfig.url, testApp.baseUrl)
+
+            RealmLog.level = LogLevel.ALL
+            runBlocking {
+                testApp.updateBaseUrl(null)
+            }
+        }
+    }
+
     @Test
     @Ignore // See https://github.com/realm/realm-kotlin/issues/1734
+    @OptIn(ExperimentalEdgeServerApi::class)
     fun changeBaseUrl_trailing_slashes_trimmed() {
         assertFailsWithMessage<ServiceException>("cannot find app using Client App ID") {
             runBlocking {
@@ -519,6 +543,7 @@ class AppTests {
 
     @Test
     @Ignore // see https://github.com/realm/realm-kotlin/issues/1734
+    @OptIn(ExperimentalEdgeServerApi::class)
     fun changeBaseUrl_empty() {
         assertFailsWithMessage<ServiceException>("cannot find app using Client App ID") {
             runBlocking {
@@ -528,6 +553,7 @@ class AppTests {
     }
 
     @Test
+    @OptIn(ExperimentalEdgeServerApi::class)
     fun changeBaseUrl_invalidUrl() {
         assertFailsWithMessage<IllegalArgumentException>("URL missing scheme separator") {
             runBlocking {
@@ -538,6 +564,7 @@ class AppTests {
 
     @Test
     @Ignore // see https://github.com/realm/realm-kotlin/issues/1734
+    @OptIn(ExperimentalEdgeServerApi::class)
     fun changeBaseUrl_nonAppServicesUrl() {
         assertFailsWithMessage<ServiceException>("http error code considered fatal") {
             runBlocking {

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
@@ -512,10 +512,10 @@ class AppTests {
         }
     }
 
-//    @OptIn(ExperimentalEdgeServerApi::class)
     @Test
-    @Ignore // We don't have a way to test this on CI, so for now just verify manually that the
-            // request towards the server after setting the URL to null is using the default URL.
+    // We don't have a way to test this on CI, so for now just verify manually that the
+    // request towards the server after setting the URL to null is using the default URL.
+    @Ignore
     @OptIn(ExperimentalEdgeServerApi::class)
     fun changeBaseUrl_null() {
         TestApp(

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/AppTests.kt
@@ -508,6 +508,7 @@ class AppTests {
     }
 
     @Test
+    @Ignore // See https://github.com/realm/realm-kotlin/issues/1734
     fun changeBaseUrl_trailing_slashes_trimmed() {
         assertFailsWithMessage<ServiceException>("cannot find app using Client App ID") {
             runBlocking {
@@ -517,6 +518,7 @@ class AppTests {
     }
 
     @Test
+    @Ignore // see https://github.com/realm/realm-kotlin/issues/1734
     fun changeBaseUrl_empty() {
         assertFailsWithMessage<ServiceException>("cannot find app using Client App ID") {
             runBlocking {
@@ -535,6 +537,7 @@ class AppTests {
     }
 
     @Test
+    @Ignore // see https://github.com/realm/realm-kotlin/issues/1734
     fun changeBaseUrl_nonAppServicesUrl() {
         assertFailsWithMessage<ServiceException>("http error code considered fatal") {
             runBlocking {


### PR DESCRIPTION
With this PR we add support for changing the App Services URL allowing roaming between Atlas and Edge server.

Closes https://github.com/realm/realm-kotlin/issues/1659