### PR TITLE
Always unpacking JVM native lib when using SNAPSHOT version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None.
 
 ### Enhancements
-- None.
+- Improved mechanism for unpacking of JVM native libs suitable for local development. (Issue [#1715](https://github.com/realm/realm-kotlin/issues/1715) [JIRA](https://jira.mongodb.org/browse/RKOTLIN-1065)).
 
 ### Fixed
 - None.

--- a/packages/cinterop/src/jvmMain/kotlin/io/realm/kotlin/jvm/SoLoader.kt
+++ b/packages/cinterop/src/jvmMain/kotlin/io/realm/kotlin/jvm/SoLoader.kt
@@ -61,7 +61,7 @@ class SoLoader {
         // path should be <default user lib dir>/io.realm.kotlin/libraryVersion]/librealmffi.so
         // if the full path exists then load it otherwise unpack and load it.
         val libraryInstallationLocation: File = defaultAbsolutePath(libraryName)
-        if (!libraryInstallationLocation.exists()) {
+        if (!libraryInstallationLocation.exists() || SDK_VERSION.endsWith("-SNAPSHOT", ignoreCase = true)) {
             unpackAndInstall(libraryName, libraryInstallationLocation)
         }
         @Suppress("UnsafeDynamicallyLoadedCode")


### PR DESCRIPTION
Fixes https://github.com/realm/realm-kotlin/issues/1715

This was tested locally by adding a JVM test that checks the schema version 
```Kotlin
assertEquals(realm.schemaVersion(), 42)
```

Then on AS edit the Core method `realm_get_schema_version` (inside https://github.com/realm/realm-core/blob/master/src/realm/object-store/c_api/schema.cpp#L52-L56) to return a different version which should compile a new native shared library to be extracted which has the new value. Observe that the test passes with the modified version .

Note: Obviously If you edit the `buildSrc/src/main/kotlin/Config.kt` to use a named version locally this work around won't work 