### PR TITLE
[RKOTLIN-1137] Fix incorrect currentTime() for Android devices on API 25 and blow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* `RealmInstant.now` was returning incorrect value on Android devices running API 25 and below (Issue: [#1849](https://github.com/realm/realm-kotlin/issues/1849)).
 
 ### Compatibility
 * File format: Generates Realms with file format v24 (reads and upgrades file format v10 or later).

--- a/packages/library-base/src/androidMain/kotlin/io/realm/kotlin/internal/platform/SystemUtilsAndroid.kt
+++ b/packages/library-base/src/androidMain/kotlin/io/realm/kotlin/internal/platform/SystemUtilsAndroid.kt
@@ -44,6 +44,7 @@ public actual fun currentTime(): RealmInstant {
         val jtInstant = java.time.Clock.systemUTC().instant()
         RealmInstantImpl(jtInstant.epochSecond, jtInstant.nano)
     } else {
-        RealmInstantImpl(System.currentTimeMillis(), 0)
+        val now = System.currentTimeMillis()
+        RealmInstantImpl(now / 1000, (now % 1000).toInt() * 1_000_000)
     }
 }


### PR DESCRIPTION
Also add millisecond precision.

This fixes https://github.com/realm/realm-kotlin/issues/1849