### PR TITLE
Avoid exporting Core's symbols to allow mixing multiple SDKs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -149,6 +149,7 @@ jobs:
             -DREALM_ENABLE_SYNC=1 \
             -DREALM_NO_TESTS=1 \
             -DREALM_BUILD_LIB_ONLY=true \
+            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
             ../../src/jvm
             make -j8
 
@@ -218,6 +219,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release `
           -DREALM_ENABLE_SYNC=ON `
           -DREALM_NO_TESTS=1 `
+          -DCMAKE_CXX_VISIBILITY_PRESET=hidden `
           -DVCPKG_TARGET_TRIPLET=x64-windows-static
           cmake --build . --config Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None.
 
 ### Enhancements
-- None.
+- Avoid exporting Core's symbols so we can build statically Kotlin SDK with other SDKs like Swift in the same project [RKOTLIN-877](https://jira.mongodb.org/browse/RKOTLIN-877).
 
 ### Fixed
 - None.

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -470,6 +470,11 @@ fun getSharedCMakeFlags(buildType: BuildType, ccache: Boolean = true): Array<Str
         add("-DREALM_NO_TESTS=1")
         add("-DREALM_BUILD_LIB_ONLY=true")
         add("-DREALM_CORE_SUBMODULE_BUILD=true")
+        // This will prevent exporting Core's symbols. which is useful when combining for example Swift SDK and Kotlin Multiplatform
+        // in the same app. The generated dynamically linked shared Framework from Kotlin/Native can then be linked dynamically into the iOS app (!use_frameworks in Cocoapods)
+        // or statically. This will also reduce the binary size a little bit (avoid storing metadata about exported symbols)
+        // TODO update on Linux as well
+        add("-DCMAKE_CXX_VISIBILITY_PRESET=hidden")
     }
     return args.toTypedArray()
 }


### PR DESCRIPTION
The cinterop KLIB includes compiled core's static libraries that will be used by the linker to build the final app. This PR will avoid exporting Core's symbols so if the user adds another SDK 
like Swift to their app then build/link statically the Swift app the two versions of Core will not conflicts 

Most of the work was testing with `MultiplatformDemo` and `MultiplatformDemoWithSync` while adding a POD dependency to Swift SDK and using two Realms using two version of Core inside the same iOS app.

when building such app the dynamic framweork build from Kotlin/Native should not include any Core symbols like the following:
```
xcrun dyldinfo  ../shared/build/bin/ios/podDebugFramework/shared.framework/shared -weak_bind  | c++filt
weak binding information:
segment section          address       type     addend symbol
__DATA  __la_symbol_ptr  0x00A3C168    pointer       0 _Konan_DebugBuffer
__DATA  __la_symbol_ptr  0x00A3C170    pointer       0 _Konan_DebugBufferSize
__DATA  __la_symbol_ptr  0x00A3C178    pointer       0 _Konan_DebugObjectToUtf8Array
__DATA_CONST __got            0x0090C1C0    pointer       0 typeinfo for std::length_error
__DATA_CONST __got            0x0090C1C8    pointer       0 typeinfo for std::out_of_range
__DATA_CONST __got            0x0090C1D8    pointer       0 typeinfo for std::overflow_error
__DATA_CONST __const          0x009FB878    pointer       0 typeinfo for std::overflow_error
__DATA_CONST __got            0x0090C1E0    pointer       0 typeinfo for std::invalid_argument
__DATA_CONST __const          0x00A0FCC0    pointer       0 typeinfo for std::invalid_argument
__DATA  __la_symbol_ptr  0x00A3C700    pointer       0 operator delete[](void*)
__DATA  __la_symbol_ptr  0x00A3C708    pointer       0 operator delete(void*)
__DATA  __la_symbol_ptr  0x00A3C710    pointer       0 operator new[](unsigned long)
__DATA  __la_symbol_ptr  0x00A3C718    pointer       0 operator new(unsigned long)
__DATA  __la_symbol_ptr  0x00A3C720    pointer       0 operator new(unsigned long, std::nothrow_t const&)
```
