### PR TITLE
[RKOTLIN-1102] Remove nullability check in `SubscriptionSetImpl.waitForSynchronization`

### DIFF
--- a/.github/workflows/include-check-cache.yml
+++ b/.github/workflows/include-check-cache.yml
@@ -93,7 +93,7 @@ jobs:
     # This also include changes to Realm Core as they are hashed as part of `/packages/external/core`
     - name: Calculate ./packages SHAs 
       id: packages-cache-key
-      run: echo "sha=${{ hashFiles('./packages/**', './buildSrc/**', '!./packages/test-base/**', '!./packages/test-sync/**') }}" >> $GITHUB_OUTPUT
+      run: echo "sha=${{ hashFiles('./packages/**', './buildSrc/**') }}" >> $GITHUB_OUTPUT
 
     - name: Calculate ./benchmarks SHAs 
       id: calculate-benchmarks-cache-key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * [Sync] Fatal sync exceptions are now thrown as `UnrecoverableSyncException`. (Issue [#1767](https://github.com/realm/realm-kotlin/issues/1767) [RKOTLIN-1096](https://jira.mongodb.org/browse/RKOTLIN-1096)).
+* [Sync] Fix `NullPointerException` in `SubscriptionSet.waitForSynchronization`. (Issue [#1777](https://github.com/realm/realm-kotlin/issues/1777) [RKOTLIN-1102](https://jira.mongodb.org/browse/RKOTLIN-1102)).
 
 ### Compatibility
 * File format: Generates Realms with file format v24 (reads and upgrades file format v10 or later).

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/exceptions/RealmException.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/exceptions/RealmException.kt
@@ -9,7 +9,7 @@ package io.realm.kotlin.exceptions
  */
 public open class RealmException : RuntimeException {
     public constructor() : super()
-    public constructor(message: String) : super(message)
-    public constructor(message: String, cause: Throwable) : super(message, cause)
-    public constructor(cause: Throwable) : super(cause)
+    public constructor(message: String?) : super(message)
+    public constructor(message: String?, cause: Throwable) : super(message, cause)
+    public constructor(cause: Throwable?) : super(cause)
 }

--- a/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/exceptions/RealmException.kt
+++ b/packages/library-base/src/commonMain/kotlin/io/realm/kotlin/exceptions/RealmException.kt
@@ -10,6 +10,6 @@ package io.realm.kotlin.exceptions
 public open class RealmException : RuntimeException {
     public constructor() : super()
     public constructor(message: String?) : super(message)
-    public constructor(message: String?, cause: Throwable) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
     public constructor(cause: Throwable?) : super(cause)
 }

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/AppException.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/AppException.kt
@@ -94,5 +94,5 @@ import io.realm.kotlin.exceptions.RealmException
  * @see SyncException
  */
 public open class AppException internal constructor(
-    message: String,
+    message: String?,
 ) : RealmException(message)

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/SyncExceptions.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/exceptions/SyncExceptions.kt
@@ -31,7 +31,7 @@ import io.realm.kotlin.types.RealmAny
  *
  * @see io.realm.kotlin.mongodb.sync.SyncConfiguration.Builder.errorHandler
  */
-public open class SyncException internal constructor(message: String) : AppException(message)
+public open class SyncException internal constructor(message: String?) : AppException(message)
 
 /**
  * Thrown when something has gone wrong with Device Sync in a way that is not recoverable.
@@ -60,7 +60,7 @@ public class WrongSyncTypeException internal constructor(message: String) : Sync
  * Thrown when the server does not support one or more of the queries defined in the
  * [io.realm.kotlin.mongodb.sync.SubscriptionSet].
  */
-public class BadFlexibleSyncQueryException internal constructor(message: String) :
+public class BadFlexibleSyncQueryException internal constructor(message: String?) :
     SyncException(message)
 
 /**

--- a/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SubscriptionSetImpl.kt
+++ b/packages/library-sync/src/commonMain/kotlin/io/realm/kotlin/mongodb/internal/SubscriptionSetImpl.kt
@@ -127,7 +127,7 @@ internal class SubscriptionSetImpl<T : BaseRealm>(
                     if (result) {
                         return true
                     } else {
-                        throw BadFlexibleSyncQueryException(errorMessage!!)
+                        throw BadFlexibleSyncQueryException(errorMessage)
                     }
                 }
                 else -> throw IllegalStateException("Unexpected value: $result")

--- a/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/CredentialsTests.kt
+++ b/packages/test-sync/src/commonTest/kotlin/io/realm/kotlin/test/mongodb/common/CredentialsTests.kt
@@ -369,7 +369,7 @@ class CredentialsTests {
             payload = mapOf("mail" to TestHelper.randomEmail(), "id" to 0)
         )
 
-        assertFailsWithMessage<AuthException>("unauthorized") {
+        assertFailsWithMessage<AuthException>("Authentication failed") {
             runBlocking {
                 app.login(credentials)
             }


### PR DESCRIPTION
closes https://github.com/realm/realm-kotlin/issues/1777

Removes a nullability check on the synchronization error message that is causing a null pointer exception crash