### PR TITLE
Fix compiler crash after update to Kotlin 2.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.1.0 (2025-05-15)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+Fix compiler crash after update to Kotlin 2.1.21 (Issue [#1857](https://github.com/realm/realm-kotlin/issues/1857))
 
 ## 3.0.0 (2024-10-03)
 

--- a/benchmarks/gradle/wrapper/gradle-wrapper.properties
+++ b/benchmarks/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,15 +105,15 @@ tasks {
     register<GradleBuild>("mavenCentralUpload") {
         description = "Push all Realm artifacts to Maven Central"
         group = "Publishing"
-        buildFile = file("${rootDir}/packages/build.gradle.kts")
+        dir = file("${rootDir}/packages/build.gradle.kts")
         tasks = listOf("publishToSonatype")
         copyProperties(this)
     }
 
     // TODO Verify we can actually use these debug symbols
     val archiveDebugSymbols by register("archiveDebugSymbols", Zip::class) {
-        archiveName = "realm-kotlin-jni-libs-unstripped-${currentVersion}.zip"
-        destinationDir = releaseMetaDataDir
+        archiveFileName.set("realm-kotlin-jni-libs-unstripped-${currentVersion}.zip")
+        destinationDirectory.set(releaseMetaDataDir)
         from("${rootDir}/packages/cinterop/build/intermediates/merged_native_libs/release/out/lib") {
             include("**/*.so")
         }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -62,7 +62,7 @@ val HOST_OS: OperatingSystem = findHostOs()
 
 object Realm {
     val ciBuild = (System.getenv("CI") != null)
-    const val version = "3.0.0"
+    const val version = "3.1.0"
     const val group = "io.realm.kotlin"
     const val projectUrl = "https://realm.io"
     const val pluginPortalId = "io.realm.kotlin"
@@ -123,10 +123,10 @@ object Versions {
     const val junit = "4.13.2" // https://mvnrepository.com/artifact/junit/junit
     const val kbson = "0.4.0" // https://github.com/mongodb/kbson
     // When updating the Kotlin version, also remember to update /examples/min-android-sample/build.gradle.kts
-    const val kotlin = "2.0.20" // https://github.com/JetBrains/kotlin and https://kotlinlang.org/docs/releases.html#release-details
+    const val kotlin = "2.1.21" // https://github.com/JetBrains/kotlin and https://kotlinlang.org/docs/releases.html#release-details
     const val kotlinJvmTarget = "1.8" // Which JVM bytecode version is kotlin compiled to.
-    const val latestKotlin = "2.0.20" // https://kotlinlang.org/docs/eap.html#build-details
-    const val kotlinCompileTesting = "0.5.1" // https://github.com/zacsweers/kotlin-compile-testing
+    const val latestKotlin = "2.1.21" // https://kotlinlang.org/docs/eap.html#build-details
+    const val kotlinCompileTesting = "0.7.1" // https://github.com/zacsweers/kotlin-compile-testing
     const val ktlint = "0.45.2" // https://github.com/pinterest/ktlint
     const val ktor = "2.3.12" // https://github.com/ktorio/ktor
     const val multidex = "2.0.1" // https://developer.android.com/jetpack/androidx/releases/multidex
@@ -134,7 +134,7 @@ object Versions {
     const val okio = "3.9.0" // https://square.github.io/okio/#releases
     const val relinker = "1.4.5" // https://github.com/KeepSafe/ReLinker
     const val serialization = "1.7.1" // https://kotlinlang.org/docs/releases.html#release-details
-    const val shadowJar =  "6.1.0" // https://mvnrepository.com/artifact/com.github.johnrengelman.shadow/com.github.johnrengelman.shadow.gradle.plugin?repo=gradle-plugins
+    const val shadowJar =  "8.1.1" // https://mvnrepository.com/artifact/com.github.johnrengelman.shadow/com.github.johnrengelman.shadow.gradle.plugin?repo=gradle-plugins
     const val snakeYaml = "1.33" // https://github.com/snakeyaml/snakeyaml
     val sourceCompatibilityVersion = JavaVersion.VERSION_1_8 // Language level of any Java source code.
     val targetCompatibilityVersion = JavaVersion.VERSION_1_8 // Version of generated JVM bytecode from Java files.

--- a/examples/kmm-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/kmm-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/min-android-sample/build.gradle.kts
+++ b/examples/min-android-sample/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.1.3")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
         classpath("io.realm.kotlin:gradle-plugin:${rootProject.extra["realmVersion"]}")
     }
 }

--- a/examples/min-android-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/min-android-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/realm-java-compatibility/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/realm-java-compatibility/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -809,4 +809,28 @@ abstract class CmakeVersionProvider : ValueSource<String, ValueSourceParameters.
 // enable execution optimizations for generateSdkVersionConstant
 afterEvaluate {
     tasks.getByName("sourcesJar").dependsOn(generateSdkVersionConstant)
+    tasks.named("androidDebugSourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("androidReleaseSourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("jvmSourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("iosX64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("iosArm64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("iosSimulatorArm64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("macosArm64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("macosX64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
 }

--- a/packages/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelDefaultMethodGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelDefaultMethodGeneration.kt
@@ -76,7 +76,6 @@ class RealmModelDefaultMethodGeneration(private val pluginContext: IrPluginConte
                     type = pluginContext.irBuiltIns.booleanType,
                     symbol = realmEquals.symbol,
                     typeArgumentsCount = 0,
-                    valueArgumentsCount = 2
                 ).apply {
                     dispatchReceiver = irGetObject(realmObjectHelper.symbol)
                     putValueArgument(0, irGet(function.dispatchReceiverParameter!!.type, function.dispatchReceiverParameter!!.symbol))
@@ -96,7 +95,6 @@ class RealmModelDefaultMethodGeneration(private val pluginContext: IrPluginConte
                     type = pluginContext.irBuiltIns.intType,
                     symbol = realmHashCode.symbol,
                     typeArgumentsCount = 0,
-                    valueArgumentsCount = 1
                 ).apply {
                     dispatchReceiver = irGetObject(realmObjectHelper.symbol)
                     putValueArgument(0, irGet(function.dispatchReceiverParameter!!.type, function.dispatchReceiverParameter!!.symbol))
@@ -115,7 +113,6 @@ class RealmModelDefaultMethodGeneration(private val pluginContext: IrPluginConte
                     type = pluginContext.irBuiltIns.stringType,
                     symbol = realmToString.symbol,
                     typeArgumentsCount = 0,
-                    valueArgumentsCount = 1
                 ).apply {
                     dispatchReceiver = irGetObject(realmObjectHelper.symbol)
                     putValueArgument(0, irGet(function.dispatchReceiverParameter!!.type, function.dispatchReceiverParameter!!.symbol))

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelLoweringExtension.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.fromSymbolOwner
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.defaultType

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/RealmModelSyntheticPropertiesGeneration.kt
@@ -92,6 +92,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrPropertyReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrVarargImpl
+import org.jetbrains.kotlin.ir.expressions.impl.fromSymbolOwner
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
@@ -303,7 +304,6 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                 type = companionFieldsType,
                 symbol = mapOf,
                 typeArgumentsCount = 2,
-                valueArgumentsCount = 1,
                 origin = null,
                 superQualifierSymbol = null
             ).apply {
@@ -503,7 +503,6 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                             type = classInfoClass.defaultType,
                             symbol = classInfoCreateMethod.symbol,
                             typeArgumentsCount = 0,
-                            valueArgumentsCount = 4
                         ).apply {
                             dispatchReceiver = irGetObject(classInfoClass.companionObject()!!.symbol)
                             var arg = 0
@@ -677,7 +676,7 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                 } ?: irNull(pluginContext.irBuiltIns.kClassClass.typeWith(typedRealmObjectInterface.defaultType).makeNullable())
 
                                 // Define the link target. Empty string if there is none.
-                                val linkPropertyName: IrConst<String> = if (type == linkingObjectType) {
+                                val linkPropertyName: IrConst = if (type == linkingObjectType) {
                                     val targetPropertyName = getLinkingObjectPropertyName(backingField)
                                     irString(targetPropertyName)
                                 } else {
@@ -690,7 +689,6 @@ class RealmModelSyntheticPropertiesGeneration(private val pluginContext: IrPlugi
                                     type = propertyClass.defaultType,
                                     symbol = propertyCreateMethod,
                                     typeArgumentsCount = 0,
-                                    valueArgumentsCount = 10
                                 ).apply {
                                     var arg = 0
                                     // Persisted name

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/fir/model/CompanionExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/fir/model/CompanionExtension.kt
@@ -66,7 +66,7 @@ class CompanionExtension(session: FirSession) : FirDeclarationGenerationExtensio
         classSymbol: FirClassSymbol<*>,
         context: MemberGenerationContext
     ): Set<Name> {
-        if (classSymbol.isCompanion && (classSymbol.getContainingClassSymbol(session) as? FirClassSymbol<*>)?.isBaseRealmObject == true) {
+        if (classSymbol.isCompanion && (classSymbol.getContainingClassSymbol() as? FirClassSymbol<*>)?.isBaseRealmObject == true) {
             return setOf(
                 Names.REALM_OBJECT_COMPANION_SCHEMA_METHOD,
                 Names.REALM_OBJECT_COMPANION_NEW_INSTANCE_METHOD,
@@ -88,7 +88,7 @@ class CompanionExtension(session: FirSession) : FirDeclarationGenerationExtensio
                         owner,
                         RealmPluginGeneratorKey,
                         callableId.callableName,
-                        session.builtinTypes.anyType.type,
+                        session.builtinTypes.anyType.coneType,
                     ).symbol
                 )
 
@@ -98,7 +98,7 @@ class CompanionExtension(session: FirSession) : FirDeclarationGenerationExtensio
                         owner,
                         RealmPluginGeneratorKey,
                         callableId.callableName,
-                        session.builtinTypes.anyType.type
+                        session.builtinTypes.anyType.coneType
                     ).symbol
                 )
 

--- a/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/fir/model/ObjectExtension.kt
+++ b/packages/plugin-compiler/src/main/kotlin/io/realm/kotlin/compiler/fir/model/ObjectExtension.kt
@@ -67,7 +67,7 @@ class ObjectExtension(session: FirSession) : FirDeclarationGenerationExtension(s
                         owner,
                         RealmPluginGeneratorKey,
                         callableId.callableName,
-                        session.builtinTypes.stringType.type,
+                        session.builtinTypes.stringType.coneType,
                     ) {
                         modality = Modality.OPEN
                     }.symbol
@@ -78,10 +78,10 @@ class ObjectExtension(session: FirSession) : FirDeclarationGenerationExtension(s
                         owner,
                         RealmPluginGeneratorKey,
                         callableId.callableName,
-                        session.builtinTypes.booleanType.type,
+                        session.builtinTypes.booleanType.coneType,
                     ) {
                         modality = Modality.OPEN
-                        valueParameter(Name.identifier("other"), session.builtinTypes.nullableAnyType.type)
+                        valueParameter(Name.identifier("other"), session.builtinTypes.nullableAnyType.coneType)
                     }.symbol
                 )
             Names.REALM_OBJECT_HASH_CODE ->
@@ -90,7 +90,7 @@ class ObjectExtension(session: FirSession) : FirDeclarationGenerationExtension(s
                         owner,
                         RealmPluginGeneratorKey,
                         callableId.callableName,
-                        session.builtinTypes.intType.type,
+                        session.builtinTypes.intType.coneType,
                     ) {
                         modality = Modality.OPEN
                     }.symbol


### PR DESCRIPTION
- Bumped Kotlin version to 2.1.21
- Upgraded Gradle to 8.12.1
- Fixed plugin-compiler compatibility with updated Kotlin (adjusted to signature changes)