### PR TITLE
[RKOTLIN-1084] Remove deprecated property `RealmClass.isEmbedded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This release will bump the Realm file format from version 23 to 24. Opening a fi
 ### Breaking changes
 * Removed property `RealmLog.level`. Log levels can be set with `RealmLog.setLevel`. (Issue [#1691](https://github.com/realm/realm-kotlin/issues/1691) [JIRA](https://jira.mongodb.org/browse/RKOTLIN-1038))
 * Removed `LogConfiguration`. Log levels and custom loggers can be set with `RealmLog`. (Issue [#1691](https://github.com/realm/realm-kotlin/issues/1691) [JIRA](https://jira.mongodb.org/browse/RKOTLIN-1038))
+* Removed deprecated `RealmClass.isEmbedded`. Class embeddeness can be check with `RealmClassKind.EMBEDDED`. (Issue [#1753](https://github.com/realm/realm-kotlin/issues/1753) [JIRA](https://jira.mongodb.org/browse/RKOTLIN-1080))
 
 ### Enhancements
 * Support for RealmLists and RealmDictionaries in `RealmAny`. (Issue [#1434](https://github.com/realm/realm-kotlin/issues/1434))

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/schema/RealmClassImpl.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/internal/schema/RealmClassImpl.kt
@@ -39,8 +39,6 @@ public data class RealmClassImpl(
         it.type.run { this is ValuePropertyType && isPrimaryKey }
     }
 
-    override val isEmbedded: Boolean = cinteropClass.isEmbedded
-
     override val kind: RealmClassKind
         get() = when {
             cinteropClass.isEmbedded -> RealmClassKind.EMBEDDED

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/schema/RealmClass.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/schema/RealmClass.kt
@@ -37,12 +37,6 @@ public interface RealmClass {
     public val primaryKey: RealmProperty?
 
     /**
-     * Returns whether or not the class is embedded.
-     */
-    @Deprecated("This property has been deprecated.", ReplaceWith("kind == RealmClassKind.EMBEDDED", "io.realm.kotlin.schema.RealmClassKind"))
-    public val isEmbedded: Boolean
-
-    /**
      * Returns what type of Realm model class this is.
      */
     public val kind: RealmClassKind

--- a/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmSchemaTests.kt
+++ b/packages/test-base/src/commonTest/kotlin/io/realm/kotlin/test/common/RealmSchemaTests.kt
@@ -96,21 +96,18 @@ class RealmSchemaTests {
         val schemaVariationsDescriptor = schema[SCHEMA_VARIATION_CLASS_NAME]
             ?: fail("Couldn't find class")
         assertEquals(SCHEMA_VARIATION_CLASS_NAME, schemaVariationsDescriptor.name)
-        assertFalse(schemaVariationsDescriptor.isEmbedded)
         assertEquals(schemaVariationsDescriptor.kind, RealmClassKind.STANDARD)
         assertEquals("string", schemaVariationsDescriptor.primaryKey?.name)
 
         val sampleName = "Sample"
         val sampleDescriptor = schema[sampleName] ?: fail("Couldn't find class")
         assertEquals(sampleName, sampleDescriptor.name)
-        assertFalse(sampleDescriptor.isEmbedded)
         assertNotEquals(sampleDescriptor.kind, RealmClassKind.EMBEDDED)
         assertNull(sampleDescriptor.primaryKey)
 
         val embeddedChildName = "EmbeddedChild"
         val embeddedChildDescriptor = schema[embeddedChildName] ?: fail("Couldn't find class")
         assertEquals(embeddedChildName, embeddedChildDescriptor.name)
-        assertTrue(embeddedChildDescriptor.isEmbedded)
         assertEquals(embeddedChildDescriptor.kind, RealmClassKind.EMBEDDED)
         assertNull(embeddedChildDescriptor.primaryKey)
     }


### PR DESCRIPTION
Closes https://github.com/realm/realm-kotlin/issues/1753